### PR TITLE
[Virtualized DataGrid] Fix direction for List

### DIFF
--- a/change/@fluentui-contrib-react-data-grid-react-window-792e435e-0385-4845-bd15-ee5909f20788.json
+++ b/change/@fluentui-contrib-react-data-grid-react-window-792e435e-0385-4845-bd15-ee5909f20788.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix RTL direction for virtualized DataGridBody",
+  "packageName": "@fluentui-contrib/react-data-grid-react-window",
+  "email": "dragoshomner@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-data-grid-react-window/src/components/DataGridBody/renderDataGridBody.tsx
+++ b/packages/react-data-grid-react-window/src/components/DataGridBody/renderDataGridBody.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { getSlots } from '@fluentui/react-components';
+import { getSlots, useFluent } from '@fluentui/react-components';
 import type {
   DataGridBodyState,
   DataGridBodySlots,
@@ -11,6 +11,7 @@ import { FixedSizeList as List } from 'react-window';
  */
 export const renderDataGridBody_unstable = (state: DataGridBodyState) => {
   const { slots, slotProps } = getSlots<DataGridBodySlots>(state);
+  const { dir } = useFluent();
 
   return (
     <slots.root {...slotProps.root}>
@@ -20,6 +21,7 @@ export const renderDataGridBody_unstable = (state: DataGridBodyState) => {
         itemData={state.rows}
         height={state.height}
         itemCount={state.rows.length}
+        direction={dir}
         {...state.listProps}
       >
         {state.virtualizedRow}


### PR DESCRIPTION
The scope of this PR is to fix the direction for the virtualized DataGrid. Before adding this change, by default, react-window uses the default direction (which is `LTR` - check their [wiki page](https://react-window.vercel.app/#/api/FixedSizeGrid)), even if the FluentUI Provider set it to be `RTL`. It was fixed by passing the `direction` prop to `List` component. 

The changes were tested using Storybook and setting the `dir` parameter to `rtl`. You can check the changes in the following screenshots:

| Before  | After  |
|---|---|
| ![image](https://github.com/microsoft/fluentui-contrib/assets/43915731/8d536f57-6258-4a9d-a2de-e2900527c996)| ![image](https://github.com/microsoft/fluentui-contrib/assets/43915731/0465b428-0c90-4501-ab0b-915f816897af)  |