### PR TITLE
chore: Set compilation target to es2019

### DIFF
--- a/change/@fluentui-contrib-react-chat-8a0422bd-aaaa-46d2-9962-006520348f61.json
+++ b/change/@fluentui-contrib-react-chat-8a0422bd-aaaa-46d2-9962-006520348f61.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "feat: downgrade to es2019",
+  "packageName": "@fluentui-contrib/react-chat",
+  "email": "lingfan.gao@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-contrib-react-data-grid-react-window-7b037308-1547-49cc-9b5a-5ff9de12051f.json
+++ b/change/@fluentui-contrib-react-data-grid-react-window-7b037308-1547-49cc-9b5a-5ff9de12051f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "feat: downgrade to es2019",
+  "packageName": "@fluentui-contrib/react-data-grid-react-window",
+  "email": "lingfan.gao@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-contrib-react-shadow-6ddd9824-b130-4001-ae67-3bff22314daf.json
+++ b/change/@fluentui-contrib-react-shadow-6ddd9824-b130-4001-ae67-3bff22314daf.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "feat: downgrade to es2019",
+  "packageName": "@fluentui-contrib/react-shadow",
+  "email": "lingfan.gao@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nx-plugin/src/generators/library/files/.swcrc
+++ b/packages/nx-plugin/src/generators/library/files/.swcrc
@@ -1,6 +1,6 @@
 {
   "jsc": {
-    "target": "es2020",
+    "target": "es2019",
     "parser": {
       "syntax": "typescript",
       "tsx": true,

--- a/packages/react-chat/.swcrc
+++ b/packages/react-chat/.swcrc
@@ -1,6 +1,6 @@
 {
   "jsc": {
-    "target": "es2020",
+    "target": "es2019",
     "parser": {
       "syntax": "typescript",
       "tsx": true,

--- a/packages/react-data-grid-react-window/.swcrc
+++ b/packages/react-data-grid-react-window/.swcrc
@@ -1,6 +1,6 @@
 {
   "jsc": {
-    "target": "es2020",
+    "target": "es2019",
     "parser": {
       "syntax": "typescript",
       "tsx": true,

--- a/packages/react-shadow/.swcrc
+++ b/packages/react-shadow/.swcrc
@@ -1,6 +1,6 @@
 {
   "jsc": {
-    "target": "es2020",
+    "target": "es2019",
     "parser": {
       "syntax": "typescript",
       "tsx": true,


### PR DESCRIPTION
Sets The compilation target of the repo to 2019 for webpack 4 compat webpack/webpack#10227 which does not support optional chaining without extra babel loader transpilation.

Also puts the repo in line with the Fluent UI core repo which uses es2019