### PR TITLE
feat(react-tree-grid): implements TreeGridRowGroup component

### DIFF
--- a/packages/react-tree-grid/package.json
+++ b/packages/react-tree-grid/package.json
@@ -3,13 +3,13 @@
   "version": "0.0.1",
   "private": true,
   "peerDependencies": {
+    "@fluentui/react-components": ">=9.44.5 < 10.0.0",
     "@types/react": ">=16.8.0 <19.0.0",
     "@types/react-dom": ">=16.8.0 <19.0.0",
     "react": ">=16.8.0 <19.0.0",
     "react-dom": ">=16.8.0 <19.0.0"
   },
   "dependencies": {
-    "@fluentui/react-components": ">=9.44.4 < 10.0.0",
     "@fluentui/react-context-selector": ">=9.1.47 < 10.0.0",
     "@fluentui/keyboard-keys": ">=9.0.6 < 10.0.0",
     "@fluentui/react-tabster": ">=9.14.0 < 10.0.0",

--- a/packages/react-tree-grid/src/components/TreeGridCell/useTreeGridCellStyles.styles.ts
+++ b/packages/react-tree-grid/src/components/TreeGridCell/useTreeGridCellStyles.styles.ts
@@ -1,7 +1,7 @@
 import { makeResetStyles, mergeClasses } from '@fluentui/react-components';
 
 const useResetStyles = makeResetStyles({
-  flex: '1 1 auto',
+  flex: '1 1 100%',
 });
 
 export const useTreeGridCellStyles = () =>

--- a/packages/react-tree-grid/src/components/TreeGridRow/TreeGridRow.tsx
+++ b/packages/react-tree-grid/src/components/TreeGridRow/TreeGridRow.tsx
@@ -2,14 +2,20 @@ import * as React from 'react';
 import {
   mergeClasses,
   useArrowNavigationGroup,
+  useEventCallback,
   useFocusableGroup,
 } from '@fluentui/react-components';
 import { useTreeGridRowStyles } from './useTreeGridRowStyles.styles';
 import { TreeGridRowProps } from './TreeGridRow.types';
 import { useMergedTabsterAttributes_unstable } from '@fluentui/react-tabster';
+import { isHTMLElement } from '@fluentui/react-utilities';
+import { ArrowLeft, ArrowRight, Enter } from '@fluentui/keyboard-keys';
+import { useTreeGridRowGroupContext } from '../TreeGridRowGroup/TreeGridRowGroup';
 
 export const TreeGridRow = React.forwardRef(
   (props: TreeGridRowProps, ref: React.ForwardedRef<HTMLDivElement>) => {
+    const { groupOwner = false, className, ...rest } = props;
+    const { level, open, requestOpenChange } = useTreeGridRowGroupContext();
     const styles = useTreeGridRowStyles();
     const tabsterAttributes = useMergedTabsterAttributes_unstable(
       useArrowNavigationGroup({
@@ -21,14 +27,60 @@ export const TreeGridRow = React.forwardRef(
         ignoreDefaultKeydown: { Enter: true },
       })
     );
+    const handleKeyDown = useEventCallback(
+      (event: React.KeyboardEvent<HTMLDivElement>) => {
+        props.onKeyDown?.(event);
+        if (event.target !== event.currentTarget) return;
+        switch (event.key) {
+          case Enter: {
+            return event.currentTarget.click();
+          }
+          case ArrowRight: {
+            if (open === false) {
+              requestOpenChange({ open: true, event, type: 'keydown' });
+            }
+            return;
+          }
+          case ArrowLeft: {
+            if (open === true) {
+              requestOpenChange({ open: false, event, type: 'keydown' });
+            }
+            return;
+          }
+        }
+      }
+    );
+    const handleClick = useEventCallback(
+      (event: React.MouseEvent<HTMLDivElement>) => {
+        props.onClick?.(event);
+        if (
+          !isHTMLElement(event.target) ||
+          !(
+            event.target === event.currentTarget ||
+            event.target.parentElement === event.currentTarget
+          )
+        ) {
+          return;
+        }
+        requestOpenChange({ open: !open, event, type: 'click' });
+      }
+    );
+    if (!open && !groupOwner) return null;
     return (
       <div
         ref={ref}
         role="row"
         tabIndex={0}
-        {...props}
-        className={mergeClasses(styles, props.className)}
+        aria-level={level + 1}
+        {...rest}
+        className={mergeClasses(styles, className)}
         {...tabsterAttributes}
+        {...(groupOwner && {
+          onKeyDown: handleKeyDown,
+          onClick: handleClick,
+          'aria-expanded': open,
+          'aria-level': level,
+        })}
       />
     );
   }

--- a/packages/react-tree-grid/src/components/TreeGridRow/TreeGridRow.types.ts
+++ b/packages/react-tree-grid/src/components/TreeGridRow/TreeGridRow.types.ts
@@ -1,4 +1,5 @@
+import {} from '@fluentui/react-utilities';
+
 export type TreeGridRowProps = JSX.IntrinsicElements['div'] & {
-  // aria-level is required for screen readers to understand the nesting level of the row
-  'aria-level': number | string;
+  groupOwner?: boolean;
 };

--- a/packages/react-tree-grid/src/components/TreeGridRowGroup/TreGridRow.types.ts
+++ b/packages/react-tree-grid/src/components/TreeGridRowGroup/TreGridRow.types.ts
@@ -1,0 +1,20 @@
+import * as React from 'react';
+import { EventData, EventHandler } from '@fluentui/react-utilities';
+
+export type TreeGridRowGroupContextValue = {
+  level: number;
+  open: boolean;
+  requestOpenChange(data: OnOpenChangeData): void;
+};
+
+export type OnOpenChangeData = { open: boolean } & (
+  | EventData<'click', React.MouseEvent<HTMLDivElement>>
+  | EventData<'keydown', React.KeyboardEvent<HTMLDivElement>>
+);
+
+export type TreeGridRowGroupProps = {
+  children?: React.ReactNode;
+  open?: boolean;
+  defaultOpen?: boolean;
+  onOpenChange?: EventHandler<OnOpenChangeData>;
+};

--- a/packages/react-tree-grid/src/components/TreeGridRowGroup/TreeGridRowGroup.tsx
+++ b/packages/react-tree-grid/src/components/TreeGridRowGroup/TreeGridRowGroup.tsx
@@ -1,0 +1,57 @@
+import * as React from 'react';
+import {
+  useControllableState,
+  useEventCallback,
+} from '@fluentui/react-utilities';
+import {
+  OnOpenChangeData,
+  TreeGridRowGroupContextValue,
+  TreeGridRowGroupProps,
+} from './TreGridRow.types';
+
+export const TreeGridRowGroup = (props: TreeGridRowGroupProps) => {
+  const { level, open: parentOpen } = useTreeGridRowGroupContext();
+  const [open, setOpen] = useControllableState({
+    state: props.open,
+    initialState: false,
+    defaultState: props.defaultOpen,
+  });
+
+  const requestOpenChange = useEventCallback((data: OnOpenChangeData) => {
+    props.onOpenChange?.(data.event, data);
+    setOpen(data.open);
+  });
+
+  const context: TreeGridRowGroupContextValue = React.useMemo(
+    () => ({
+      level: level + 1,
+      open,
+      requestOpenChange,
+    }),
+    [level, open, requestOpenChange]
+  );
+  if (!parentOpen) return null;
+  return (
+    <TreeGridRowGroupProvider value={context}>
+      {props.children}
+    </TreeGridRowGroupProvider>
+  );
+};
+
+const defaultTreeGridRowGroupContextValue: TreeGridRowGroupContextValue = {
+  level: 0,
+  open: true,
+  requestOpenChange: () => {
+    /* noop */
+  },
+};
+
+const TreeGridRowGroupContext = React.createContext<
+  TreeGridRowGroupContextValue | undefined
+>(undefined);
+
+const { Provider: TreeGridRowGroupProvider } = TreeGridRowGroupContext;
+
+export const useTreeGridRowGroupContext = () =>
+  React.useContext(TreeGridRowGroupContext) ??
+  defaultTreeGridRowGroupContextValue;

--- a/packages/react-tree-grid/src/components/TreeGridRowGroup/index.ts
+++ b/packages/react-tree-grid/src/components/TreeGridRowGroup/index.ts
@@ -1,0 +1,2 @@
+export * from './TreeGridRowGroup';
+export * from './TreGridRow.types';

--- a/packages/react-tree-grid/src/index.ts
+++ b/packages/react-tree-grid/src/index.ts
@@ -2,5 +2,7 @@ export type { TreeGridCellProps } from './components/TreeGridCell';
 export { TreeGridCell } from './components/TreeGridCell';
 export type { TreeGridRowProps } from './components/TreeGridRow';
 export { TreeGridRow } from './components/TreeGridRow';
+export type { TreeGridRowGroupProps } from './components/TreeGridRowGroup';
+export { TreeGridRowGroup } from './components/TreeGridRowGroup';
 export { TreeGrid } from './components/TreeGrid';
 export { useTreeGridOpenRows } from './hooks/useTreeGridControl';

--- a/packages/react-tree-grid/stories/Default.stories.tsx
+++ b/packages/react-tree-grid/stories/Default.stories.tsx
@@ -3,7 +3,7 @@ import {
   TreeGrid,
   TreeGridCell,
   TreeGridRow,
-  useTreeGridOpenRows,
+  TreeGridRowGroup,
 } from '@fluentui-contrib/react-tree-grid';
 import {
   Button,
@@ -15,119 +15,113 @@ import {
 } from '@fluentui/react-components';
 
 export const Default = () => {
-  const { openRows, getTreeGridProps, getTreeGridRowProps } =
-    useTreeGridOpenRows();
   return (
-    <TreeGrid {...getTreeGridProps()} aria-label="All meetings">
-      <TreeGridRow aria-level={1} {...getTreeGridRowProps({ id: 'today' })}>
-        <TreeGridCell header>Today</TreeGridCell>
-        <TreeGridCell aria-colspan={3}>
-          <Button>Header action</Button>
-        </TreeGridCell>
-      </TreeGridRow>
-      {openRows.has('today') && (
-        <>
-          <TreeGridRow aria-level={2}>
-            <TreeGridCell header>
-              Monthly townhall, 10:00 AM to 11:00 AM
-            </TreeGridCell>
-            <TreeGridCell>
-              <Button>Chat with participants</Button>
-            </TreeGridCell>
-            <TreeGridCell>
-              <Menu>
-                <MenuTrigger disableButtonEnhancement>
-                  <Button>Toggle menu</Button>
-                </MenuTrigger>
+    <TreeGrid aria-label="All meetings">
+      <TreeGridRowGroup>
+        <TreeGridRow groupOwner>
+          <TreeGridCell header>Today</TreeGridCell>
+          <TreeGridCell aria-colspan={3}>
+            <Button>Header action</Button>
+          </TreeGridCell>
+        </TreeGridRow>
+        <TreeGridRow>
+          <TreeGridCell header>
+            Monthly townhall, 10:00 AM to 11:00 AM
+          </TreeGridCell>
+          <TreeGridCell>
+            <Button>Chat with participants</Button>
+          </TreeGridCell>
+          <TreeGridCell>
+            <Menu>
+              <MenuTrigger disableButtonEnhancement>
+                <Button>Toggle menu</Button>
+              </MenuTrigger>
 
-                <MenuPopover>
-                  <MenuList>
-                    <MenuItem>New </MenuItem>
-                    <MenuItem>New Window</MenuItem>
-                    <MenuItem disabled>Open File</MenuItem>
-                    <MenuItem>Open Folder</MenuItem>
-                  </MenuList>
-                </MenuPopover>
-              </Menu>
-            </TreeGridCell>
-            <TreeGridCell>
-              <Button>Agenda and notes</Button>
-            </TreeGridCell>
-          </TreeGridRow>
-          <TreeGridRow aria-level={2}>
-            <TreeGridCell header>
-              Planning for next quarter, 11:00 AM to 12:00 PM
-            </TreeGridCell>
-            <TreeGridCell>
-              <Button>Chat with participants</Button>
-            </TreeGridCell>
-            <TreeGridCell>
-              <Button>View recap</Button>
-            </TreeGridCell>
-          </TreeGridRow>
-        </>
-      )}
-      <TreeGridRow aria-level={1} {...getTreeGridRowProps({ id: 'last-week' })}>
-        <TreeGridCell header>Last week</TreeGridCell>
-        <TreeGridCell aria-colspan={5}>
-          <Button>Header action</Button>
-        </TreeGridCell>
-      </TreeGridRow>
-      {openRows.has('last-week') && (
-        <>
-          <TreeGridRow aria-level={2}>
-            <TreeGridCell header>
-              Weekly summary #2, 2:30 PM to 3:30 PM
-            </TreeGridCell>
-            <TreeGridCell>
-              <Button>Chat with participants</Button>
-            </TreeGridCell>
-            <TreeGridCell>
-              <Button>View recap</Button>
-            </TreeGridCell>
-            <TreeGridCell>
-              <Button>Agenda and notes</Button>
-            </TreeGridCell>
-            <TreeGridCell>
-              <Button>4 tasks</Button>
-            </TreeGridCell>
-          </TreeGridRow>
-          <TreeGridRow aria-level={2}>
-            <TreeGridCell header>
-              Mandatory training #1, 9:00 AM to 10:00 AM
-            </TreeGridCell>
-            <TreeGridCell>
-              <Button>Chat with participants</Button>
-            </TreeGridCell>
-            <TreeGridCell>
-              <Button>View recap</Button>
-            </TreeGridCell>
-            <TreeGridCell>
-              <Button>Agenda and notes</Button>
-            </TreeGridCell>
-          </TreeGridRow>
-          <TreeGridRow aria-level={2}>
-            <TreeGridCell header>
-              Meeting with John, 10:15 AM to 11:15 AM
-            </TreeGridCell>
-            <TreeGridCell>
-              <Button>Chat with participants</Button>
-            </TreeGridCell>
-            <TreeGridCell>
-              <Button>View recap</Button>
-            </TreeGridCell>
-            <TreeGridCell>
-              <Button>Agenda and notes</Button>
-            </TreeGridCell>
-            <TreeGridCell>
-              <Button>2 tasks</Button>
-            </TreeGridCell>
-            <TreeGridCell>
-              <Button>Transcript</Button>
-            </TreeGridCell>
-          </TreeGridRow>
-        </>
-      )}
+              <MenuPopover>
+                <MenuList>
+                  <MenuItem>New </MenuItem>
+                  <MenuItem>New Window</MenuItem>
+                  <MenuItem disabled>Open File</MenuItem>
+                  <MenuItem>Open Folder</MenuItem>
+                </MenuList>
+              </MenuPopover>
+            </Menu>
+          </TreeGridCell>
+          <TreeGridCell>
+            <Button>Agenda and notes</Button>
+          </TreeGridCell>
+        </TreeGridRow>
+        <TreeGridRow>
+          <TreeGridCell header>
+            Planning for next quarter, 11:00 AM to 12:00 PM
+          </TreeGridCell>
+          <TreeGridCell>
+            <Button>Chat with participants</Button>
+          </TreeGridCell>
+          <TreeGridCell>
+            <Button>View recap</Button>
+          </TreeGridCell>
+        </TreeGridRow>
+      </TreeGridRowGroup>
+      <TreeGridRowGroup>
+        <TreeGridRow groupOwner>
+          <TreeGridCell header>Last week</TreeGridCell>
+          <TreeGridCell aria-colspan={5}>
+            <Button>Header action</Button>
+          </TreeGridCell>
+        </TreeGridRow>
+        <TreeGridRow>
+          <TreeGridCell header>
+            Weekly summary #2, 2:30 PM to 3:30 PM
+          </TreeGridCell>
+          <TreeGridCell>
+            <Button>Chat with participants</Button>
+          </TreeGridCell>
+          <TreeGridCell>
+            <Button>View recap</Button>
+          </TreeGridCell>
+          <TreeGridCell>
+            <Button>Agenda and notes</Button>
+          </TreeGridCell>
+          <TreeGridCell>
+            <Button>4 tasks</Button>
+          </TreeGridCell>
+        </TreeGridRow>
+        <TreeGridRow>
+          <TreeGridCell header>
+            Mandatory training #1, 9:00 AM to 10:00 AM
+          </TreeGridCell>
+          <TreeGridCell>
+            <Button>Chat with participants</Button>
+          </TreeGridCell>
+          <TreeGridCell>
+            <Button>View recap</Button>
+          </TreeGridCell>
+          <TreeGridCell>
+            <Button>Agenda and notes</Button>
+          </TreeGridCell>
+        </TreeGridRow>
+        <TreeGridRow>
+          <TreeGridCell header>
+            Meeting with John, 10:15 AM to 11:15 AM
+          </TreeGridCell>
+          <TreeGridCell>
+            <Button>Chat with participants</Button>
+          </TreeGridCell>
+          <TreeGridCell>
+            <Button>View recap</Button>
+          </TreeGridCell>
+          <TreeGridCell>
+            <Button>Agenda and notes</Button>
+          </TreeGridCell>
+          <TreeGridCell>
+            <Button>2 tasks</Button>
+          </TreeGridCell>
+          <TreeGridCell>
+            <Button>Transcript</Button>
+          </TreeGridCell>
+        </TreeGridRow>
+      </TreeGridRowGroup>
     </TreeGrid>
   );
 };


### PR DESCRIPTION
## Changes

1. Introduces `TreeGridRowGroup` component

## Possible problems with this implementation

1. there's nothing limiting the user to add more than one `groupOwner` in the same group
2. there's nothing limiting that the first row on a `TreeGridRowGroup` should be the `groupOwner`
3. each `TreeGridRow` controls it's own visibility (this might not be ideal for virtualization cases, as the visibility of the nodes is dictated by the virtualization library on scroll normally?!)