### PR TITLE
chore: Allow peer dependency mismatches for @fluentui/react-components

### DIFF
--- a/.syncpackrc
+++ b/.syncpackrc
@@ -1,0 +1,20 @@
+{
+  "dependencyTypes": [
+    "prod",
+    "peer"
+  ],
+  "versionGroups": [
+    {
+      "packages": [
+        "**"
+      ],
+      "dependencies": [
+        "@fluentui/react-components"
+      ],
+      "dependencyTypes": [
+        "peer"
+      ],
+      "isIgnored": true
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "nx affected --target=build",
     "change": "beachball change",
-    "check-dependencies": "syncpack list-mismatches --types prod,peer",
+    "check-dependencies": "syncpack list-mismatches --types prod",
     "lint": "nx affected --target=lint",
     "test": "nx affected --target=test",
     "type-check": "nx affected --target=type-check",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "nx affected --target=build",
     "change": "beachball change",
-    "check-dependencies": "syncpack list-mismatches --types prod",
+    "check-dependencies": "syncpack list-mismatches",
     "lint": "nx affected --target=lint",
     "test": "nx affected --target=test",
     "type-check": "nx affected --target=type-check",


### PR DESCRIPTION
Peer dependencies are not actually installed by this repository and there is also no easy way to validate them with automation. #25 tried to implement some kind of validation for peer dependencies does not handle all cases correctly.

After this PR, it is up to library owners to make sure their libraries work correctly with the declared peer dependencies. https://github.com/microsoft/fluentui-contrib/issues/52 tracks adding automated validation

Allow mismatches in peer dependencies for `@fluentui/react-components` for now since it's the only known case currently where we _**want**_ mismatches