### PR TITLE
feat: :hover and :active pseudoclasses should not count to combinator depth

### DIFF
--- a/change/@fluentui-contrib-stylelint-plugin-2f2ebb22-17ec-474a-ba11-93127236e071.json
+++ b/change/@fluentui-contrib-stylelint-plugin-2f2ebb22-17ec-474a-ba11-93127236e071.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: :hover and :active pseudoclasses should not count to combinator depth",
+  "packageName": "@fluentui-contrib/stylelint-plugin",
+  "email": "lingfan.gao@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/stylelint-plugin/src/rules/combinator-depth/README.md
+++ b/packages/stylelint-plugin/src/rules/combinator-depth/README.md
@@ -49,3 +49,37 @@ export function Component() {
   );
 }
 ```
+
+```tsx
+import { makeStyles, Button, buttonClassNames } from '@fluentui/react-components';
+import { SendRegular } from '@fluentui/react-icons';
+
+const useStyles = makeStyles({
+  showIcon: {
+    // ✅ certain pseudo classes do not count toward allowed depth
+    ':hover': {
+      [`& .${buttonClassNames.icon}`]
+      opacity: 1,
+    }
+
+    ':active': {
+      [`& .${buttonClassNames.icon}`]
+      opacity: 1,
+    }
+  },
+
+  hiddenIcon: {
+    opacity: 0,
+  }
+});
+
+export function Component() {
+  const styles = useStyles();
+
+  return (
+    <div>
+      <Button className={styles.root} icon={{ children: <SendRegular />, className: styles.hiddenIcon }}>Foo</Button>
+    </div>
+  );
+}
+```

--- a/packages/stylelint-plugin/src/rules/combinator-depth/combinator-depth.test.ts
+++ b/packages/stylelint-plugin/src/rules/combinator-depth/combinator-depth.test.ts
@@ -74,6 +74,43 @@ describe('combinator-depth', () => {
     );
   });
 
+  it('should not report error if the second token is a pseudo class', async () => {
+    const { errored, results } = await stylelint.lint({
+      code: `.foo:hover div { color: red; }`,
+      config: {
+        pluginFunctions: {
+          [rule.ruleName]: rule,
+        },
+        rules: {
+          [rule.ruleName]: [0],
+        },
+      },
+    });
+
+    expect(errored).toBe(false);
+    expect(results.length).toBe(1);
+    expect(results[0].warnings.length).toBe(0);
+  });
+
+  it('should report error if combinator depth after a pseudo class exceeds allowed depth', async () => {
+    const { errored, results } = await stylelint.lint({
+      code: `.foo:hover div div { color: red; }`,
+      config: {
+        pluginFunctions: {
+          [rule.ruleName]: rule,
+        },
+        rules: {
+          [rule.ruleName]: [0],
+        },
+      },
+    });
+
+    expect(errored).toBe(true);
+    expect(results.length).toBe(1);
+    expect(results[0].warnings.length).toBe(1);
+    expect(results[0].warnings[0].text).toContain(`maximum allowed depth of 0`);
+  });
+
   it.each([false, 'a', '%'])(
     'should throw an error if not configured with an %s',
     (allowedDepth) => {

--- a/packages/stylelint-plugin/src/rules/combinator-depth/combinator-depth.ts
+++ b/packages/stylelint-plugin/src/rules/combinator-depth/combinator-depth.ts
@@ -48,10 +48,17 @@ export default createRule({
 
         continue;
       }
-      tokenizedSelector.reverse();
       const combinatorCount = tokenizedSelector.filter(
         (token) => token.type === 'combinator'
       ).length;
+
+      if (
+        tokenizedSelector[1].type === 'pseudo-class' &&
+        [':hover', ':active'].includes(tokenizedSelector[1].content) &&
+        combinatorCount <= allowedDepth + 1
+      ) {
+        continue;
+      }
 
       if (combinatorCount > allowedDepth) {
         stylelint.utils.report({


### PR DESCRIPTION
It's valid to use these pseudoclasses to toggle visiblity or other changes in children elements.