### PR TITLE
chore: Generate @fluentui/react-components peer dep safely

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "prettier": "^2.6.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "semver": "^7.5.2",
     "syncpack": "^9.8.6",
     "ts-jest": "^29.1.0",
     "ts-node": "10.9.1",

--- a/packages/nx-plugin/src/generators/library/findInstalledReactComponentsVersion.ts
+++ b/packages/nx-plugin/src/generators/library/findInstalledReactComponentsVersion.ts
@@ -1,0 +1,39 @@
+import { exec as execCb } from 'child_process';
+import { promisify } from 'util';
+import { parse } from 'semver';
+
+const exec = promisify(execCb);
+
+export async function findInstalledReactComponentsVersion() {
+  const { stdout } = await exec(
+    `yarn list --pattern @fluentui/react-components --json --depth=0`
+  );
+  const rawEntries = stdout.split('\n');
+  const entries = rawEntries.map((entry) => {
+    try {
+      return JSON.parse(entry);
+    } catch {
+      return {} as unknown;
+    }
+  });
+  const entry = entries.find((entry) => {
+    if (entry.data?.trees?.[0]?.name.includes('@fluentui/react-components')) {
+      return true;
+    }
+  });
+
+  if (!entry) {
+    throw new Error(
+      'Could not find installed @fluentui/react-components version in lockfile, please report this issue'
+    );
+  }
+
+  const version = entry.data.trees[0].name.split('@')[2];
+  if (parse(version)) {
+    return version;
+  }
+
+  throw new Error(
+    'Could not find installed @fluentui/react-components version in lockfile, please report this issue'
+  );
+}

--- a/packages/nx-plugin/src/generators/library/generator.spec.ts
+++ b/packages/nx-plugin/src/generators/library/generator.spec.ts
@@ -1,8 +1,14 @@
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
-import { Tree, readProjectConfiguration } from '@nx/devkit';
+import {
+  Tree,
+  readProjectConfiguration,
+  readJson,
+  workspaceRoot,
+} from '@nx/devkit';
 
 import generator from './generator';
 import { LibraryGeneratorSchema } from './schema';
+import { getPackagePaths } from '../../utils';
 
 describe('create-package generator', () => {
   let tree: Tree;
@@ -12,9 +18,45 @@ describe('create-package generator', () => {
     tree = createTreeWithEmptyWorkspace();
   });
 
-  xit('should run successfully', async () => {
+  it('should run successfully', async () => {
     await generator(tree, options);
     const config = readProjectConfiguration(tree, 'test');
     expect(config).toBeDefined();
+  });
+
+  it('should generate peer dependencies', async () => {
+    await generator(tree, options);
+    const config = readProjectConfiguration(tree, 'test');
+    const paths = getPackagePaths(workspaceRoot, config.root);
+    const pkgJson = readJson(tree, paths.packageJson);
+    expect(pkgJson.peerDependencies).toMatchInlineSnapshot(`
+      {
+        "@fluentui/react-components": ">=9.20.0 <10.0.0",
+        "@types/react": ">=16.8.0 <19.0.0",
+        "@types/react-dom": ">=16.8.0 <19.0.0",
+        "react": ">=16.8.0 <19.0.0",
+        "react-dom": ">=16.8.0 <19.0.0",
+      }
+    `);
+  });
+
+  it('should add build target', async () => {
+    await generator(tree, options);
+    const config = readProjectConfiguration(tree, 'test');
+    expect(config.targets.build).toMatchInlineSnapshot(`
+      {
+        "executor": "@fluentui-contrib/nx-plugin:build",
+      }
+    `);
+  });
+
+  it('should type-check target', async () => {
+    await generator(tree, options);
+    const config = readProjectConfiguration(tree, 'test');
+    expect(config.targets['type-check']).toMatchInlineSnapshot(`
+      {
+        "executor": "@fluentui-contrib/nx-plugin:type-check",
+      }
+    `);
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -10128,6 +10128,13 @@ semver@^6.0.0, semver@^6.1.1, semver@^6.1.2, semver@^6.3.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
 
+semver@^7.5.2:
+  version "7.5.2"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.5.2.tgz#5b851e66d1be07c1cdaf37dfc856f543325a2beb"
+  integrity sha512-SoftuTROv/cRjCze/scjGyiDtcUyxw1rgYQSZY7XTmtR5hX+dm76iDbTH8TkLPHCQmlbQVSSbNZCPM2hb0knnQ==
+  dependencies:
+    lru-cache "^6.0.0"
+
 send@0.18.0:
   version "0.18.0"
   resolved "https://registry.yarnpkg.com/send/-/send-0.18.0.tgz#670167cc654b05f5aa4a767f9113bb371bc706be"


### PR DESCRIPTION
In order to guarantee that all new created packages will have a correct minimum supported peer dependency, package.json is autogenerated with the version installed in the current lockfile.

If authors need better backwards compatibility, they are responsible for testing the earlier versions of react-components themselves and setting the peer dependency manually.