### PR TITLE
fix(react-headless-provider): use functions required by JSX pragma

### DIFF
--- a/change/@fluentui-contrib-react-headless-provider-49dfe0a5-09f5-4d16-a4a9-f484382f4bcc.json
+++ b/change/@fluentui-contrib-react-headless-provider-49dfe0a5-09f5-4d16-a4a9-f484382f4bcc.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: use functions required by JSX pragma",
+  "packageName": "@fluentui-contrib/react-headless-provider",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-headless-provider/src/components/HeadlessFluentProvider/HeadlessFluentProvider.test.tsx
+++ b/packages/react-headless-provider/src/components/HeadlessFluentProvider/HeadlessFluentProvider.test.tsx
@@ -1,9 +1,16 @@
 import * as React from 'react';
 import { render } from '@testing-library/react';
+
 import { HeadlessFluentProvider } from './HeadlessFluentProvider';
 
 describe('HeadlessFluentProvider', () => {
-  it('should render', () => {
-    render(<HeadlessFluentProvider />);
+  it('should render children', () => {
+    const { getByText } = render(
+      <HeadlessFluentProvider>
+        <span>Hello world!</span>
+      </HeadlessFluentProvider>
+    );
+
+    expect(() => getByText('Hello world!')).not.toThrow();
   });
 });

--- a/packages/react-headless-provider/src/components/HeadlessFluentProvider/HeadlessFluentProvider.tsx
+++ b/packages/react-headless-provider/src/components/HeadlessFluentProvider/HeadlessFluentProvider.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
 import {
-  useFluent,
   renderFluentProvider_unstable,
+  slot,
+  useFluent,
   useFluentProviderContextValues_unstable,
 } from '@fluentui/react-components';
 import type {
@@ -65,7 +66,7 @@ function useHeadlessFluentProviderState(
     // In headless mode, we don't render any elements
 
     components: { root: React.Fragment },
-    root: { children },
+    root: slot.always({ children }, { elementType: React.Fragment }),
 
     // Styling is ignored in headless mode
 


### PR DESCRIPTION
Fixes a warning from `@fluentui/react-utilities`:

```
    @fluentui/react-utilities [assertSlots]:
    "state.root" is not a slot!
    Be sure to create slots properly by using "slot.always" or "slot.optional".
```