### PR TITLE
chore: fix docs deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ jobs:
 
       - run: yarn nx affected --target=type-check --parallel --max-parallel=3
       - run: yarn nx affected --target=build --parallel --max-parallel=3
+      - run: yarn nx affected --target=build-storybook --parallel --max-parallel=3
       - run: yarn nx affected --target=test --parallel --max-parallel=2
       - run: yarn nx affected --target=lint --parallel --max-parallel=3
       - run: yarn nx format:check --base origin/main
@@ -35,3 +36,21 @@ jobs:
         run: |
           git status --porcelain
           git diff-index --quiet HEAD -- || exit 1
+
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Derive appropriate SHAs for base and head for `nx affected` commands
+        uses: nrwl/nx-set-shas@v2
+
+      - uses: actions/setup-node@v3
+        with:
+          cache: 'yarn'
+          node-version: '16'
+
+      - run: yarn install --frozen-lockfile
+      - run: yarn nx affected --target=build-storybook --parallel --max-parallel=3


### PR DESCRIPTION
Adds a `/stories` folder with `.gitkeep` file to avoid storybook build error. Also adds a new CI job to build affected storybook projects