### PR TITLE
chore: lint tsx files by default

### DIFF
--- a/packages/nx-plugin/src/generators/library/generator.spec.ts
+++ b/packages/nx-plugin/src/generators/library/generator.spec.ts
@@ -59,4 +59,23 @@ describe('create-package generator', () => {
       }
     `);
   });
+
+  it('should update lint configuration', async () => {
+    await generator(tree, options);
+    const config = readProjectConfiguration(tree, 'test');
+    expect(config.targets?.lint).toMatchInlineSnapshot(`
+      {
+        "executor": "@nx/linter:eslint",
+        "options": {
+          "lintFilePatterns": [
+            "test/**/*.ts",
+            "test/**/*.tsx",
+          ],
+        },
+        "outputs": [
+          "{options.outputFile}",
+        ],
+      }
+    `);
+  });
 });

--- a/packages/nx-plugin/src/generators/library/generator.ts
+++ b/packages/nx-plugin/src/generators/library/generator.ts
@@ -31,6 +31,7 @@ export default async function (tree: Tree, options: LibraryGeneratorSchema) {
   }
 
   const { root: projectRoot, targets } = newProject;
+  const paths = getPackagePaths(workspaceRoot, projectRoot);
   if (!targets) {
     return;
   }
@@ -43,9 +44,11 @@ export default async function (tree: Tree, options: LibraryGeneratorSchema) {
     executor: '@fluentui-contrib/nx-plugin:type-check',
   };
 
-  updateProjectConfiguration(tree, name, newProject);
+  targets.lint.options = {
+    lintFilePatterns: [`${projectRoot}/**/*.ts`, `${projectRoot}/**/*.tsx`],
+  };
 
-  const paths = getPackagePaths(workspaceRoot, projectRoot);
+  updateProjectConfiguration(tree, name, newProject);
   tree.delete(path.join(paths.src, 'lib'));
   const reactComponentsVersion = await findInstalledReactComponentsVersion();
 

--- a/packages/react-chat/project.json
+++ b/packages/react-chat/project.json
@@ -15,7 +15,10 @@
       "executor": "@nx/linter:eslint",
       "outputs": ["{options.outputFile}"],
       "options": {
-        "lintFilePatterns": ["packages/react-chat/**/*.ts"]
+        "lintFilePatterns": [
+          "packages/react-chat/**/*.ts",
+          "packages/react-chat/**/*.tsx"
+        ]
       }
     },
     "test": {

--- a/packages/react-shadow/project.json
+++ b/packages/react-shadow/project.json
@@ -15,7 +15,10 @@
       "executor": "@nx/linter:eslint",
       "outputs": ["{options.outputFile}"],
       "options": {
-        "lintFilePatterns": ["packages/react-shadow/**/*.ts"]
+        "lintFilePatterns": [
+          "packages/react-shadow/**/*.ts",
+          "packages/react-shadow/**/*.tsx"
+        ]
       }
     },
     "test": {


### PR DESCRIPTION
NX generated project.json does not include linting tsx files by default. Make this change for all current packages and update the library creation generator.