### PR TITLE
React data grid react window/fix/align peer dependencies

### DIFF
--- a/change/@fluentui-contrib-react-data-grid-react-window-2d085383-fcc7-473f-a6dd-3de79057cbeb.json
+++ b/change/@fluentui-contrib-react-data-grid-react-window-2d085383-fcc7-473f-a6dd-3de79057cbeb.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Align peer dependencies with the original package to enable strict package managers know upfront the dependencies",
+  "packageName": "@fluentui-contrib/react-data-grid-react-window",
+  "email": "mushierc@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-data-grid-react-window/package.json
+++ b/packages/react-data-grid-react-window/package.json
@@ -6,6 +6,9 @@
   },
   "peerDependencies": {
     "@fluentui/react-components": ">=9.25.1 <10.0.0",
-    "react": ">=16.8.0 <19.0.0"
+    "@types/react": ">=16.8.0 <19.0.0",
+    "@types/react-dom": ">=16.8.0 <19.0.0",
+    "react": ">=16.8.0 <19.0.0",
+    "react-dom": ">=16.8.0 <19.0.0"
   }
 }


### PR DESCRIPTION
Align peer dependencies to enable strict package managers know and link correct dependencies.