### PR TITLE
chore: Remove node types in tsconfig.lib.json by default

### DIFF
--- a/packages/nx-plugin/src/generators/library/files/tsconfig.lib.json
+++ b/packages/nx-plugin/src/generators/library/files/tsconfig.lib.json
@@ -2,8 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "../../dist/out-tsc",
-    "declaration": true,
-    "types": ["node"]
+    "declaration": true
   },
   "include": ["src/**/*.ts"],
   "exclude": ["jest.config.ts", "src/**/*.test.ts", "src/**/*.test.tsx" , "files/**"]

--- a/packages/react-chat/tsconfig.lib.json
+++ b/packages/react-chat/tsconfig.lib.json
@@ -2,8 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "../../dist/out-tsc",
-    "declaration": true,
-    "types": ["node"]
+    "declaration": true
   },
   "include": ["src/**/*.ts"],
   "exclude": [

--- a/packages/react-shadow/tsconfig.lib.json
+++ b/packages/react-shadow/tsconfig.lib.json
@@ -2,8 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "../../dist/out-tsc",
-    "declaration": true,
-    "types": ["node"]
+    "declaration": true
   },
   "include": ["src/**/*.ts"],
   "exclude": [


### PR DESCRIPTION
Removes node types by default from web packages, and updates library generator not to add them.