### PR TITLE
chore: Add react-dom to peer-dependencies with automation

### DIFF
--- a/packages/nx-plugin/src/executors/build/executor.ts
+++ b/packages/nx-plugin/src/executors/build/executor.ts
@@ -61,7 +61,9 @@ function copyPackageJson(paths: PackagePaths) {
     },
     peerDependencies: {
       '@types/react': '>=16.8.0 <19.0.0',
+      '@types/react-dom': '>=16.8.0 <19.0.0',
       react: '>=16.8.0 <19.0.0',
+      'react-dom': '>=16.8.0 <19.0.0',
       ...packageJson.peerDependencies,
     },
     exports: {


### PR DESCRIPTION
Updates build to include react-dom and types as peer dependencies to support [midgard-yarn-strict](https://github.com/VincentBailly/midgard-yarn-strict) which forces packages to declare all peer dependencies of their entire dependency tree.

This will also align peer dependencies with Fluent UI core repo.