### PR TITLE
chore: update @fluentui/react-components version to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@babel/preset-env": "^7.21.5",
     "@babel/preset-react": "^7.18.6",
     "@babel/preset-typescript": "^7.21.5",
-    "@fluentui/react-components": "^9.30.0",
+    "@fluentui/react-components": "^9.44.4",
     "@griffel/shadow-dom": "~0.1.0",
     "@nx/devkit": "16.1.4",
     "@nx/eslint-plugin": "16.1.4",

--- a/packages/nx-plugin/src/generators/library/generator.spec.ts
+++ b/packages/nx-plugin/src/generators/library/generator.spec.ts
@@ -31,7 +31,7 @@ describe('create-package generator', () => {
     const pkgJson = readJson(tree, paths.packageJson);
     expect(pkgJson.peerDependencies).toMatchInlineSnapshot(`
       {
-        "@fluentui/react-components": ">=9.35.1 <10.0.0",
+        "@fluentui/react-components": ">=9.44.4 <10.0.0",
         "@types/react": ">=16.8.0 <19.0.0",
         "@types/react-dom": ">=16.8.0 <19.0.0",
         "react": ">=16.8.0 <19.0.0",

--- a/packages/react-tree-grid/package.json
+++ b/packages/react-tree-grid/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "private": true,
   "peerDependencies": {
-    "@fluentui/react-components": ">=9.35.1 < 10.0.0",
+    "@fluentui/react-components": ">=9.44.4 < 10.0.0",
     "@fluentui/react-shared-contexts": ">=9.7.2 <10.0.0",
     "@fluentui/keyboard-keys": ">=9.0.6 < 10.0.0",
     "@fluentui/react-tabster": ">=9.14.0 < 10.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1309,6 +1309,11 @@
   resolved "https://registry.yarnpkg.com/@floating-ui/core/-/core-1.2.6.tgz#d21ace437cc919cdd8f1640302fa8851e65e75c0"
   integrity sha512-EvYTiXet5XqweYGClEmpu3BoxmsQ4hkj3QaYA6qEnigCWffTP3vNRwBReTdrwDwo7OoJ3wM8Uoe9Uk4n+d4hfg==
 
+"@floating-ui/devtools@0.2.1":
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/@floating-ui/devtools/-/devtools-0.2.1.tgz#3e8023e09ede273a7aa426e7911f3dac630024c5"
+  integrity sha512-8PHJLbD6VhBh+LJ1uty/Bz30qs02NXCE5u8WpOhSewlYXUWl03GNXknr9AS2yaAWJEQaY27x7eByJs44gODBcw==
+
 "@floating-ui/dom@^1.2.0":
   version "1.2.8"
   resolved "https://registry.yarnpkg.com/@floating-ui/dom/-/dom-1.2.8.tgz#aee0f6ccc0787ab8fe741487a6e5e95b7b125375"
@@ -1316,800 +1321,841 @@
   dependencies:
     "@floating-ui/core" "^1.2.6"
 
-"@fluentui/keyboard-keys@^9.0.6":
-  version "9.0.6"
-  resolved "https://registry.yarnpkg.com/@fluentui/keyboard-keys/-/keyboard-keys-9.0.6.tgz#62449f81223f5a2c2755ff6f286b6e47f1b93135"
-  integrity sha512-WvJrCKvt8Om04S+IwypeJ3FG2tP2TSNFMSMYouDdeKspKD1EmQyQybs7YA9+Fh98X5ERF14zBCurgtNjpDH6gQ==
+"@fluentui/keyboard-keys@^9.0.7":
+  version "9.0.7"
+  resolved "https://registry.yarnpkg.com/@fluentui/keyboard-keys/-/keyboard-keys-9.0.7.tgz#a603ea0827ccd48ab606fd48ff259b8a914d23d4"
+  integrity sha512-vaQ+lOveQTdoXJYqDQXWb30udSfTVcIuKk1rV0X0eGAgcHeSDeP1HxMy+OgHOQZH3OiBH4ZYeWxb+tmfiDiygQ==
   dependencies:
     "@swc/helpers" "^0.5.1"
 
-"@fluentui/priority-overflow@^9.1.7":
-  version "9.1.7"
-  resolved "https://registry.yarnpkg.com/@fluentui/priority-overflow/-/priority-overflow-9.1.7.tgz#061bc9235b318e9d613d11f2e2cdc37fbb551ce2"
-  integrity sha512-+SzSmEr5+/n7c1vmqAb2Ykk3Z5Dh2yqIl/dDbQjuiSaQzZHjr/b59A06x6t/JXKWFH8g4yG6A2LpSeLIbRBP9Q==
+"@fluentui/priority-overflow@^9.1.11":
+  version "9.1.11"
+  resolved "https://registry.yarnpkg.com/@fluentui/priority-overflow/-/priority-overflow-9.1.11.tgz#d418560859f75e8727824972a9db9f76d5b74b83"
+  integrity sha512-sdrpavvKX2kepQ1d6IaI3ObLq5SAQBPRHPGx2+wiMWL7cEx9vGGM0fmeicl3soqqmM5uwCmWnZk9QZv9XOY98w==
   dependencies:
     "@swc/helpers" "^0.5.1"
 
-"@fluentui/react-accordion@^9.3.23":
-  version "9.3.23"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-accordion/-/react-accordion-9.3.23.tgz#b4917eef8c99300a3dcef58f8d5d4650b03dd190"
-  integrity sha512-B1fI3zHYhHpXfL5uNQw2CuvXy/btWfGcQQsDj9abf1OjV1X0avGgdoIkYo5dkSX93Y6GFG0Xo9+sQKyg2tF4DA==
+"@fluentui/react-accordion@^9.3.36":
+  version "9.3.36"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-accordion/-/react-accordion-9.3.36.tgz#f46096a38fdf8c147627c6a45bd64f0dd6fc6ae1"
+  integrity sha512-t1Q9SI5P1x53SF7stmpI7mauPd24mV+XqOOHY2htqR+vIa6n+gTLvvFe8qwPLsfK8kkyISzCaP1yHriPV9GqUQ==
   dependencies:
-    "@fluentui/react-aria" "^9.3.43"
-    "@fluentui/react-context-selector" "^9.1.41"
-    "@fluentui/react-icons" "^2.0.217"
-    "@fluentui/react-jsx-runtime" "^9.0.18"
-    "@fluentui/react-shared-contexts" "^9.10.0"
-    "@fluentui/react-tabster" "^9.14.0"
-    "@fluentui/react-theme" "^9.1.14"
-    "@fluentui/react-utilities" "^9.15.1"
+    "@fluentui/react-aria" "^9.7.1"
+    "@fluentui/react-context-selector" "^9.1.47"
+    "@fluentui/react-icons" "^2.0.224"
+    "@fluentui/react-jsx-runtime" "^9.0.25"
+    "@fluentui/react-shared-contexts" "^9.13.2"
+    "@fluentui/react-tabster" "^9.17.1"
+    "@fluentui/react-theme" "^9.1.16"
+    "@fluentui/react-utilities" "^9.15.6"
     "@griffel/react" "^1.5.14"
     "@swc/helpers" "^0.5.1"
 
-"@fluentui/react-alert@9.0.0-beta.87":
-  version "9.0.0-beta.87"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-alert/-/react-alert-9.0.0-beta.87.tgz#7d7b69339607df05622a38b1a8f017d7b3b93ea2"
-  integrity sha512-V+nxPCXmNO2q02BbLqaugMxAcxScPP0qA17EzgvgNjfHDIeRzkxEfhBB0rLmVUhC5QI9K5Gi6Uv1rJSgCq3TBg==
+"@fluentui/react-alert@9.0.0-beta.102":
+  version "9.0.0-beta.102"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-alert/-/react-alert-9.0.0-beta.102.tgz#09838085cce106f83109cf689ce22cd6ef497245"
+  integrity sha512-ZIbeW4Di1oJqPe87fFOciA57WZfFsTz8pBnI5n0x+jFl9tAnbp4FCWQHlatVf7rOkixet72ym0M9pSD1ez3U9A==
   dependencies:
-    "@fluentui/react-avatar" "^9.5.41"
-    "@fluentui/react-button" "^9.3.50"
-    "@fluentui/react-icons" "^2.0.217"
-    "@fluentui/react-jsx-runtime" "^9.0.18"
-    "@fluentui/react-tabster" "^9.14.0"
-    "@fluentui/react-theme" "^9.1.14"
-    "@fluentui/react-utilities" "^9.15.1"
+    "@fluentui/react-avatar" "^9.6.7"
+    "@fluentui/react-button" "^9.3.63"
+    "@fluentui/react-icons" "^2.0.224"
+    "@fluentui/react-jsx-runtime" "^9.0.25"
+    "@fluentui/react-tabster" "^9.17.1"
+    "@fluentui/react-theme" "^9.1.16"
+    "@fluentui/react-utilities" "^9.15.6"
     "@griffel/react" "^1.5.14"
     "@swc/helpers" "^0.5.1"
 
-"@fluentui/react-aria@^9.3.43":
-  version "9.3.43"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-aria/-/react-aria-9.3.43.tgz#0b1591ca5fa34c0bd61e52a5922e7be7daf5c408"
-  integrity sha512-LO/u3ea4IgZUlXePO4V/ufwMZnoSILTT8FEgsxkcgauzMxmIRwijtJ9fYImifndu95Npl3OlA77CmMZwFsLsDQ==
+"@fluentui/react-aria@^9.7.1":
+  version "9.7.1"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-aria/-/react-aria-9.7.1.tgz#4c6058affab9ce2b217a542191563c14232c458a"
+  integrity sha512-LuupqbV/6ZWd/6t8xIKa/yg8CbIvp98T1GYw/eyseDk26dBvNY0Ue11O5Z5uN3fwVCR1a92cO0aFyPcv4fmaHA==
   dependencies:
-    "@fluentui/keyboard-keys" "^9.0.6"
-    "@fluentui/react-utilities" "^9.15.1"
+    "@fluentui/keyboard-keys" "^9.0.7"
+    "@fluentui/react-shared-contexts" "^9.13.2"
+    "@fluentui/react-tabster" "^9.17.1"
+    "@fluentui/react-utilities" "^9.15.6"
     "@swc/helpers" "^0.5.1"
 
-"@fluentui/react-avatar@^9.5.41":
-  version "9.5.41"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-avatar/-/react-avatar-9.5.41.tgz#95b43619eaf0299cf760c47b6cc5608c775cb3fd"
-  integrity sha512-SfDFrrn76HoXlqaGtan0BomsLqcq3r6mIdcZuRtb/lp0qg7buBAXZgFpkDU3U65/JqxeaPfSQPJ2jEK2wngS7g==
+"@fluentui/react-avatar@^9.6.7":
+  version "9.6.7"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-avatar/-/react-avatar-9.6.7.tgz#57582379d98d45c879ac5edef93634aa3cf69eb2"
+  integrity sha512-8eZn9muu8a30v/C+ygZShpAQpTUefH+C4sW4hSUbuIIdalpU/CGkAe9iDLO+8dMxGQCXx1Y873ipNRsyDBCrLg==
   dependencies:
-    "@fluentui/react-badge" "^9.2.10"
-    "@fluentui/react-context-selector" "^9.1.41"
-    "@fluentui/react-icons" "^2.0.217"
-    "@fluentui/react-jsx-runtime" "^9.0.18"
-    "@fluentui/react-popover" "^9.8.16"
-    "@fluentui/react-shared-contexts" "^9.10.0"
-    "@fluentui/react-tabster" "^9.14.0"
-    "@fluentui/react-theme" "^9.1.14"
-    "@fluentui/react-tooltip" "^9.3.17"
-    "@fluentui/react-utilities" "^9.15.1"
+    "@fluentui/react-badge" "^9.2.20"
+    "@fluentui/react-context-selector" "^9.1.47"
+    "@fluentui/react-icons" "^2.0.224"
+    "@fluentui/react-jsx-runtime" "^9.0.25"
+    "@fluentui/react-popover" "^9.8.31"
+    "@fluentui/react-shared-contexts" "^9.13.2"
+    "@fluentui/react-tabster" "^9.17.1"
+    "@fluentui/react-theme" "^9.1.16"
+    "@fluentui/react-tooltip" "^9.4.9"
+    "@fluentui/react-utilities" "^9.15.6"
     "@griffel/react" "^1.5.14"
     "@swc/helpers" "^0.5.1"
 
-"@fluentui/react-badge@^9.2.10":
-  version "9.2.10"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-badge/-/react-badge-9.2.10.tgz#d2324bd814f2b0e81dcce1bccd5ec40acdaa4156"
-  integrity sha512-Z4lS3VHyqTxTEUwuCXD7th5wK+5E+FAyTLgs0S5wvh8B7t347IBEyyhlaTfrjzZA5lKsU2KWL5GKsgBQdPZURg==
+"@fluentui/react-badge@^9.2.20":
+  version "9.2.20"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-badge/-/react-badge-9.2.20.tgz#0f3bae29df81d237bb94e680e1a6065549d5cec3"
+  integrity sha512-6qLLEr1D/ZXwF7kBXb+iOh2Cke+0N2tJXCxYoLUEjtOlUDHvEMl32oO5b8WQZMVGGQCTGY192LxT8vAPqxREyg==
   dependencies:
-    "@fluentui/react-icons" "^2.0.217"
-    "@fluentui/react-jsx-runtime" "^9.0.18"
-    "@fluentui/react-shared-contexts" "^9.10.0"
-    "@fluentui/react-theme" "^9.1.14"
-    "@fluentui/react-utilities" "^9.15.1"
+    "@fluentui/react-icons" "^2.0.224"
+    "@fluentui/react-jsx-runtime" "^9.0.25"
+    "@fluentui/react-shared-contexts" "^9.13.2"
+    "@fluentui/react-theme" "^9.1.16"
+    "@fluentui/react-utilities" "^9.15.6"
     "@griffel/react" "^1.5.14"
     "@swc/helpers" "^0.5.1"
 
-"@fluentui/react-button@^9.3.50":
-  version "9.3.50"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-button/-/react-button-9.3.50.tgz#83f7b5de646c201b5e6a519b06d50657c2290df6"
-  integrity sha512-GjlZLuyRE5AFPTMxY2KKkVrEUaoPCT31K4bhEuOMI/k8ETA0J0RiKrtDSNGNlRlhSL4JKbrI+MNiTHHQkm8f+g==
+"@fluentui/react-breadcrumb@^9.0.9":
+  version "9.0.9"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-breadcrumb/-/react-breadcrumb-9.0.9.tgz#8bbd4a8144c3aaf35437d417451c64e5074c0e33"
+  integrity sha512-xNOGoVHGihjfFeio9FhE2urYE+aRKjqkYDRTqZu9dWwRnjhAO90V9QXztTgJjxPCf+PYNzJH/39Sm0NKOxynyg==
   dependencies:
-    "@fluentui/keyboard-keys" "^9.0.6"
-    "@fluentui/react-aria" "^9.3.43"
-    "@fluentui/react-icons" "^2.0.217"
-    "@fluentui/react-jsx-runtime" "^9.0.18"
-    "@fluentui/react-shared-contexts" "^9.10.0"
-    "@fluentui/react-tabster" "^9.14.0"
-    "@fluentui/react-theme" "^9.1.14"
-    "@fluentui/react-utilities" "^9.15.1"
+    "@fluentui/react-aria" "^9.7.1"
+    "@fluentui/react-button" "^9.3.63"
+    "@fluentui/react-icons" "^2.0.224"
+    "@fluentui/react-jsx-runtime" "^9.0.25"
+    "@fluentui/react-link" "^9.2.5"
+    "@fluentui/react-shared-contexts" "^9.13.2"
+    "@fluentui/react-tabster" "^9.17.1"
+    "@fluentui/react-theme" "^9.1.16"
+    "@fluentui/react-utilities" "^9.15.6"
     "@griffel/react" "^1.5.14"
     "@swc/helpers" "^0.5.1"
 
-"@fluentui/react-card@^9.0.49":
-  version "9.0.49"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-card/-/react-card-9.0.49.tgz#0036959d8935678edcb077e892c59141c7ccc69a"
-  integrity sha512-uznA7bimsJqHLiaNI1X+muOVNmj379xoLRqchPN7xbjkY5BUmJZ/vu5LuDZuYCmnpBnk+phc8SltoAg3/LSnTg==
+"@fluentui/react-button@^9.3.63":
+  version "9.3.63"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-button/-/react-button-9.3.63.tgz#8d4f320b815fae30c41502cb258e8e829a281a7f"
+  integrity sha512-Yw+LwQMEnXUMpHKjpW1aRC7RqSfcpWK4ytS0SPiu1TrFuvc/3meCPsXnIYhdlZrlBeRQdNucSaWNGBHAUmGt9w==
   dependencies:
-    "@fluentui/keyboard-keys" "^9.0.6"
-    "@fluentui/react-jsx-runtime" "^9.0.18"
-    "@fluentui/react-tabster" "^9.14.0"
-    "@fluentui/react-theme" "^9.1.14"
-    "@fluentui/react-utilities" "^9.15.1"
+    "@fluentui/keyboard-keys" "^9.0.7"
+    "@fluentui/react-aria" "^9.7.1"
+    "@fluentui/react-icons" "^2.0.224"
+    "@fluentui/react-jsx-runtime" "^9.0.25"
+    "@fluentui/react-shared-contexts" "^9.13.2"
+    "@fluentui/react-tabster" "^9.17.1"
+    "@fluentui/react-theme" "^9.1.16"
+    "@fluentui/react-utilities" "^9.15.6"
     "@griffel/react" "^1.5.14"
     "@swc/helpers" "^0.5.1"
 
-"@fluentui/react-checkbox@^9.1.51":
-  version "9.1.51"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-checkbox/-/react-checkbox-9.1.51.tgz#52ec2ee0575c2303c7e16a24af311ca51b42eafc"
-  integrity sha512-+JWOMjOkVdg8bwCKJDBL6qABvKkgQhkxG64kmwlzVlazZXgp+VB+7nl3q4iwXkZwgx0kx9oc1cbhWg9ZgfZJ2Q==
+"@fluentui/react-card@^9.0.62":
+  version "9.0.62"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-card/-/react-card-9.0.62.tgz#cef0238e91a8fbed4199f3d35e71fda6fbff0fd6"
+  integrity sha512-PIYrhwTN+LbMf3dOQviOQLulOwyUa8QwXCL/ISSdrqb4AQcGA7ldcBxvRNi/XXw/Z+Z6Pxj2h1fkT5vtlow7Yg==
   dependencies:
-    "@fluentui/react-field" "^9.1.38"
-    "@fluentui/react-icons" "^2.0.217"
-    "@fluentui/react-jsx-runtime" "^9.0.18"
-    "@fluentui/react-label" "^9.1.46"
-    "@fluentui/react-shared-contexts" "^9.10.0"
-    "@fluentui/react-tabster" "^9.14.0"
-    "@fluentui/react-theme" "^9.1.14"
-    "@fluentui/react-utilities" "^9.15.1"
+    "@fluentui/keyboard-keys" "^9.0.7"
+    "@fluentui/react-jsx-runtime" "^9.0.25"
+    "@fluentui/react-tabster" "^9.17.1"
+    "@fluentui/react-theme" "^9.1.16"
+    "@fluentui/react-utilities" "^9.15.6"
     "@griffel/react" "^1.5.14"
     "@swc/helpers" "^0.5.1"
 
-"@fluentui/react-combobox@^9.5.25":
-  version "9.5.25"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-combobox/-/react-combobox-9.5.25.tgz#3eabb0c00547b6dcee673db1d240676417f02abf"
-  integrity sha512-dKa5GctJHjqatvHyFFmspzpc0CJXliBJMF/LTZ+zA4vovCbxMpTQCDtrbfyiV6D84Q827Ry9/6xe3Id2tVGMRQ==
+"@fluentui/react-checkbox@^9.2.6":
+  version "9.2.6"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-checkbox/-/react-checkbox-9.2.6.tgz#f5a8460a145b33ebf8623e69e39bcbb88cc268b9"
+  integrity sha512-4P+YqtByqb41EhyWwQaizyc+lBtFj7e4ufcn6xLYbMI6bKrvODN1vsk1XbzFGxP18aWp2Ivf4d0INIlmR1T21w==
   dependencies:
-    "@fluentui/keyboard-keys" "^9.0.6"
-    "@fluentui/react-context-selector" "^9.1.41"
-    "@fluentui/react-field" "^9.1.38"
-    "@fluentui/react-icons" "^2.0.217"
-    "@fluentui/react-jsx-runtime" "^9.0.18"
-    "@fluentui/react-portal" "^9.3.24"
-    "@fluentui/react-positioning" "^9.9.21"
-    "@fluentui/react-shared-contexts" "^9.10.0"
-    "@fluentui/react-theme" "^9.1.14"
-    "@fluentui/react-utilities" "^9.15.1"
+    "@fluentui/react-field" "^9.1.48"
+    "@fluentui/react-icons" "^2.0.224"
+    "@fluentui/react-jsx-runtime" "^9.0.25"
+    "@fluentui/react-label" "^9.1.56"
+    "@fluentui/react-shared-contexts" "^9.13.2"
+    "@fluentui/react-tabster" "^9.17.1"
+    "@fluentui/react-theme" "^9.1.16"
+    "@fluentui/react-utilities" "^9.15.6"
     "@griffel/react" "^1.5.14"
     "@swc/helpers" "^0.5.1"
 
-"@fluentui/react-components@^9.30.0":
-  version "9.35.1"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-components/-/react-components-9.35.1.tgz#7de862948c4738e9d4c32f5639b0310452c34eb8"
-  integrity sha512-jKSygoiQzTlqpAf9JJcj0ihtIqxjRDpivgzIpSJs7qpLQN14cRgr9thFiFKt2sn8BBVwBhQHGCpPCJuf5XWn1g==
+"@fluentui/react-combobox@^9.6.0":
+  version "9.6.0"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-combobox/-/react-combobox-9.6.0.tgz#2374c7fbd341f256ebeb28b494e66868efda53b7"
+  integrity sha512-nPqM7qhyDpv5KjD70IUosi1vkFlunxPYTopi0imc8MJLnRzp2yhkuL8+lLUTfVLFy3T4ZVrWBoOhpy2Fu+YBHQ==
   dependencies:
-    "@fluentui/react-accordion" "^9.3.23"
-    "@fluentui/react-alert" "9.0.0-beta.87"
-    "@fluentui/react-avatar" "^9.5.41"
-    "@fluentui/react-badge" "^9.2.10"
-    "@fluentui/react-button" "^9.3.50"
-    "@fluentui/react-card" "^9.0.49"
-    "@fluentui/react-checkbox" "^9.1.51"
-    "@fluentui/react-combobox" "^9.5.25"
-    "@fluentui/react-dialog" "^9.7.10"
-    "@fluentui/react-divider" "^9.2.46"
-    "@fluentui/react-drawer" "9.0.0-beta.36"
-    "@fluentui/react-field" "^9.1.38"
-    "@fluentui/react-image" "^9.1.43"
-    "@fluentui/react-infobutton" "9.0.0-beta.71"
-    "@fluentui/react-input" "^9.4.48"
-    "@fluentui/react-label" "^9.1.46"
-    "@fluentui/react-link" "^9.1.29"
-    "@fluentui/react-menu" "^9.12.27"
-    "@fluentui/react-message-bar" "^9.0.1"
-    "@fluentui/react-overflow" "^9.0.40"
-    "@fluentui/react-persona" "^9.2.51"
-    "@fluentui/react-popover" "^9.8.16"
-    "@fluentui/react-portal" "^9.3.24"
-    "@fluentui/react-positioning" "^9.9.21"
-    "@fluentui/react-progress" "^9.1.48"
-    "@fluentui/react-provider" "^9.10.8"
-    "@fluentui/react-radio" "^9.1.51"
-    "@fluentui/react-select" "^9.1.48"
-    "@fluentui/react-shared-contexts" "^9.10.0"
-    "@fluentui/react-skeleton" "^9.0.36"
-    "@fluentui/react-slider" "^9.1.51"
-    "@fluentui/react-spinbutton" "^9.2.48"
-    "@fluentui/react-spinner" "^9.3.26"
-    "@fluentui/react-switch" "^9.1.51"
-    "@fluentui/react-table" "^9.10.6"
-    "@fluentui/react-tabs" "^9.3.52"
-    "@fluentui/react-tabster" "^9.14.0"
-    "@fluentui/react-tags" "^9.0.5"
-    "@fluentui/react-text" "^9.3.43"
-    "@fluentui/react-textarea" "^9.3.48"
-    "@fluentui/react-theme" "^9.1.14"
-    "@fluentui/react-toast" "^9.3.12"
-    "@fluentui/react-toolbar" "^9.1.51"
-    "@fluentui/react-tooltip" "^9.3.17"
-    "@fluentui/react-tree" "^9.4.6"
-    "@fluentui/react-utilities" "^9.15.1"
-    "@fluentui/react-virtualizer" "9.0.0-alpha.52"
+    "@fluentui/keyboard-keys" "^9.0.7"
+    "@fluentui/react-context-selector" "^9.1.47"
+    "@fluentui/react-field" "^9.1.48"
+    "@fluentui/react-icons" "^2.0.224"
+    "@fluentui/react-jsx-runtime" "^9.0.25"
+    "@fluentui/react-portal" "^9.4.8"
+    "@fluentui/react-positioning" "^9.12.2"
+    "@fluentui/react-shared-contexts" "^9.13.2"
+    "@fluentui/react-tabster" "^9.17.1"
+    "@fluentui/react-theme" "^9.1.16"
+    "@fluentui/react-utilities" "^9.15.6"
     "@griffel/react" "^1.5.14"
     "@swc/helpers" "^0.5.1"
 
-"@fluentui/react-context-selector@^9.1.41":
-  version "9.1.41"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-context-selector/-/react-context-selector-9.1.41.tgz#de34e396990793e09264d700f12f921280d8b450"
-  integrity sha512-Q0Gbem5rz7hK9uBrWLOhD4TWzCSqYzA+TNpd8vYE2/9GHFTc16EvKEg1gsnvlA0lNHwTR0JwT0QT8d2KsNHa4w==
+"@fluentui/react-components@^9.44.4":
+  version "9.44.4"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-components/-/react-components-9.44.4.tgz#9a20f56382aa939c02860f93b784151cb3d9fb6e"
+  integrity sha512-a4PT8/fz6BtRHKRZWO0j9DxYLpU9ms3kGQ/xbRLRf5R4jL2GOD2ZZPnWS9wAYaOu9HBoUMM6fVuLNoISwfjOGQ==
   dependencies:
-    "@fluentui/react-utilities" "^9.15.1"
-    "@swc/helpers" "^0.5.1"
-
-"@fluentui/react-dialog@^9.7.10":
-  version "9.7.10"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-dialog/-/react-dialog-9.7.10.tgz#296e1fd4ffd1d11fda2c93c744e43be6acf1947d"
-  integrity sha512-71gOQ8eMV64UUTw7rro2bOr6rA3KzQcdolsp6xzwN3LRPDkf9euGmTmeZvOm67FgqUq5VseqQRICjywfTm3x7g==
-  dependencies:
-    "@fluentui/keyboard-keys" "^9.0.6"
-    "@fluentui/react-aria" "^9.3.43"
-    "@fluentui/react-context-selector" "^9.1.41"
-    "@fluentui/react-icons" "^2.0.217"
-    "@fluentui/react-jsx-runtime" "^9.0.18"
-    "@fluentui/react-portal" "^9.3.24"
-    "@fluentui/react-shared-contexts" "^9.10.0"
-    "@fluentui/react-tabster" "^9.14.0"
-    "@fluentui/react-theme" "^9.1.14"
-    "@fluentui/react-utilities" "^9.15.1"
+    "@fluentui/react-accordion" "^9.3.36"
+    "@fluentui/react-alert" "9.0.0-beta.102"
+    "@fluentui/react-avatar" "^9.6.7"
+    "@fluentui/react-badge" "^9.2.20"
+    "@fluentui/react-breadcrumb" "^9.0.9"
+    "@fluentui/react-button" "^9.3.63"
+    "@fluentui/react-card" "^9.0.62"
+    "@fluentui/react-checkbox" "^9.2.6"
+    "@fluentui/react-combobox" "^9.6.0"
+    "@fluentui/react-dialog" "^9.9.5"
+    "@fluentui/react-divider" "^9.2.56"
+    "@fluentui/react-drawer" "^9.0.9"
+    "@fluentui/react-field" "^9.1.48"
+    "@fluentui/react-image" "^9.1.53"
+    "@fluentui/react-infobutton" "9.0.0-beta.86"
+    "@fluentui/react-infolabel" "^9.0.14"
+    "@fluentui/react-input" "^9.4.58"
+    "@fluentui/react-label" "^9.1.56"
+    "@fluentui/react-link" "^9.2.5"
+    "@fluentui/react-menu" "^9.12.43"
+    "@fluentui/react-message-bar" "^9.0.14"
+    "@fluentui/react-overflow" "^9.1.6"
+    "@fluentui/react-persona" "^9.2.66"
+    "@fluentui/react-popover" "^9.8.31"
+    "@fluentui/react-portal" "^9.4.8"
+    "@fluentui/react-positioning" "^9.12.2"
+    "@fluentui/react-progress" "^9.1.58"
+    "@fluentui/react-provider" "^9.13.6"
+    "@fluentui/react-radio" "^9.2.1"
+    "@fluentui/react-select" "^9.1.58"
+    "@fluentui/react-shared-contexts" "^9.13.2"
+    "@fluentui/react-skeleton" "^9.0.46"
+    "@fluentui/react-slider" "^9.1.63"
+    "@fluentui/react-spinbutton" "^9.2.58"
+    "@fluentui/react-spinner" "^9.3.36"
+    "@fluentui/react-switch" "^9.1.63"
+    "@fluentui/react-table" "^9.11.3"
+    "@fluentui/react-tabs" "^9.4.4"
+    "@fluentui/react-tabster" "^9.17.1"
+    "@fluentui/react-tags" "^9.0.20"
+    "@fluentui/react-text" "^9.4.5"
+    "@fluentui/react-textarea" "^9.3.58"
+    "@fluentui/react-theme" "^9.1.16"
+    "@fluentui/react-toast" "^9.3.25"
+    "@fluentui/react-toolbar" "^9.1.64"
+    "@fluentui/react-tooltip" "^9.4.9"
+    "@fluentui/react-tree" "^9.4.23"
+    "@fluentui/react-utilities" "^9.15.6"
+    "@fluentui/react-virtualizer" "9.0.0-alpha.64"
     "@griffel/react" "^1.5.14"
     "@swc/helpers" "^0.5.1"
 
-"@fluentui/react-divider@^9.2.46":
-  version "9.2.46"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-divider/-/react-divider-9.2.46.tgz#45e71cecb60003ce66165463eec31f3d300946f5"
-  integrity sha512-+YBrlHz5MZ+gjH36J5orn9MZNXSdz6vOm+4XmJZRyStvfStjcfgVImOfmDs4SYcokwvqq5RTrL9iL/VGseTTMQ==
+"@fluentui/react-context-selector@^9.1.47":
+  version "9.1.47"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-context-selector/-/react-context-selector-9.1.47.tgz#ffaba02beff1879c3fa01893798a32b938120438"
+  integrity sha512-sjI2tu8ELjna1oIIgWc4Xa/pF9fTnaA27DtlcqZnAPInv/UyHbsZCE0V4jc3NQMBofWKpK2gypXtEGHmTCYsFg==
   dependencies:
-    "@fluentui/react-jsx-runtime" "^9.0.18"
-    "@fluentui/react-shared-contexts" "^9.10.0"
-    "@fluentui/react-theme" "^9.1.14"
-    "@fluentui/react-utilities" "^9.15.1"
+    "@fluentui/react-utilities" "^9.15.6"
+    "@swc/helpers" "^0.5.1"
+
+"@fluentui/react-dialog@^9.9.5":
+  version "9.9.5"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-dialog/-/react-dialog-9.9.5.tgz#d260ae68313970bce168185f213529889d8ada14"
+  integrity sha512-TADvVSw0rP+dI/keaLNZ+dMbqYdkIHR4D/Uu7sBjIyaaJtGvb/oNeDtNjk2BXO6ObaAGnQvxs6AJkJQ1mvklkg==
+  dependencies:
+    "@fluentui/keyboard-keys" "^9.0.7"
+    "@fluentui/react-aria" "^9.7.1"
+    "@fluentui/react-context-selector" "^9.1.47"
+    "@fluentui/react-icons" "^2.0.224"
+    "@fluentui/react-jsx-runtime" "^9.0.25"
+    "@fluentui/react-portal" "^9.4.8"
+    "@fluentui/react-shared-contexts" "^9.13.2"
+    "@fluentui/react-tabster" "^9.17.1"
+    "@fluentui/react-theme" "^9.1.16"
+    "@fluentui/react-utilities" "^9.15.6"
+    "@griffel/react" "^1.5.14"
+    "@swc/helpers" "^0.5.1"
+    react-transition-group "^4.4.1"
+
+"@fluentui/react-divider@^9.2.56":
+  version "9.2.56"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-divider/-/react-divider-9.2.56.tgz#3dbc8e910e354ca46611d8adaaa3f54f32a90f7c"
+  integrity sha512-5QTzBltI+WGgLGfQYjmk7YfzR1zIIUhS2Pz+RUriBmovAijJRWNX3Wa4NUcTiP/sQJden0cKxHKNbHzoofOcLg==
+  dependencies:
+    "@fluentui/react-jsx-runtime" "^9.0.25"
+    "@fluentui/react-shared-contexts" "^9.13.2"
+    "@fluentui/react-theme" "^9.1.16"
+    "@fluentui/react-utilities" "^9.15.6"
     "@griffel/react" "^1.5.14"
     "@swc/helpers" "^0.5.1"
 
-"@fluentui/react-drawer@9.0.0-beta.36":
-  version "9.0.0-beta.36"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-drawer/-/react-drawer-9.0.0-beta.36.tgz#16e3b605751ce1f65a5f0476fcce416b1ad154a1"
-  integrity sha512-PvBCM6qJClDxvc++BIqjO/XbkDI+D0i0KqJkZTl74E5N4LDII0UUQUqjfr/mtGUOvGaUnOe88js4bzoJYBy2uA==
+"@fluentui/react-drawer@^9.0.9":
+  version "9.0.9"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-drawer/-/react-drawer-9.0.9.tgz#c80e10ac962a2ca15b7cf7fee3a832657c8b9cb8"
+  integrity sha512-uF4EpNFKiKbPVcpdFM/j4XhAI4Aj0nbve8aARlD3WgCsmPjKEhIsfRY6o1qxdrAbhbb/s6ZvhUa+SuhoE9dQlA==
   dependencies:
-    "@fluentui/react-dialog" "^9.7.10"
-    "@fluentui/react-jsx-runtime" "^9.0.18"
-    "@fluentui/react-motion-preview" "^0.3.4"
-    "@fluentui/react-shared-contexts" "^9.10.0"
-    "@fluentui/react-tabster" "^9.14.0"
-    "@fluentui/react-theme" "^9.1.14"
-    "@fluentui/react-utilities" "^9.15.1"
+    "@fluentui/react-dialog" "^9.9.5"
+    "@fluentui/react-jsx-runtime" "^9.0.25"
+    "@fluentui/react-motion-preview" "^0.5.8"
+    "@fluentui/react-shared-contexts" "^9.13.2"
+    "@fluentui/react-tabster" "^9.17.1"
+    "@fluentui/react-theme" "^9.1.16"
+    "@fluentui/react-utilities" "^9.15.6"
     "@griffel/react" "^1.5.14"
     "@swc/helpers" "^0.5.1"
 
-"@fluentui/react-field@^9.1.38":
-  version "9.1.38"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-field/-/react-field-9.1.38.tgz#22a6b8fa7c476087fc69aec146a1104232d9cff2"
-  integrity sha512-P+zOPm2tu7//trczqkQQT0DP9r6oVEwBlaBiAJara464sudCiXbsq8F4wFHxTAw7BNtbqKenOsEJkJq1sx4Exw==
+"@fluentui/react-field@^9.1.48":
+  version "9.1.48"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-field/-/react-field-9.1.48.tgz#b73b554bc166ae5cbb8fc3a7eb22f58f3ab4e604"
+  integrity sha512-J8TUP730WDlyPXbea1m13aB4seDUIxeLAEZyFYx2igmSzCnA8LTAtsOyqHFC8EcR1/twmIB+jdD1XG7n9JpR2g==
   dependencies:
-    "@fluentui/react-context-selector" "^9.1.41"
-    "@fluentui/react-icons" "^2.0.217"
-    "@fluentui/react-jsx-runtime" "^9.0.18"
-    "@fluentui/react-label" "^9.1.46"
-    "@fluentui/react-theme" "^9.1.14"
-    "@fluentui/react-utilities" "^9.15.1"
+    "@fluentui/react-context-selector" "^9.1.47"
+    "@fluentui/react-icons" "^2.0.224"
+    "@fluentui/react-jsx-runtime" "^9.0.25"
+    "@fluentui/react-label" "^9.1.56"
+    "@fluentui/react-theme" "^9.1.16"
+    "@fluentui/react-utilities" "^9.15.6"
     "@griffel/react" "^1.5.14"
     "@swc/helpers" "^0.5.1"
 
-"@fluentui/react-icons@^2.0.217":
-  version "2.0.220"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-icons/-/react-icons-2.0.220.tgz#93e422c5b3fd8550377795fda083e0474dc5abf5"
-  integrity sha512-AIe0y3QuG2dATGVlszyt/xCzVhyBcDulQnDepSLZvDXkuu8zL/zqQaSuiOizwZUVxxuF0SvePyf4zgi86zgtjg==
+"@fluentui/react-icons@^2.0.224":
+  version "2.0.225"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-icons/-/react-icons-2.0.225.tgz#fc0302a69db1d91cb184c0afd1a9dcb3fd9fbbc7"
+  integrity sha512-L9phN3bAMlZCa5+/ObGjIO+5GI8M50ym766sraSq92jaJwgAXrCJDLWuDGWZRGrC63DcagtR2culptj3q7gMMg==
   dependencies:
     "@griffel/react" "^1.0.0"
     tslib "^2.1.0"
 
-"@fluentui/react-image@^9.1.43":
-  version "9.1.43"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-image/-/react-image-9.1.43.tgz#6ca6ebb7c8ce1f0c07e9c1f2bda68f80a4d08af2"
-  integrity sha512-87ogWT/gwa4DQe4uXjqwFD29Zkf4SxIHHjPzdydYTEpLEa3FEGF9HRW/Sz7v7Qz/pR4Ic9LsBbuwk+/XhpEa7w==
+"@fluentui/react-image@^9.1.53":
+  version "9.1.53"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-image/-/react-image-9.1.53.tgz#8ae4929582fb15494879fd8bace1f303e3f259b2"
+  integrity sha512-kw9SU6bnzyIxzkAZIvgJK+jSlvOa5U5wR6D6ZmAdKZD9P9b2CryhUPK3nRzwm5dEgl3iChPRpu3pLSqXpnlj/Q==
   dependencies:
-    "@fluentui/react-jsx-runtime" "^9.0.18"
-    "@fluentui/react-shared-contexts" "^9.10.0"
-    "@fluentui/react-theme" "^9.1.14"
-    "@fluentui/react-utilities" "^9.15.1"
+    "@fluentui/react-jsx-runtime" "^9.0.25"
+    "@fluentui/react-shared-contexts" "^9.13.2"
+    "@fluentui/react-theme" "^9.1.16"
+    "@fluentui/react-utilities" "^9.15.6"
     "@griffel/react" "^1.5.14"
     "@swc/helpers" "^0.5.1"
 
-"@fluentui/react-infobutton@9.0.0-beta.71":
-  version "9.0.0-beta.71"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-infobutton/-/react-infobutton-9.0.0-beta.71.tgz#09a23f63240f7ac58a20c17c14eae85ba5c01286"
-  integrity sha512-kLxgX577cihAG9TVDR76PlzjjhmcTrL2FR8vZ1lUj1UlG9hsCshJhUnBagd1AeSImFvJnzQxqf6nOu+QwnJXIQ==
+"@fluentui/react-infobutton@9.0.0-beta.86":
+  version "9.0.0-beta.86"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-infobutton/-/react-infobutton-9.0.0-beta.86.tgz#29e8f4f5a2b494afec34d7ff0458dbbf4faa6cde"
+  integrity sha512-nzo1rBNDyFHwa4Ik4W+AnzwE2ua6+5uQxH2OQTLS4PlGnIycaecGgjZBRr0Kk8vO5fAPrBtbEAPVAdxMj54SvQ==
   dependencies:
-    "@fluentui/react-icons" "^2.0.217"
-    "@fluentui/react-jsx-runtime" "^9.0.18"
-    "@fluentui/react-label" "^9.1.46"
-    "@fluentui/react-popover" "^9.8.16"
-    "@fluentui/react-tabster" "^9.14.0"
-    "@fluentui/react-theme" "^9.1.14"
-    "@fluentui/react-utilities" "^9.15.1"
+    "@fluentui/react-icons" "^2.0.224"
+    "@fluentui/react-jsx-runtime" "^9.0.25"
+    "@fluentui/react-label" "^9.1.56"
+    "@fluentui/react-popover" "^9.8.31"
+    "@fluentui/react-tabster" "^9.17.1"
+    "@fluentui/react-theme" "^9.1.16"
+    "@fluentui/react-utilities" "^9.15.6"
     "@griffel/react" "^1.5.14"
     "@swc/helpers" "^0.5.1"
 
-"@fluentui/react-input@^9.4.48":
-  version "9.4.48"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-input/-/react-input-9.4.48.tgz#7048e5ac02847505f8d7f004b90b1dc0f4128508"
-  integrity sha512-uRwwkVQU+USmBMeZf2gBTD5EokVr2hTS43cU5EPWPRb5shPKPCS5OC9uXBvvJmZyqvCzibzeFzf9WRJtFX0geg==
+"@fluentui/react-infolabel@^9.0.14":
+  version "9.0.14"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-infolabel/-/react-infolabel-9.0.14.tgz#5514186729860b08e72d57605115f4557c1f8c9a"
+  integrity sha512-MOEi5Tat2XLz3CnUuZBkwAAFK6sPqmwX04gT9cRpg917yE2zv8RTolh+Png8Ah14Gtg+H7fN3Xe+3XmEVJiE9w==
   dependencies:
-    "@fluentui/react-field" "^9.1.38"
-    "@fluentui/react-jsx-runtime" "^9.0.18"
-    "@fluentui/react-shared-contexts" "^9.10.0"
-    "@fluentui/react-theme" "^9.1.14"
-    "@fluentui/react-utilities" "^9.15.1"
+    "@fluentui/react-icons" "^2.0.224"
+    "@fluentui/react-jsx-runtime" "^9.0.25"
+    "@fluentui/react-label" "^9.1.56"
+    "@fluentui/react-popover" "^9.8.31"
+    "@fluentui/react-tabster" "^9.17.1"
+    "@fluentui/react-theme" "^9.1.16"
+    "@fluentui/react-utilities" "^9.15.6"
     "@griffel/react" "^1.5.14"
     "@swc/helpers" "^0.5.1"
 
-"@fluentui/react-jsx-runtime@^9.0.18":
-  version "9.0.18"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-jsx-runtime/-/react-jsx-runtime-9.0.18.tgz#b9b2ac32903d9a97911473641c5e5c650b32ebec"
-  integrity sha512-uGuVSWwnNa6LrsPmTcqrF5xkjfc4RffUERART2Z4ojfn1wq7rhLOdWmCcEBnbYl1AhPvD1ohOLc8EqDrlrYPHw==
+"@fluentui/react-input@^9.4.58":
+  version "9.4.58"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-input/-/react-input-9.4.58.tgz#611e159def607d7db9bdfe601395de8b8233b2cb"
+  integrity sha512-MC114o+qKDXhP+KZydubcTrUSDu8DywYn3oV+QS6HCNGReTIO0M+hygGKqHYEHCvyMOEb/K/oLyUlZZdXoWdrQ==
   dependencies:
-    "@fluentui/react-utilities" "^9.15.1"
+    "@fluentui/react-field" "^9.1.48"
+    "@fluentui/react-jsx-runtime" "^9.0.25"
+    "@fluentui/react-shared-contexts" "^9.13.2"
+    "@fluentui/react-theme" "^9.1.16"
+    "@fluentui/react-utilities" "^9.15.6"
+    "@griffel/react" "^1.5.14"
+    "@swc/helpers" "^0.5.1"
+
+"@fluentui/react-jsx-runtime@^9.0.25":
+  version "9.0.25"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-jsx-runtime/-/react-jsx-runtime-9.0.25.tgz#9ccedb1ad7e0c3a661578f565db06360b05c6225"
+  integrity sha512-FPWYfA2OLzlpAOYLdeS9oEENGCcD5kW1Bn7EQcgA1AJVHxHfcZqRqojhGGQcTh08Xh8tPMF2cLIzXiGuxdcr9w==
+  dependencies:
+    "@fluentui/react-utilities" "^9.15.6"
     "@swc/helpers" "^0.5.1"
     react-is "^17.0.2"
 
-"@fluentui/react-label@^9.1.46":
-  version "9.1.46"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-label/-/react-label-9.1.46.tgz#d7307fb78c3b261b3589a23c79d737d8d6d017c3"
-  integrity sha512-BCI6m2PmWbdTAkqpRZ+3nwkHJs1adIIXRuX7ZdUHIlEdW6NzNEB7CljC/35UrQpWAtQvFnPp7fEBRlqyQSpJ2g==
+"@fluentui/react-label@^9.1.56":
+  version "9.1.56"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-label/-/react-label-9.1.56.tgz#0b5fe578093d351ea73b5da78f1569696bd59576"
+  integrity sha512-q7mo8bpc3JEUCl0yarwYYCeVUypfmfQ6OJbJhT+WNUITz7jhOkHCMCsWb9BNoyVBEMBGrypV/LqAqyDQykgDCw==
   dependencies:
-    "@fluentui/react-jsx-runtime" "^9.0.18"
-    "@fluentui/react-shared-contexts" "^9.10.0"
-    "@fluentui/react-theme" "^9.1.14"
-    "@fluentui/react-utilities" "^9.15.1"
+    "@fluentui/react-jsx-runtime" "^9.0.25"
+    "@fluentui/react-shared-contexts" "^9.13.2"
+    "@fluentui/react-theme" "^9.1.16"
+    "@fluentui/react-utilities" "^9.15.6"
     "@griffel/react" "^1.5.14"
     "@swc/helpers" "^0.5.1"
 
-"@fluentui/react-link@^9.1.29":
-  version "9.1.29"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-link/-/react-link-9.1.29.tgz#09df4a5099e09d61264f305398d371120deb75a5"
-  integrity sha512-OZo9NDsxpk9meWd6jVhJgfEOtITxFffWyXlm5bKw6yVGJuWl0wU+ByhrkEZ5RQuvxjEjyD4rvx75ug1Yt0u9Bw==
+"@fluentui/react-link@^9.2.5":
+  version "9.2.5"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-link/-/react-link-9.2.5.tgz#59ec2f809cc5f41479886ac2f1c25362ba3e4dd4"
+  integrity sha512-p5dz5EigggczOwuQqAU9stfp5CkPcYxMemWj2aizrUKJdMfpLY2FqBTlnCUmIIn2ZTjkJaUeD4xE6W/bMsFyiA==
   dependencies:
-    "@fluentui/keyboard-keys" "^9.0.6"
-    "@fluentui/react-jsx-runtime" "^9.0.18"
-    "@fluentui/react-shared-contexts" "^9.10.0"
-    "@fluentui/react-tabster" "^9.14.0"
-    "@fluentui/react-theme" "^9.1.14"
-    "@fluentui/react-utilities" "^9.15.1"
+    "@fluentui/keyboard-keys" "^9.0.7"
+    "@fluentui/react-jsx-runtime" "^9.0.25"
+    "@fluentui/react-shared-contexts" "^9.13.2"
+    "@fluentui/react-tabster" "^9.17.1"
+    "@fluentui/react-theme" "^9.1.16"
+    "@fluentui/react-utilities" "^9.15.6"
     "@griffel/react" "^1.5.14"
     "@swc/helpers" "^0.5.1"
 
-"@fluentui/react-menu@^9.12.27":
-  version "9.12.27"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-menu/-/react-menu-9.12.27.tgz#527bc79f137fb2ab162a450a43d5ebe0a8ee6aaf"
-  integrity sha512-JvqwjZ2z4Seor60d9WEfglJ/G+zQa1EhMzNDlKRpxVkH01zrfHoCq6JLAmVc/IP3NmtG8aZvw9Tv0/DKmh31gg==
+"@fluentui/react-menu@^9.12.43":
+  version "9.12.43"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-menu/-/react-menu-9.12.43.tgz#38bf6f300f2c36a685e859f6ae358fd60ff7b9b5"
+  integrity sha512-2B2TCJ9C3AtWuwxo2wPA4iIFDLL2swgFMrRIN/itZWGWmcuznt+yydZhNXxR7kPb97onOOia0UG4PeynwHQEzA==
   dependencies:
-    "@fluentui/keyboard-keys" "^9.0.6"
-    "@fluentui/react-aria" "^9.3.43"
-    "@fluentui/react-context-selector" "^9.1.41"
-    "@fluentui/react-icons" "^2.0.217"
-    "@fluentui/react-jsx-runtime" "^9.0.18"
-    "@fluentui/react-portal" "^9.3.24"
-    "@fluentui/react-positioning" "^9.9.21"
-    "@fluentui/react-shared-contexts" "^9.10.0"
-    "@fluentui/react-tabster" "^9.14.0"
-    "@fluentui/react-theme" "^9.1.14"
-    "@fluentui/react-utilities" "^9.15.1"
+    "@fluentui/keyboard-keys" "^9.0.7"
+    "@fluentui/react-aria" "^9.7.1"
+    "@fluentui/react-context-selector" "^9.1.47"
+    "@fluentui/react-icons" "^2.0.224"
+    "@fluentui/react-jsx-runtime" "^9.0.25"
+    "@fluentui/react-portal" "^9.4.8"
+    "@fluentui/react-positioning" "^9.12.2"
+    "@fluentui/react-shared-contexts" "^9.13.2"
+    "@fluentui/react-tabster" "^9.17.1"
+    "@fluentui/react-theme" "^9.1.16"
+    "@fluentui/react-utilities" "^9.15.6"
     "@griffel/react" "^1.5.14"
     "@swc/helpers" "^0.5.1"
 
-"@fluentui/react-message-bar@^9.0.1":
-  version "9.0.1"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-message-bar/-/react-message-bar-9.0.1.tgz#45ab67a4a18700f1232fb5bdea439fcaee2d1d58"
-  integrity sha512-pOLGkGTKnWLfIWKrgy79LFZi4g6BIYz7ZwVVc4fdiNA0Jkg9YmFSDjEiIp57J4QAtlw0Pe5GzMOTflrPD+pldg==
+"@fluentui/react-message-bar@^9.0.14":
+  version "9.0.14"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-message-bar/-/react-message-bar-9.0.14.tgz#6b8c43f8939070b5e44f9cf95cbf2359575eb4a1"
+  integrity sha512-OOAepPTnd40QOIT/eAABTbk309gnBDV0i6jBz5Oz4FOcikBvWVcvtKri8RjOAo7a+d7MFOg4vFu/3n8cbOg5rg==
   dependencies:
-    "@fluentui/react-button" "^9.3.50"
-    "@fluentui/react-icons" "^2.0.217"
-    "@fluentui/react-jsx-runtime" "^9.0.18"
-    "@fluentui/react-shared-contexts" "^9.10.0"
-    "@fluentui/react-theme" "^9.1.14"
-    "@fluentui/react-utilities" "^9.15.1"
+    "@fluentui/react-button" "^9.3.63"
+    "@fluentui/react-icons" "^2.0.224"
+    "@fluentui/react-jsx-runtime" "^9.0.25"
+    "@fluentui/react-shared-contexts" "^9.13.2"
+    "@fluentui/react-theme" "^9.1.16"
+    "@fluentui/react-utilities" "^9.15.6"
     "@griffel/react" "^1.5.14"
     "@swc/helpers" "^0.5.1"
     react-transition-group "^4.4.1"
 
-"@fluentui/react-motion-preview@^0.3.4":
-  version "0.3.4"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-motion-preview/-/react-motion-preview-0.3.4.tgz#e5880c095b158dc06e756ce168823e34c799c735"
-  integrity sha512-5Ru/uoLEMQVDEHJIqfs8TZPN38ABZlVgcnBHmfpYwF+zuL6RgP8VQehGSgDpD/eZ2YLHqa6Cl9uNWZYK4ouXNQ==
+"@fluentui/react-motion-preview@^0.5.8":
+  version "0.5.8"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-motion-preview/-/react-motion-preview-0.5.8.tgz#3740b037d1810b83e27d300ea7bf2731fe9824e8"
+  integrity sha512-cNh9HGsH/bLrFG+IXIdsFHSQKErE0dtnZrjYTHYjbDIjo0AnUTT3N9jBCuMppfri6kiVbd14L6fnppthEYs1hQ==
   dependencies:
-    "@fluentui/react-jsx-runtime" "^9.0.18"
-    "@fluentui/react-shared-contexts" "^9.10.0"
-    "@fluentui/react-theme" "^9.1.14"
-    "@fluentui/react-utilities" "^9.15.1"
+    "@fluentui/react-jsx-runtime" "^9.0.25"
+    "@fluentui/react-shared-contexts" "^9.13.2"
+    "@fluentui/react-theme" "^9.1.16"
+    "@fluentui/react-utilities" "^9.15.6"
     "@griffel/react" "^1.5.14"
     "@swc/helpers" "^0.5.1"
 
-"@fluentui/react-overflow@^9.0.40":
-  version "9.0.40"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-overflow/-/react-overflow-9.0.40.tgz#256c4daa277c44946f718e8b22fc4c53924aa854"
-  integrity sha512-xOwQrEuU4ouLZgVFsGLtYzLPQlkGrQii3TWoHbOoFKXt0K30J/0PsuRy8Z1gZylDMkpgzRaKydMD6KqBDghREw==
+"@fluentui/react-overflow@^9.1.6":
+  version "9.1.6"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-overflow/-/react-overflow-9.1.6.tgz#7f48aebfbc7ccec2441025a1087b4740d16d570b"
+  integrity sha512-kBDBQan7aDWvZJIYxXoNtUXOR4JsetaMxzNjM8DZfHC3k5k9E/jftxEughDRCA4TGirNQSsR02VPXl3DhZ35ng==
   dependencies:
-    "@fluentui/priority-overflow" "^9.1.7"
-    "@fluentui/react-context-selector" "^9.1.41"
-    "@fluentui/react-theme" "^9.1.14"
-    "@fluentui/react-utilities" "^9.15.1"
+    "@fluentui/priority-overflow" "^9.1.11"
+    "@fluentui/react-context-selector" "^9.1.47"
+    "@fluentui/react-theme" "^9.1.16"
+    "@fluentui/react-utilities" "^9.15.6"
     "@griffel/react" "^1.5.14"
     "@swc/helpers" "^0.5.1"
 
-"@fluentui/react-persona@^9.2.51":
-  version "9.2.51"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-persona/-/react-persona-9.2.51.tgz#4178d35d0dbdaeb959b2cbb40e31a70316e36e9d"
-  integrity sha512-ktqp4yKqrCqJKAIcaL5Jh+dwAod5MrDWG0KUGJucqwRnojGEvjduXExTs1kppoZHHb3PeQbYtzq3WgfsNf+evg==
+"@fluentui/react-persona@^9.2.66":
+  version "9.2.66"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-persona/-/react-persona-9.2.66.tgz#b6ff520f4cf1fd19ed03c309d04bdb1331c77467"
+  integrity sha512-mcGSPuzAvCI9gvwjG6r/7A9bl4qBNtK4gKoRjC8Kh212cRNyN9np6oumFZs8OfYrcIgFl/P43K6bKx2Z+dW9zw==
   dependencies:
-    "@fluentui/react-avatar" "^9.5.41"
-    "@fluentui/react-badge" "^9.2.10"
-    "@fluentui/react-jsx-runtime" "^9.0.18"
-    "@fluentui/react-shared-contexts" "^9.10.0"
-    "@fluentui/react-theme" "^9.1.14"
-    "@fluentui/react-utilities" "^9.15.1"
+    "@fluentui/react-avatar" "^9.6.7"
+    "@fluentui/react-badge" "^9.2.20"
+    "@fluentui/react-jsx-runtime" "^9.0.25"
+    "@fluentui/react-shared-contexts" "^9.13.2"
+    "@fluentui/react-theme" "^9.1.16"
+    "@fluentui/react-utilities" "^9.15.6"
     "@griffel/react" "^1.5.14"
     "@swc/helpers" "^0.5.1"
 
-"@fluentui/react-popover@^9.8.16":
-  version "9.8.16"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-popover/-/react-popover-9.8.16.tgz#6155561137eaf29565f65ebfe32071ade9f77fb4"
-  integrity sha512-k1WP0DwPBhuXNJKlRxiqyP7SC5fEl2fNmaMNeiMyFmIJYnwGFUvURXxYWF0G/9GAtimNV6cj4WjTHxd3kGeL0Q==
+"@fluentui/react-popover@^9.8.31":
+  version "9.8.31"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-popover/-/react-popover-9.8.31.tgz#ff30717b6430ab030f00449e154efd6cf37787e3"
+  integrity sha512-Av8X2QfZwg8rSZdC5mehEHOCzrLOy24/hdQMiRcEAXR1wiJgJrVnOx7GObGADzP2lCYa0+KoGJ2H4LA8FBSc3g==
   dependencies:
-    "@fluentui/keyboard-keys" "^9.0.6"
-    "@fluentui/react-aria" "^9.3.43"
-    "@fluentui/react-context-selector" "^9.1.41"
-    "@fluentui/react-jsx-runtime" "^9.0.18"
-    "@fluentui/react-portal" "^9.3.24"
-    "@fluentui/react-positioning" "^9.9.21"
-    "@fluentui/react-shared-contexts" "^9.10.0"
-    "@fluentui/react-tabster" "^9.14.0"
-    "@fluentui/react-theme" "^9.1.14"
-    "@fluentui/react-utilities" "^9.15.1"
+    "@fluentui/keyboard-keys" "^9.0.7"
+    "@fluentui/react-aria" "^9.7.1"
+    "@fluentui/react-context-selector" "^9.1.47"
+    "@fluentui/react-jsx-runtime" "^9.0.25"
+    "@fluentui/react-portal" "^9.4.8"
+    "@fluentui/react-positioning" "^9.12.2"
+    "@fluentui/react-shared-contexts" "^9.13.2"
+    "@fluentui/react-tabster" "^9.17.1"
+    "@fluentui/react-theme" "^9.1.16"
+    "@fluentui/react-utilities" "^9.15.6"
     "@griffel/react" "^1.5.14"
     "@swc/helpers" "^0.5.1"
 
-"@fluentui/react-portal@^9.3.24":
-  version "9.3.24"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-portal/-/react-portal-9.3.24.tgz#9f2546d2cfbb9499f0662cb06839613b77cd261e"
-  integrity sha512-5ZSoDkIhOCO8WTS314SlaoG23xs+4ISAhzPpxnHCcdn0ZswUIZ3YuDSQioUoFFIPS7Ag/IiR11gLSg7RS8xxBQ==
+"@fluentui/react-portal@^9.4.8":
+  version "9.4.8"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-portal/-/react-portal-9.4.8.tgz#8d632e502a8eea08c77e4f3fe04a9818719c484e"
+  integrity sha512-aXeoTBMi/+1lLOHD1e1InTZuVYUt8ZQ34IxXASaF4w7qbBHGeaCB9wMzSPu5d3jpUWhM1iRXVJngYdio5zFKsQ==
   dependencies:
-    "@fluentui/react-shared-contexts" "^9.10.0"
-    "@fluentui/react-tabster" "^9.14.0"
-    "@fluentui/react-utilities" "^9.15.1"
+    "@fluentui/react-shared-contexts" "^9.13.2"
+    "@fluentui/react-tabster" "^9.17.1"
+    "@fluentui/react-utilities" "^9.15.6"
     "@griffel/react" "^1.5.14"
     "@swc/helpers" "^0.5.1"
     use-disposable "^1.0.1"
 
-"@fluentui/react-positioning@^9.9.21":
-  version "9.9.21"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-positioning/-/react-positioning-9.9.21.tgz#3c36bb10c68fa3e4c5143129ef90aa3e06db570a"
-  integrity sha512-4n3W8WTbEbkcnk3XhxXgFTgF7SSR9FxKfzsHDe56fUgVnpsIcKuR2BZw5sUYDEKVpw/qcxj4aNk/4i4fIPufAw==
+"@fluentui/react-positioning@^9.12.2":
+  version "9.12.2"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-positioning/-/react-positioning-9.12.2.tgz#d43389f1acfa54ad7a061c5f275a3e2f292c5a14"
+  integrity sha512-lBlnyf3NAaX6bYq0PI5Ifie9/km68CtZywMvgHprZE9UkBZbGFwQLzemxQkAYoYhwXoebaQA5a5ODwDbUvwPWg==
   dependencies:
+    "@floating-ui/devtools" "0.2.1"
     "@floating-ui/dom" "^1.2.0"
-    "@fluentui/react-shared-contexts" "^9.10.0"
-    "@fluentui/react-theme" "^9.1.14"
-    "@fluentui/react-utilities" "^9.15.1"
+    "@fluentui/react-shared-contexts" "^9.13.2"
+    "@fluentui/react-theme" "^9.1.16"
+    "@fluentui/react-utilities" "^9.15.6"
     "@griffel/react" "^1.5.14"
     "@swc/helpers" "^0.5.1"
 
-"@fluentui/react-progress@^9.1.48":
-  version "9.1.48"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-progress/-/react-progress-9.1.48.tgz#95bb4e2384d39c29a621ea872c8aac5433f431f9"
-  integrity sha512-37TOC8NGSd0yI91Xqqo3+vx8gDdqfaxWw5ensohJyMSoCiyU+r1bPR/W1WQehwYQIuDO9f8UkLhb07GTgt7I/g==
+"@fluentui/react-progress@^9.1.58":
+  version "9.1.58"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-progress/-/react-progress-9.1.58.tgz#4b2c9e21ecd50681e693dc4eb6cae00f9f9e5f87"
+  integrity sha512-eemljzCw/dIpyHVaeMtTep9gmoa43fJ91wJ29g9/u5ZkmIrtfbCkWmTtdk5NbnvSRQK1Kdk08dxZsIuzm/lbmA==
   dependencies:
-    "@fluentui/react-field" "^9.1.38"
-    "@fluentui/react-jsx-runtime" "^9.0.18"
-    "@fluentui/react-shared-contexts" "^9.10.0"
-    "@fluentui/react-theme" "^9.1.14"
-    "@fluentui/react-utilities" "^9.15.1"
+    "@fluentui/react-field" "^9.1.48"
+    "@fluentui/react-jsx-runtime" "^9.0.25"
+    "@fluentui/react-shared-contexts" "^9.13.2"
+    "@fluentui/react-theme" "^9.1.16"
+    "@fluentui/react-utilities" "^9.15.6"
     "@griffel/react" "^1.5.14"
     "@swc/helpers" "^0.5.1"
 
-"@fluentui/react-provider@^9.10.8":
-  version "9.10.8"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-provider/-/react-provider-9.10.8.tgz#582fa4e53e569a0ad0bba5126637507bfd319c2b"
-  integrity sha512-9EUrunj7b2xYUyixGviqpqmdluX0C8htssm+XUcDUkzdnTJZ/qKiC9dUBPp2TS7MKmb6UZeKw40Ipog9GloUkg==
+"@fluentui/react-provider@^9.13.6":
+  version "9.13.6"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-provider/-/react-provider-9.13.6.tgz#bc2a63f5ab50e8a2f5f72795378fc1ecfa0445a4"
+  integrity sha512-i7dDEc28xQKGD/5pFZYZEY+v/u2sGs5x8sTH/cuW0kA6PuU8OQxcwTtRo7NA1JoUWvPaRNJD+8AVhZmh/CZCpQ==
   dependencies:
-    "@fluentui/react-icons" "^2.0.217"
-    "@fluentui/react-jsx-runtime" "^9.0.18"
-    "@fluentui/react-shared-contexts" "^9.10.0"
-    "@fluentui/react-tabster" "^9.14.0"
-    "@fluentui/react-theme" "^9.1.14"
-    "@fluentui/react-utilities" "^9.15.1"
+    "@fluentui/react-icons" "^2.0.224"
+    "@fluentui/react-jsx-runtime" "^9.0.25"
+    "@fluentui/react-shared-contexts" "^9.13.2"
+    "@fluentui/react-tabster" "^9.17.1"
+    "@fluentui/react-theme" "^9.1.16"
+    "@fluentui/react-utilities" "^9.15.6"
     "@griffel/core" "^1.14.1"
     "@griffel/react" "^1.5.14"
     "@swc/helpers" "^0.5.1"
 
-"@fluentui/react-radio@^9.1.51":
-  version "9.1.51"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-radio/-/react-radio-9.1.51.tgz#0552509e518f0467e6fb26f4d4d45b821d66f99d"
-  integrity sha512-XYT/VtkqNScG3zDsOux6d7gtHvUukBl++6wS+HBEkQ7/Qer3IMxOTDm5o9n1deSPbbowX99C4twWbHRDGpmRlg==
+"@fluentui/react-radio@^9.2.1":
+  version "9.2.1"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-radio/-/react-radio-9.2.1.tgz#0abd3f3412ff129900a0c72d071221da8461ffd3"
+  integrity sha512-iw3QASrgfCaGkSCJDZ1KowJUIhj7eMAx91rOu1x3uzPUyRFo/P7nqYPWg+pTZmZdphjItCpcE4L09VxQ7+Y6tw==
   dependencies:
-    "@fluentui/react-field" "^9.1.38"
-    "@fluentui/react-icons" "^2.0.217"
-    "@fluentui/react-jsx-runtime" "^9.0.18"
-    "@fluentui/react-label" "^9.1.46"
-    "@fluentui/react-shared-contexts" "^9.10.0"
-    "@fluentui/react-tabster" "^9.14.0"
-    "@fluentui/react-theme" "^9.1.14"
-    "@fluentui/react-utilities" "^9.15.1"
+    "@fluentui/react-field" "^9.1.48"
+    "@fluentui/react-jsx-runtime" "^9.0.25"
+    "@fluentui/react-label" "^9.1.56"
+    "@fluentui/react-shared-contexts" "^9.13.2"
+    "@fluentui/react-tabster" "^9.17.1"
+    "@fluentui/react-theme" "^9.1.16"
+    "@fluentui/react-utilities" "^9.15.6"
     "@griffel/react" "^1.5.14"
     "@swc/helpers" "^0.5.1"
 
-"@fluentui/react-select@^9.1.48":
-  version "9.1.48"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-select/-/react-select-9.1.48.tgz#edcc07bad3569f116d6e68e2d58766f0d5bbcc3f"
-  integrity sha512-CmwmlcIlhnD7ojZLDWQ7fUxTo8UDJsEh+wARb4tEm5EmTZltvRhh/C5i85yUZtdWuBPcOll9OlomCX/K/Ag3+g==
+"@fluentui/react-select@^9.1.58":
+  version "9.1.58"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-select/-/react-select-9.1.58.tgz#123446a9b6e0dbaf8c863c82f0cf18d3b2e9a861"
+  integrity sha512-/4LBOZhAfKfus+6mf09fAAVZlHaKz9hawnRgYeENIC7/ZqWQe8ea5m+xZj9MTsjXzFLmdmzItuz6e360g0Xepg==
   dependencies:
-    "@fluentui/react-field" "^9.1.38"
-    "@fluentui/react-icons" "^2.0.217"
-    "@fluentui/react-jsx-runtime" "^9.0.18"
-    "@fluentui/react-shared-contexts" "^9.10.0"
-    "@fluentui/react-theme" "^9.1.14"
-    "@fluentui/react-utilities" "^9.15.1"
+    "@fluentui/react-field" "^9.1.48"
+    "@fluentui/react-icons" "^2.0.224"
+    "@fluentui/react-jsx-runtime" "^9.0.25"
+    "@fluentui/react-shared-contexts" "^9.13.2"
+    "@fluentui/react-theme" "^9.1.16"
+    "@fluentui/react-utilities" "^9.15.6"
     "@griffel/react" "^1.5.14"
     "@swc/helpers" "^0.5.1"
 
-"@fluentui/react-shared-contexts@^9.10.0":
-  version "9.10.0"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-shared-contexts/-/react-shared-contexts-9.10.0.tgz#9f9c91cbfb07bbbe786b192c28e5c8c9776c4211"
-  integrity sha512-2ubHqWnnd2VX82wAuGV0VVOXuQMQPz3x+8cgcGDI+z0lGrBF679N8W55QuEisvnDojoe6iASxJmc311N3aRzSQ==
+"@fluentui/react-shared-contexts@^9.13.2":
+  version "9.13.2"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-shared-contexts/-/react-shared-contexts-9.13.2.tgz#45351ccf67d5bb5d362f74e4dfffa0a7b3c5dcca"
+  integrity sha512-78aEZdff7vaUOmeRyMDPc/Ml+kbwn02BiRLPQhqgYtCyjy0V3YBpmYfqxO8N5hUIZcFTedyOaHWpzVeEYxpNmA==
   dependencies:
-    "@fluentui/react-theme" "^9.1.14"
+    "@fluentui/react-theme" "^9.1.16"
     "@swc/helpers" "^0.5.1"
 
-"@fluentui/react-skeleton@^9.0.36":
-  version "9.0.36"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-skeleton/-/react-skeleton-9.0.36.tgz#f39e5542c9a809d3651ce07eeb540c6d7842d9e1"
-  integrity sha512-n3+t0vDUDSV6yx4qGDDh/aUQ8rkvFc2xC3evdTLPf4ovCh2rHbUpemnlkXz3m4wfnr//Fh/uXdNlITIp3duyFA==
+"@fluentui/react-skeleton@^9.0.46":
+  version "9.0.46"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-skeleton/-/react-skeleton-9.0.46.tgz#f2fd5ce6d06e5ebc462db952df61a2fb449a8c56"
+  integrity sha512-LshgVaBg1JjlzpgB5eUJZC965uX9nbEeXacFdxY+X9D457Hu68j+muNOUQ1RHB32ZrMIxukGfseWt0+Wz+j4QQ==
   dependencies:
-    "@fluentui/react-field" "^9.1.38"
-    "@fluentui/react-jsx-runtime" "^9.0.18"
-    "@fluentui/react-shared-contexts" "^9.10.0"
-    "@fluentui/react-theme" "^9.1.14"
-    "@fluentui/react-utilities" "^9.15.1"
+    "@fluentui/react-field" "^9.1.48"
+    "@fluentui/react-jsx-runtime" "^9.0.25"
+    "@fluentui/react-shared-contexts" "^9.13.2"
+    "@fluentui/react-theme" "^9.1.16"
+    "@fluentui/react-utilities" "^9.15.6"
     "@griffel/react" "^1.5.14"
     "@swc/helpers" "^0.5.1"
 
-"@fluentui/react-slider@^9.1.51":
-  version "9.1.51"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-slider/-/react-slider-9.1.51.tgz#eaaa61d30e1072da071689598b24fd44185ac87e"
-  integrity sha512-j13VQDiLq/YQMMI2Kv9FQ8RrUqdrFQUH6WVf8Dkeyjto1LztH4R1E2d4CrVSFAhboBp8eacUkrImmlRDoFIK6Q==
+"@fluentui/react-slider@^9.1.63":
+  version "9.1.63"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-slider/-/react-slider-9.1.63.tgz#72c082168b8cad5ff706599380b4692a99401512"
+  integrity sha512-8toNPnd5HpM6TK/uxDTHmgznk4fw4AaSbIRBYGhnUpu5n+IbqIkEZ00q4Wb+/m2G7BOVYz2PTpv1NRRoaf0GGQ==
   dependencies:
-    "@fluentui/react-field" "^9.1.38"
-    "@fluentui/react-jsx-runtime" "^9.0.18"
-    "@fluentui/react-shared-contexts" "^9.10.0"
-    "@fluentui/react-tabster" "^9.14.0"
-    "@fluentui/react-theme" "^9.1.14"
-    "@fluentui/react-utilities" "^9.15.1"
+    "@fluentui/react-field" "^9.1.48"
+    "@fluentui/react-jsx-runtime" "^9.0.25"
+    "@fluentui/react-shared-contexts" "^9.13.2"
+    "@fluentui/react-tabster" "^9.17.1"
+    "@fluentui/react-theme" "^9.1.16"
+    "@fluentui/react-utilities" "^9.15.6"
     "@griffel/react" "^1.5.14"
     "@swc/helpers" "^0.5.1"
 
-"@fluentui/react-spinbutton@^9.2.48":
-  version "9.2.48"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-spinbutton/-/react-spinbutton-9.2.48.tgz#23810129a2bf48d716bad16b78393af98b0bf040"
-  integrity sha512-KU+Fj8y/s7aozKZ3ClGL87solxH5VG0IbpPr7TA/U1uS+sXP3NF2WBBKfaNqqsUuAYppdKKm7Hqi0qekSDAQEQ==
+"@fluentui/react-spinbutton@^9.2.58":
+  version "9.2.58"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-spinbutton/-/react-spinbutton-9.2.58.tgz#81e694a67bdef6abdf7a23a42be1039815081df6"
+  integrity sha512-5oheMykqKizeldgwNectm/n/JW9DsryVEiGdW4Ag59EZL9QP8534s33L4RyyHnq/ta2QBVycGZmKad2dC50wMw==
   dependencies:
-    "@fluentui/keyboard-keys" "^9.0.6"
-    "@fluentui/react-field" "^9.1.38"
-    "@fluentui/react-icons" "^2.0.217"
-    "@fluentui/react-jsx-runtime" "^9.0.18"
-    "@fluentui/react-shared-contexts" "^9.10.0"
-    "@fluentui/react-theme" "^9.1.14"
-    "@fluentui/react-utilities" "^9.15.1"
+    "@fluentui/keyboard-keys" "^9.0.7"
+    "@fluentui/react-field" "^9.1.48"
+    "@fluentui/react-icons" "^2.0.224"
+    "@fluentui/react-jsx-runtime" "^9.0.25"
+    "@fluentui/react-shared-contexts" "^9.13.2"
+    "@fluentui/react-theme" "^9.1.16"
+    "@fluentui/react-utilities" "^9.15.6"
     "@griffel/react" "^1.5.14"
     "@swc/helpers" "^0.5.1"
 
-"@fluentui/react-spinner@^9.3.26":
-  version "9.3.26"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-spinner/-/react-spinner-9.3.26.tgz#d13a87175bd25c8de6884d076f214cd7caf7bf72"
-  integrity sha512-RG5lURyl30Zy46Gitkz2aPaO2YRFnuMFt8nl/p0mdvN3n/Ai8KfNHXN8rqObO6BvuHZF3NowZjIpaXx63Gngiw==
+"@fluentui/react-spinner@^9.3.36":
+  version "9.3.36"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-spinner/-/react-spinner-9.3.36.tgz#c49b1980ea21c171b02f8b7c02f81fb9ee4ad584"
+  integrity sha512-t5+zKCa8ZIYDVdYNSGxisMjLCZgYJiRV8Gd+FYRnhK+WRKJFqGK/VYctEyJsf41FoEtKuK/lN6Y/sUq4xqhB2g==
   dependencies:
-    "@fluentui/react-jsx-runtime" "^9.0.18"
-    "@fluentui/react-label" "^9.1.46"
-    "@fluentui/react-shared-contexts" "^9.10.0"
-    "@fluentui/react-theme" "^9.1.14"
-    "@fluentui/react-utilities" "^9.15.1"
+    "@fluentui/react-jsx-runtime" "^9.0.25"
+    "@fluentui/react-label" "^9.1.56"
+    "@fluentui/react-shared-contexts" "^9.13.2"
+    "@fluentui/react-theme" "^9.1.16"
+    "@fluentui/react-utilities" "^9.15.6"
     "@griffel/react" "^1.5.14"
     "@swc/helpers" "^0.5.1"
 
-"@fluentui/react-switch@^9.1.51":
-  version "9.1.51"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-switch/-/react-switch-9.1.51.tgz#88ed3182bd9b306dce68bac477cfc2704aa003ea"
-  integrity sha512-u0MP47dPu3URP/Zhiubj1RxvCpKMmDfOgDf/Hw6CQZ0ZZ0ATELUax+3cnUZA4C9H1i3rzEE0ceJ2IyY5Ak/6dw==
+"@fluentui/react-switch@^9.1.63":
+  version "9.1.63"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-switch/-/react-switch-9.1.63.tgz#1f3dc55d13aab1e473aa7664248f732a4eeaaffe"
+  integrity sha512-FmnaWyykRPKnQIfVICdRo6pcP4gQ85rHs/JDRwewgPrFOu00N/u2MvW4X7M1Kc0eMKyCDjgwKaSQJGyHVkXmaw==
   dependencies:
-    "@fluentui/react-field" "^9.1.38"
-    "@fluentui/react-icons" "^2.0.217"
-    "@fluentui/react-jsx-runtime" "^9.0.18"
-    "@fluentui/react-label" "^9.1.46"
-    "@fluentui/react-shared-contexts" "^9.10.0"
-    "@fluentui/react-tabster" "^9.14.0"
-    "@fluentui/react-theme" "^9.1.14"
-    "@fluentui/react-utilities" "^9.15.1"
+    "@fluentui/react-field" "^9.1.48"
+    "@fluentui/react-icons" "^2.0.224"
+    "@fluentui/react-jsx-runtime" "^9.0.25"
+    "@fluentui/react-label" "^9.1.56"
+    "@fluentui/react-shared-contexts" "^9.13.2"
+    "@fluentui/react-tabster" "^9.17.1"
+    "@fluentui/react-theme" "^9.1.16"
+    "@fluentui/react-utilities" "^9.15.6"
     "@griffel/react" "^1.5.14"
     "@swc/helpers" "^0.5.1"
 
-"@fluentui/react-table@^9.10.6":
-  version "9.10.6"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-table/-/react-table-9.10.6.tgz#cd57a300904ff73036e32aafb0336d3c3e706a0a"
-  integrity sha512-goIyh1FT7l4r3bBO7hwKai6v3S+613yu8dcwk+BfMsM1e3eHFocgNXhweF1RzZHLU8OBKGWu3fk1VTnWqQmw/g==
+"@fluentui/react-table@^9.11.3":
+  version "9.11.3"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-table/-/react-table-9.11.3.tgz#c4771dffeebd39404302ec6ca905d8d8ee669fe5"
+  integrity sha512-RsRqvg1zGnNpSQO7xYTscc/YUsbF3Ir2EJj6d6GhZQMb7nf+EJJJLf6uP9hKMVCu8sK5JAhz+M17+9wDmnvlvQ==
   dependencies:
-    "@fluentui/keyboard-keys" "^9.0.6"
-    "@fluentui/react-aria" "^9.3.43"
-    "@fluentui/react-avatar" "^9.5.41"
-    "@fluentui/react-checkbox" "^9.1.51"
-    "@fluentui/react-context-selector" "^9.1.41"
-    "@fluentui/react-icons" "^2.0.217"
-    "@fluentui/react-jsx-runtime" "^9.0.18"
-    "@fluentui/react-radio" "^9.1.51"
-    "@fluentui/react-shared-contexts" "^9.10.0"
-    "@fluentui/react-tabster" "^9.14.0"
-    "@fluentui/react-theme" "^9.1.14"
-    "@fluentui/react-utilities" "^9.15.1"
+    "@fluentui/keyboard-keys" "^9.0.7"
+    "@fluentui/react-aria" "^9.7.1"
+    "@fluentui/react-avatar" "^9.6.7"
+    "@fluentui/react-checkbox" "^9.2.6"
+    "@fluentui/react-context-selector" "^9.1.47"
+    "@fluentui/react-icons" "^2.0.224"
+    "@fluentui/react-jsx-runtime" "^9.0.25"
+    "@fluentui/react-radio" "^9.2.1"
+    "@fluentui/react-shared-contexts" "^9.13.2"
+    "@fluentui/react-tabster" "^9.17.1"
+    "@fluentui/react-theme" "^9.1.16"
+    "@fluentui/react-utilities" "^9.15.6"
     "@griffel/react" "^1.5.14"
     "@swc/helpers" "^0.5.1"
 
-"@fluentui/react-tabs@^9.3.52":
-  version "9.3.52"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-tabs/-/react-tabs-9.3.52.tgz#2ab51b941c4f7de82632da370419a00a2ea0e60b"
-  integrity sha512-5lW1k+Cg94bhrQYX8oGuXFnpymPPb0zbo+l4a51F8N2BsedmKkosKjLILpASRMQEKVPrxVlAujrnGNz4RYvUcQ==
+"@fluentui/react-tabs@^9.4.4":
+  version "9.4.4"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-tabs/-/react-tabs-9.4.4.tgz#e14a842d93f464d8b4ce3a2e2c816bfbd077ed98"
+  integrity sha512-pboxo0Uxp7NIpwlybc0POAoQKt/SDSSYz8Y79wdxzEGr7IEXrj/q43GY7venkgN8vMQQ4RUyq62TrkS2KyPGTA==
   dependencies:
-    "@fluentui/react-context-selector" "^9.1.41"
-    "@fluentui/react-jsx-runtime" "^9.0.18"
-    "@fluentui/react-shared-contexts" "^9.10.0"
-    "@fluentui/react-tabster" "^9.14.0"
-    "@fluentui/react-theme" "^9.1.14"
-    "@fluentui/react-utilities" "^9.15.1"
+    "@fluentui/react-context-selector" "^9.1.47"
+    "@fluentui/react-jsx-runtime" "^9.0.25"
+    "@fluentui/react-shared-contexts" "^9.13.2"
+    "@fluentui/react-tabster" "^9.17.1"
+    "@fluentui/react-theme" "^9.1.16"
+    "@fluentui/react-utilities" "^9.15.6"
     "@griffel/react" "^1.5.14"
     "@swc/helpers" "^0.5.1"
 
-"@fluentui/react-tabster@^9.14.0":
-  version "9.14.0"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-tabster/-/react-tabster-9.14.0.tgz#53938715ef8c4bb3f97c75b25abb4f2d6329a93b"
-  integrity sha512-fteaqPtTUt6OZIpwJ8bU/fzgBj0O9Xb+t2jDG19h5xlhDtl7KTWV2PNTCSdxdjwxSCRPtQuAasU0W7xcceMSpg==
+"@fluentui/react-tabster@^9.17.1":
+  version "9.17.1"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-tabster/-/react-tabster-9.17.1.tgz#6add90df4c046ab46737c44b9adf2e888ea1ea74"
+  integrity sha512-T3ETXTjZ196zeT1vTgI0/BlKyDXMwksZk9rhJySsrfHB9Zit9Y35HXF1GM+OqEVM4z5xW1ukEWq88R3mZ116tw==
   dependencies:
-    "@fluentui/react-shared-contexts" "^9.10.0"
-    "@fluentui/react-theme" "^9.1.14"
-    "@fluentui/react-utilities" "^9.15.1"
+    "@fluentui/react-shared-contexts" "^9.13.2"
+    "@fluentui/react-theme" "^9.1.16"
+    "@fluentui/react-utilities" "^9.15.6"
     "@griffel/react" "^1.5.14"
     "@swc/helpers" "^0.5.1"
-    keyborg "^2.1.0"
-    tabster "^4.8.0"
+    keyborg "^2.3.0"
+    tabster "^5.0.1"
 
-"@fluentui/react-tags@^9.0.5":
-  version "9.0.5"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-tags/-/react-tags-9.0.5.tgz#e2ecbc14f163bb32d3ed0de67f5aa538481166bc"
-  integrity sha512-GadH9I5AX4JED9cIGL1aMAcp/ExcbealoCV+AV4U+dsT4fXdZWXz9nEx0zbrKYx0P9i6Vop7h5KalSESD5tD5Q==
+"@fluentui/react-tags@^9.0.20":
+  version "9.0.20"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-tags/-/react-tags-9.0.20.tgz#0644ba46df4a8950742b469fca5d3de1c08437fe"
+  integrity sha512-BAT6iJCPj+0qmI9PSdXN2TwvlKdR2Hetl/oE6aNQJYrqRdqQu4dwBZuuqdH7Dc2ej86070fefBZu+xSZxnjptg==
   dependencies:
-    "@fluentui/keyboard-keys" "^9.0.6"
-    "@fluentui/react-aria" "^9.3.43"
-    "@fluentui/react-avatar" "^9.5.41"
-    "@fluentui/react-icons" "^2.0.217"
-    "@fluentui/react-jsx-runtime" "^9.0.18"
-    "@fluentui/react-shared-contexts" "^9.10.0"
-    "@fluentui/react-tabster" "^9.14.0"
-    "@fluentui/react-theme" "^9.1.14"
-    "@fluentui/react-utilities" "^9.15.1"
-    "@griffel/react" "^1.5.14"
-    "@swc/helpers" "^0.5.1"
-
-"@fluentui/react-text@^9.3.43":
-  version "9.3.43"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-text/-/react-text-9.3.43.tgz#3f85ad3e2df25ad16e2be459875488ad2bcaa5bc"
-  integrity sha512-kSDE3tWEXZdOOWrVcmAVkhQAFxWsaMz/ETlBzsHNvVcZ6iJIscRY/JCxbBFxBUh30QxegTMMENaExrt9KJZQsQ==
-  dependencies:
-    "@fluentui/react-jsx-runtime" "^9.0.18"
-    "@fluentui/react-shared-contexts" "^9.10.0"
-    "@fluentui/react-theme" "^9.1.14"
-    "@fluentui/react-utilities" "^9.15.1"
+    "@fluentui/keyboard-keys" "^9.0.7"
+    "@fluentui/react-aria" "^9.7.1"
+    "@fluentui/react-avatar" "^9.6.7"
+    "@fluentui/react-icons" "^2.0.224"
+    "@fluentui/react-jsx-runtime" "^9.0.25"
+    "@fluentui/react-shared-contexts" "^9.13.2"
+    "@fluentui/react-tabster" "^9.17.1"
+    "@fluentui/react-theme" "^9.1.16"
+    "@fluentui/react-utilities" "^9.15.6"
     "@griffel/react" "^1.5.14"
     "@swc/helpers" "^0.5.1"
 
-"@fluentui/react-textarea@^9.3.48":
-  version "9.3.48"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-textarea/-/react-textarea-9.3.48.tgz#064faea556f21ba6c5f3c64f000e540d485bc0ad"
-  integrity sha512-OSA10BXvyx+fRB5zRnXMODOKtSfxSLPdBLctglNU57oezAkuNipTg12iJj5gvXJQHbrjPSgZaxikdPvHo4tzpQ==
+"@fluentui/react-text@^9.4.5":
+  version "9.4.5"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-text/-/react-text-9.4.5.tgz#f410a9e154696924edf3f4b04159cf45ead25952"
+  integrity sha512-t2Ixri15Q/cFXR+0p5vrqXTLo7dUZ0tdbyUSSWjSSqCqBFrfJAL1gVMFw8MfO88je/cpqU03DaYwFYezuI6CEw==
   dependencies:
-    "@fluentui/react-field" "^9.1.38"
-    "@fluentui/react-jsx-runtime" "^9.0.18"
-    "@fluentui/react-shared-contexts" "^9.10.0"
-    "@fluentui/react-theme" "^9.1.14"
-    "@fluentui/react-utilities" "^9.15.1"
+    "@fluentui/react-jsx-runtime" "^9.0.25"
+    "@fluentui/react-shared-contexts" "^9.13.2"
+    "@fluentui/react-theme" "^9.1.16"
+    "@fluentui/react-utilities" "^9.15.6"
     "@griffel/react" "^1.5.14"
     "@swc/helpers" "^0.5.1"
 
-"@fluentui/react-theme@^9.1.14":
-  version "9.1.14"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-theme/-/react-theme-9.1.14.tgz#148bda28deeb6877cab37175d68c795bffd99f90"
-  integrity sha512-Lc76jjNETV6gOFlE8b03WxcztdMhrYlj7eu6ZfRWtS6jJvyLka2BMm4ES8RyPPKmdbLnN/+BuOE6YySBs2qamg==
+"@fluentui/react-textarea@^9.3.58":
+  version "9.3.58"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-textarea/-/react-textarea-9.3.58.tgz#93a67a401e34855df012e89714e41a41ebed4a28"
+  integrity sha512-YJRVCb50HK0WpmTBRUL7lUXOZhCzJpA7owFM3/pDOWIXGoVaXlvXcVSRYMIFSlJa4hMweGtlZncnY/9/r3+35w==
   dependencies:
-    "@fluentui/tokens" "1.0.0-alpha.11"
+    "@fluentui/react-field" "^9.1.48"
+    "@fluentui/react-jsx-runtime" "^9.0.25"
+    "@fluentui/react-shared-contexts" "^9.13.2"
+    "@fluentui/react-theme" "^9.1.16"
+    "@fluentui/react-utilities" "^9.15.6"
+    "@griffel/react" "^1.5.14"
     "@swc/helpers" "^0.5.1"
 
-"@fluentui/react-toast@^9.3.12":
-  version "9.3.12"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-toast/-/react-toast-9.3.12.tgz#ba0d41f7c60f0244642fe99bccf3b6b82cdfdd6a"
-  integrity sha512-Yl/k/q1QkKz+xfxRm4fkg/jVdB2kXN/Whckj4VQEE69W0ci37/o6wVtN/WAZigSIuoCzUmLNDtMeBYN7p1UKoQ==
+"@fluentui/react-theme@^9.1.16":
+  version "9.1.16"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-theme/-/react-theme-9.1.16.tgz#e00210847863ac8cf5d5d162639fad1c16f85a5b"
+  integrity sha512-QK2dGE5aQXN1UGdiEmGKpYGP3tHXIchLvFf8DEEOWnF4XBc9SiEPNFYkvLMJjHxZmDz4D670rsOPe0r5jFDEKQ==
   dependencies:
-    "@fluentui/keyboard-keys" "^9.0.6"
-    "@fluentui/react-aria" "^9.3.43"
-    "@fluentui/react-icons" "^2.0.217"
-    "@fluentui/react-jsx-runtime" "^9.0.18"
-    "@fluentui/react-portal" "^9.3.24"
-    "@fluentui/react-shared-contexts" "^9.10.0"
-    "@fluentui/react-tabster" "^9.14.0"
-    "@fluentui/react-theme" "^9.1.14"
-    "@fluentui/react-utilities" "^9.15.1"
+    "@fluentui/tokens" "1.0.0-alpha.13"
+    "@swc/helpers" "^0.5.1"
+
+"@fluentui/react-toast@^9.3.25":
+  version "9.3.25"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-toast/-/react-toast-9.3.25.tgz#3070733ced349a3fc83b698c06ae482c0b9b5318"
+  integrity sha512-CUVl1d4D8uvLt+yOyceJkbQSqC327gCQ4Ytr1uh3VogOMXIj0j3guAJ3MDGsRvGBRp6EoehrXFvIqCmgfkTQKA==
+  dependencies:
+    "@fluentui/keyboard-keys" "^9.0.7"
+    "@fluentui/react-aria" "^9.7.1"
+    "@fluentui/react-icons" "^2.0.224"
+    "@fluentui/react-jsx-runtime" "^9.0.25"
+    "@fluentui/react-portal" "^9.4.8"
+    "@fluentui/react-shared-contexts" "^9.13.2"
+    "@fluentui/react-tabster" "^9.17.1"
+    "@fluentui/react-theme" "^9.1.16"
+    "@fluentui/react-utilities" "^9.15.6"
     "@griffel/react" "^1.5.14"
     "@swc/helpers" "^0.5.1"
     react-transition-group "^4.4.1"
 
-"@fluentui/react-toolbar@^9.1.51":
-  version "9.1.51"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-toolbar/-/react-toolbar-9.1.51.tgz#5d88a55c27df2ab95a350d77818409175a910f5d"
-  integrity sha512-gs7fGeZxChj9c0x4QwnRkCfPz4KDFDWIMC7HtFHo3PYnchQmIIMj118Qe0CRsteLmXf4XdL954hyPlvKoJtMpQ==
+"@fluentui/react-toolbar@^9.1.64":
+  version "9.1.64"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-toolbar/-/react-toolbar-9.1.64.tgz#9444061fb5094c035c96e0e02c68bb2a6e0bd587"
+  integrity sha512-zUjcqdn2Vf0AhstlMx35r75nKUuWM+sM0ox/fjd5WKSRLGjiJtgTIb3X5iRPBoRGLMyAchMrDRFDlhEwV13yBg==
   dependencies:
-    "@fluentui/react-button" "^9.3.50"
-    "@fluentui/react-context-selector" "^9.1.41"
-    "@fluentui/react-divider" "^9.2.46"
-    "@fluentui/react-jsx-runtime" "^9.0.18"
-    "@fluentui/react-radio" "^9.1.51"
-    "@fluentui/react-shared-contexts" "^9.10.0"
-    "@fluentui/react-tabster" "^9.14.0"
-    "@fluentui/react-theme" "^9.1.14"
-    "@fluentui/react-utilities" "^9.15.1"
+    "@fluentui/react-button" "^9.3.63"
+    "@fluentui/react-context-selector" "^9.1.47"
+    "@fluentui/react-divider" "^9.2.56"
+    "@fluentui/react-jsx-runtime" "^9.0.25"
+    "@fluentui/react-radio" "^9.2.1"
+    "@fluentui/react-shared-contexts" "^9.13.2"
+    "@fluentui/react-tabster" "^9.17.1"
+    "@fluentui/react-theme" "^9.1.16"
+    "@fluentui/react-utilities" "^9.15.6"
     "@griffel/react" "^1.5.14"
     "@swc/helpers" "^0.5.1"
 
-"@fluentui/react-tooltip@^9.3.17":
-  version "9.3.17"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-tooltip/-/react-tooltip-9.3.17.tgz#398cef9d2a2926fdda8216c436b38f053e2e720a"
-  integrity sha512-s+luUSOK4NWP5vaK1cGZKwwhKBOla+JagR13dsHYa+LEGY6b5CNIj+/EFwDZP14vTZ/S31x0phpUQYMkCcjkkw==
+"@fluentui/react-tooltip@^9.4.9":
+  version "9.4.9"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-tooltip/-/react-tooltip-9.4.9.tgz#46f836c2a3899e4eda6cd3072894933a733d6291"
+  integrity sha512-02KKSv23L1ZshmCQj7Zeol1V2Vh8cil75K+zVFFrBOpseUCzpC34ito6YXWNCxOr8CAlLpxZozEBzL8Fy7OjEQ==
   dependencies:
-    "@fluentui/keyboard-keys" "^9.0.6"
-    "@fluentui/react-jsx-runtime" "^9.0.18"
-    "@fluentui/react-portal" "^9.3.24"
-    "@fluentui/react-positioning" "^9.9.21"
-    "@fluentui/react-shared-contexts" "^9.10.0"
-    "@fluentui/react-theme" "^9.1.14"
-    "@fluentui/react-utilities" "^9.15.1"
+    "@fluentui/keyboard-keys" "^9.0.7"
+    "@fluentui/react-jsx-runtime" "^9.0.25"
+    "@fluentui/react-portal" "^9.4.8"
+    "@fluentui/react-positioning" "^9.12.2"
+    "@fluentui/react-shared-contexts" "^9.13.2"
+    "@fluentui/react-tabster" "^9.17.1"
+    "@fluentui/react-theme" "^9.1.16"
+    "@fluentui/react-utilities" "^9.15.6"
     "@griffel/react" "^1.5.14"
     "@swc/helpers" "^0.5.1"
 
-"@fluentui/react-tree@^9.4.6":
-  version "9.4.6"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-tree/-/react-tree-9.4.6.tgz#5d8b970d479040aac4626e6ee3580269ee10b107"
-  integrity sha512-FbeJmWKXmTqzR3SqwIRYLpeLDIBnwYw5hsKryOVJgookMEmWQwi+VOTD9HLqOjYFWOJJ5mamA5V5+USz6uiqrQ==
+"@fluentui/react-tree@^9.4.23":
+  version "9.4.23"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-tree/-/react-tree-9.4.23.tgz#5d17cbdc549ea67038bb92067b7e9dde6d5067a8"
+  integrity sha512-ehccDPZUywGavPlgH6AbNnOXKp40VlTOVkDSS7k3j3eImFcK28yjy46IUB5YblUZPdU6QMXop3CkJX2/Q8fR3g==
   dependencies:
-    "@fluentui/keyboard-keys" "^9.0.6"
-    "@fluentui/react-aria" "^9.3.43"
-    "@fluentui/react-avatar" "^9.5.41"
-    "@fluentui/react-button" "^9.3.50"
-    "@fluentui/react-checkbox" "^9.1.51"
-    "@fluentui/react-context-selector" "^9.1.41"
-    "@fluentui/react-icons" "^2.0.217"
-    "@fluentui/react-jsx-runtime" "^9.0.18"
-    "@fluentui/react-radio" "^9.1.51"
-    "@fluentui/react-shared-contexts" "^9.10.0"
-    "@fluentui/react-tabster" "^9.14.0"
-    "@fluentui/react-theme" "^9.1.14"
-    "@fluentui/react-utilities" "^9.15.1"
+    "@fluentui/keyboard-keys" "^9.0.7"
+    "@fluentui/react-aria" "^9.7.1"
+    "@fluentui/react-avatar" "^9.6.7"
+    "@fluentui/react-button" "^9.3.63"
+    "@fluentui/react-checkbox" "^9.2.6"
+    "@fluentui/react-context-selector" "^9.1.47"
+    "@fluentui/react-icons" "^2.0.224"
+    "@fluentui/react-jsx-runtime" "^9.0.25"
+    "@fluentui/react-radio" "^9.2.1"
+    "@fluentui/react-shared-contexts" "^9.13.2"
+    "@fluentui/react-tabster" "^9.17.1"
+    "@fluentui/react-theme" "^9.1.16"
+    "@fluentui/react-utilities" "^9.15.6"
     "@griffel/react" "^1.5.14"
     "@swc/helpers" "^0.5.1"
 
-"@fluentui/react-utilities@^9.15.1":
-  version "9.15.1"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-utilities/-/react-utilities-9.15.1.tgz#b15c63ecc96614271d4faf3531394835e805e05c"
-  integrity sha512-BQz4SIcdORTJyVrl1KyiKKqawy9SUj+/m4raxIllLHSZyfFgnDHDVLv4YFlZjTRqaqtx16V53atyUu2MtsU3DA==
+"@fluentui/react-utilities@^9.15.6":
+  version "9.15.6"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-utilities/-/react-utilities-9.15.6.tgz#ddc01fc63cfef0388f54f9d0b87b7ab04eece094"
+  integrity sha512-Hli0iiA/gaWwADMe7NRD6TSy7KvL3bgek8j1sYkE9BiUI89GqyfJwU2Tm0it04iiCYvQ5WWrXPcRYyZ3/MHtpA==
   dependencies:
-    "@fluentui/keyboard-keys" "^9.0.6"
+    "@fluentui/keyboard-keys" "^9.0.7"
+    "@fluentui/react-shared-contexts" "^9.13.2"
     "@swc/helpers" "^0.5.1"
 
-"@fluentui/react-virtualizer@9.0.0-alpha.52":
-  version "9.0.0-alpha.52"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-virtualizer/-/react-virtualizer-9.0.0-alpha.52.tgz#fb33111e934738adc31709643e5d7b667cfc9138"
-  integrity sha512-VAX2IAItsC7+QNiqnz6sgEtHPk0haU8t9EuvEu0XhO9sVFVBwgQR8GKkBIQJxn98ikU1XwEw87cT97Sz0VgERQ==
+"@fluentui/react-virtualizer@9.0.0-alpha.64":
+  version "9.0.0-alpha.64"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-virtualizer/-/react-virtualizer-9.0.0-alpha.64.tgz#5ae058c7eb95c079799b6a4635127da684906701"
+  integrity sha512-QEoBUI6FMwWhG6U4688SbSCtRFV2nuqpM9O2+5QWhzv+TTdPj0VGHqEOBy0XmsNot/UivusNfi94AVQ3s4aSTA==
   dependencies:
-    "@fluentui/react-jsx-runtime" "^9.0.18"
-    "@fluentui/react-utilities" "^9.15.1"
+    "@fluentui/react-jsx-runtime" "^9.0.25"
+    "@fluentui/react-shared-contexts" "^9.13.2"
+    "@fluentui/react-utilities" "^9.15.6"
     "@griffel/react" "^1.5.14"
     "@swc/helpers" "^0.5.1"
 
-"@fluentui/tokens@1.0.0-alpha.11":
-  version "1.0.0-alpha.11"
-  resolved "https://registry.yarnpkg.com/@fluentui/tokens/-/tokens-1.0.0-alpha.11.tgz#65c1e69808dbb87d8756f31351ddf69705e0acaa"
-  integrity sha512-kHKR1/JIGcBXA0qr+MyNg8KQZL4RLJXlhaSV6yNn50rJ0kTdQHUCKbbficvNZoeQBj3x0A8/WgAbPmfppZo0Zg==
+"@fluentui/tokens@1.0.0-alpha.13":
+  version "1.0.0-alpha.13"
+  resolved "https://registry.yarnpkg.com/@fluentui/tokens/-/tokens-1.0.0-alpha.13.tgz#15c0b006bebbd587ff22589f7e48572a28f842d8"
+  integrity sha512-IzYysTTBkAH7tQZxYKpzhxYnTJkvwXhjhTOpmERgnqTFifHTP8/vaQjJAAm7dI/9zlDx1oN+y/I+KzL9bDLHZQ==
   dependencies:
     "@swc/helpers" "^0.5.1"
 
@@ -8900,10 +8946,10 @@ jsonfile@^6.0.1:
   optionalDependencies:
     graceful-fs "^4.1.6"
 
-keyborg@^2.0.0, keyborg@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/keyborg/-/keyborg-2.1.0.tgz#e6975b83ade58bef7bed13d6e107b9ed2b98ccd3"
-  integrity sha512-0+v3/GIYG6gClwBOXrHet31n1UJW49xbKgVPUu6we41aq9tAmMosVXEdctZxsQdebyxtrcxVTkvHjBD1XPOHwg==
+keyborg@^2.2.0, keyborg@^2.3.0:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/keyborg/-/keyborg-2.4.1.tgz#57afdef9d04ee242bc4e694642f9216140f2c242"
+  integrity sha512-B9EZwDd36WKlIq6JmimaTsTDx5E0aUqZcxtgTfK66ut1FbRXYhBmiB7Al2qKzB7CCX9C49sTBiiyVzsXCA6J4Q==
 
 keyv@^4.0.0, keyv@^4.5.3:
   version "4.5.4"
@@ -11719,12 +11765,12 @@ table@^6.8.1:
     string-width "^4.2.3"
     strip-ansi "^6.0.1"
 
-tabster@^4.8.0:
-  version "4.8.0"
-  resolved "https://registry.yarnpkg.com/tabster/-/tabster-4.8.0.tgz#e1f9b5c7c8e4b642d6a91e243de0dfc09d8cacc5"
-  integrity sha512-R1ib3x0Rd+iepvrzXdEkd2Qa2O5dV7jaZtR4BhkhE9sBYMolbVc6EgHGTHBQvdXQBdU8I2MXCMn0c6jarJb+GA==
+tabster@^5.0.1:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/tabster/-/tabster-5.2.0.tgz#e394708c43d6a0d63d3d60d275f3cc306e790413"
+  integrity sha512-cSi3a0gGeM9Co/gTKHlhTFfiitwVjcA+kP9lJux0U7QaRrZox1yYrfbwZhJXM7N0fux7BgvCYaOxME5k0EQ0tA==
   dependencies:
-    keyborg "^2.0.0"
+    keyborg "^2.2.0"
     tslib "^2.3.1"
 
 tapable@^2.0.0, tapable@^2.1.1, tapable@^2.2.0, tapable@^2.2.1:


### PR DESCRIPTION
The [TreeGrid implementation](https://github.com/microsoft/fluentui/pull/29780/files#diff-8749e1441ec3506af3496e403718146ffe051df15bbb62cafe19346ea8c253fd) provided by @adamsamec requires usage of the tabster version 5, which is already being used by latest v9 version (v9.44.4)

1. upgrade `@fluentui/react-components` to v9.44.4