### PR TITLE
chore(react-shadow): require proper version of @fluentui/react-components

### DIFF
--- a/change/@fluentui-contrib-react-chat-f2407b1b-2a69-47b1-a19f-42c814cdf82a.json
+++ b/change/@fluentui-contrib-react-chat-f2407b1b-2a69-47b1-a19f-42c814cdf82a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: update required version of @fluentui/react-components",
+  "packageName": "@fluentui-contrib/react-chat",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-contrib-react-shadow-bc587195-24df-4bb0-8d55-669f797168d0.json
+++ b/change/@fluentui-contrib-react-shadow-bc587195-24df-4bb0-8d55-669f797168d0.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "version bump",
+  "packageName": "@fluentui-contrib/react-shadow",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-chat/package.json
+++ b/packages/react-chat/package.json
@@ -2,6 +2,6 @@
   "name": "@fluentui-contrib/react-chat",
   "version": "0.1.3",
   "peerDependencies": {
-    "@fluentui/react-components": ">=9.20.0 <10.0.0"
+    "@fluentui/react-components": ">=9.25.1 <10.0.0"
   }
 }

--- a/packages/react-shadow/package.json
+++ b/packages/react-shadow/package.json
@@ -7,7 +7,7 @@
     "react-shadow": "^20.3.0"
   },
   "peerDependencies": {
-    "@fluentui/react-components": ">=9.20.0 <10.0.0",
+    "@fluentui/react-components": ">=9.25.1 <10.0.0",
     "@types/react": ">=16.8.0 <19.0.0",
     "react": ">=16.8.0 <19.0.0"
   }


### PR DESCRIPTION
Follow up for #20. Missed the version bump in the original PR.