### PR TITLE
fix(react-shadow): remove sync logic

### DIFF
--- a/change/@fluentui-contrib-react-shadow-50d448d8-13a6-4c02-b2a2-4054e6111b5f.json
+++ b/change/@fluentui-contrib-react-shadow-50d448d8-13a6-4c02-b2a2-4054e6111b5f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove sync logic",
+  "packageName": "@fluentui-contrib/react-shadow",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-shadow/src/root.tsx
+++ b/packages/react-shadow/src/root.tsx
@@ -13,32 +13,6 @@ const ReactComponentsWrapper: React.FC<{
 }> = ({ children, root }) => {
   const renderer = React.useMemo(() => createShadowDOMRenderer(root), [root]);
 
-  // TODO: explain this
-  React.useLayoutEffect(() => {
-    if (renderer.adoptedStyleSheets && renderer.adoptedStyleSheets.length > 0) {
-      if (
-        root.adoptedStyleSheets.find(
-          (styleSheet) => styleSheet === renderer.adoptedStyleSheets[0]
-        )
-      ) {
-        return;
-      }
-
-      root.adoptedStyleSheets = [
-        ...root.adoptedStyleSheets,
-        ...renderer.adoptedStyleSheets,
-      ];
-    }
-  }, [renderer.adoptedStyleSheets, root.adoptedStyleSheets]);
-
-  // TODO: polyfill does not work with ShadowRoot
-  // React.useLayoutEffect(() => {
-  //   applyFocusVisiblePolyfill(
-  //     root.host as HTMLElement,
-  //     root.ownerDocument.defaultView!
-  //   );
-  // }, [root]);
-
   return (
     <RendererProvider renderer={renderer}>
       <PortalMountNodeProvider value={root}>{children}</PortalMountNodeProvider>


### PR DESCRIPTION
This PR removes logic that does syncing of stylesheets as I don't see any condition when it should work and cannot reproduce when it's needed.