### PR TITLE
fix(react-shadow): render portals under shadow root

### DIFF
--- a/change/@fluentui-contrib-react-shadow-ee5bd401-e23b-4c28-a3f8-dee02e2bca07.json
+++ b/change/@fluentui-contrib-react-shadow-ee5bd401-e23b-4c28-a3f8-dee02e2bca07.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: render portals under shadow root",
+  "packageName": "@fluentui-contrib/react-shadow",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-shadow/src/root.tsx
+++ b/packages/react-shadow/src/root.tsx
@@ -1,4 +1,7 @@
-import { RendererProvider } from '@fluentui/react-components';
+import {
+  RendererProvider,
+  PortalMountNodeProvider,
+} from '@fluentui/react-components';
 import { createShadowDOMRenderer } from '@griffel/shadow-dom';
 import * as React from 'react';
 import { createProxy } from 'react-shadow';
@@ -38,12 +41,7 @@ const ReactComponentsWrapper: React.FC<{
 
   return (
     <RendererProvider renderer={renderer}>
-      {/* TODO: FluentProvider should accept ShadowRoot as targetDocument*/}
-      {/*<Provider_unstable*/}
-      {/*  value={{ dir: 'ltr', targetDocument: root as unknown as Document }}*/}
-      {/*>*/}
-      {children}
-      {/*</Provider_unstable>*/}
+      <PortalMountNodeProvider value={root}>{children}</PortalMountNodeProvider>
     </RendererProvider>
   );
 };

--- a/packages/react-shadow/stories/root/Portals.stories.tsx
+++ b/packages/react-shadow/stories/root/Portals.stories.tsx
@@ -1,0 +1,80 @@
+import { root } from '@fluentui-contrib/react-shadow';
+import {
+  Button,
+  makeStyles,
+  Menu,
+  MenuList,
+  MenuItem,
+  MenuPopover,
+  MenuTrigger,
+  shorthands,
+  tokens,
+  Tooltip,
+} from '@fluentui/react-components';
+import * as React from 'react';
+
+const useClasses = makeStyles({
+  container: {
+    display: 'flex',
+    flexDirection: 'row',
+    ...shorthands.gap('5px'),
+    ...shorthands.padding('5px'),
+  },
+  root: {
+    display: 'flex',
+    flexDirection: 'column',
+    ...shorthands.gap('10px'),
+    ...shorthands.border('3px', 'solid', tokens.colorBrandBackground2),
+    ...shorthands.borderRadius(tokens.borderRadiusMedium),
+  },
+});
+
+const ComponentSet: React.FC = () => {
+  const classes = useClasses();
+
+  return (
+    <div className={classes.root}>
+      <div className={classes.container}>
+        <Menu>
+          <MenuTrigger>
+            <Button>ToggleMenu</Button>
+          </MenuTrigger>
+          <MenuPopover>
+            <MenuList>
+              <MenuItem>New</MenuItem>
+              <MenuItem>Open</MenuItem>
+              <MenuItem>Save</MenuItem>
+            </MenuList>
+          </MenuPopover>
+        </Menu>
+        <Tooltip content="Hello world!" relationship="label">
+          <Button>A button with a tooltip</Button>
+        </Tooltip>
+      </div>
+    </div>
+  );
+};
+
+export const Portals = () => (
+  <div
+    style={{
+      border: '3px dotted orange',
+      padding: 10,
+      display: 'flex',
+      flexDirection: 'column',
+      gap: 10,
+    }}
+  >
+    <div style={{ border: '3px dotted grey', padding: 10, paddingTop: 0 }}>
+      <h1>Light DOM</h1>
+      <ComponentSet />
+    </div>
+
+    <root.div>
+      <div style={{ border: '3px dotted grey', padding: 10, paddingTop: 0 }}>
+        <h1>Shadow DOM</h1>
+        <ComponentSet />
+      </div>
+    </root.div>
+  </div>
+);

--- a/packages/react-shadow/stories/root/index.stories.tsx
+++ b/packages/react-shadow/stories/root/index.stories.tsx
@@ -1,6 +1,7 @@
 import { Meta } from '@storybook/react';
 
 export { Default } from './Default.stories';
+export { Portals } from './Portals.stories';
 
 const meta: Meta = {
   title: 'react-shadow',


### PR DESCRIPTION
Adopts the change from https://github.com/microsoft/fluentui/pull/28395 and renders components powered by Portals in shadow roots.