### PR TITLE
chore: bumps `@fluentui/react-components` to  v9.45.0

### DIFF
--- a/change/@fluentui-contrib-react-resize-handle-fbab8534-342b-4a6e-8049-bcb49148efd3.json
+++ b/change/@fluentui-contrib-react-resize-handle-fbab8534-342b-4a6e-8049-bcb49148efd3.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: bumps @fluentui/react-utilities to 9.16.0",
+  "packageName": "@fluentui-contrib/react-resize-handle",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@babel/preset-env": "^7.21.5",
     "@babel/preset-react": "^7.18.6",
     "@babel/preset-typescript": "^7.21.5",
-    "@fluentui/react-components": "^9.44.4",
+    "@fluentui/react-components": "^9.45.0",
     "@griffel/shadow-dom": "~0.1.0",
     "@nx/devkit": "16.1.4",
     "@nx/eslint-plugin": "16.1.4",

--- a/packages/nx-plugin/src/generators/library/generator.spec.ts
+++ b/packages/nx-plugin/src/generators/library/generator.spec.ts
@@ -33,7 +33,7 @@ describe('create-package generator', () => {
     const pkgJson = readJson(tree, paths.packageJson);
     expect(pkgJson.peerDependencies).toMatchInlineSnapshot(`
       {
-        "@fluentui/react-components": ">=9.44.4 <10.0.0",
+        "@fluentui/react-components": ">=9.45.0 <10.0.0",
         "@types/react": ">=16.8.0 <19.0.0",
         "@types/react-dom": ">=16.8.0 <19.0.0",
         "react": ">=16.8.0 <19.0.0",

--- a/packages/react-resize-handle/package.json
+++ b/packages/react-resize-handle/package.json
@@ -9,6 +9,6 @@
     "react-dom": ">=16.8.0 <19.0.0"
   },
   "dependencies": {
-    "@fluentui/react-utilities": ">=9.15.1 < 10.0.0"
+    "@fluentui/react-utilities": ">=9.16.0 < 10.0.0"
   }
 }

--- a/packages/react-tree-grid/package.json
+++ b/packages/react-tree-grid/package.json
@@ -13,6 +13,6 @@
     "@fluentui/react-context-selector": ">=9.1.47 < 10.0.0",
     "@fluentui/keyboard-keys": ">=9.0.6 < 10.0.0",
     "@fluentui/react-tabster": ">=9.14.0 < 10.0.0",
-    "@fluentui/react-utilities": ">=9.15.1 < 10.0.0"
+    "@fluentui/react-utilities": ">=9.16.0 < 10.0.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1335,282 +1335,282 @@
   dependencies:
     "@swc/helpers" "^0.5.1"
 
-"@fluentui/react-accordion@^9.3.36":
-  version "9.3.36"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-accordion/-/react-accordion-9.3.36.tgz#f46096a38fdf8c147627c6a45bd64f0dd6fc6ae1"
-  integrity sha512-t1Q9SI5P1x53SF7stmpI7mauPd24mV+XqOOHY2htqR+vIa6n+gTLvvFe8qwPLsfK8kkyISzCaP1yHriPV9GqUQ==
+"@fluentui/react-accordion@^9.3.38":
+  version "9.3.38"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-accordion/-/react-accordion-9.3.38.tgz#cdf6740d2b28c1743ddb26e73d113c60490a83af"
+  integrity sha512-BB8d9+Jr0v4SW58OJTIyvsxhA/iOBbvIkQZlVHKqt4tL8dHOIFPrApw5WqQqaSYJsEwt4HxmlNU4Dv8qRughbg==
   dependencies:
-    "@fluentui/react-aria" "^9.7.1"
-    "@fluentui/react-context-selector" "^9.1.47"
+    "@fluentui/react-aria" "^9.7.3"
+    "@fluentui/react-context-selector" "^9.1.49"
     "@fluentui/react-icons" "^2.0.224"
-    "@fluentui/react-jsx-runtime" "^9.0.25"
-    "@fluentui/react-shared-contexts" "^9.13.2"
-    "@fluentui/react-tabster" "^9.17.1"
+    "@fluentui/react-jsx-runtime" "^9.0.27"
+    "@fluentui/react-shared-contexts" "^9.14.0"
+    "@fluentui/react-tabster" "^9.17.3"
     "@fluentui/react-theme" "^9.1.16"
-    "@fluentui/react-utilities" "^9.15.6"
+    "@fluentui/react-utilities" "^9.16.1"
     "@griffel/react" "^1.5.14"
     "@swc/helpers" "^0.5.1"
 
-"@fluentui/react-alert@9.0.0-beta.102":
-  version "9.0.0-beta.102"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-alert/-/react-alert-9.0.0-beta.102.tgz#09838085cce106f83109cf689ce22cd6ef497245"
-  integrity sha512-ZIbeW4Di1oJqPe87fFOciA57WZfFsTz8pBnI5n0x+jFl9tAnbp4FCWQHlatVf7rOkixet72ym0M9pSD1ez3U9A==
+"@fluentui/react-alert@9.0.0-beta.104":
+  version "9.0.0-beta.104"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-alert/-/react-alert-9.0.0-beta.104.tgz#473d8b628590e5fe42ddea37a9423ed3d5e0dff0"
+  integrity sha512-Z8BGSyzEKok5wlJF2cUc8GUj2q+c1D+119YF0WtHLiieh7pwOHjBcDJOHqnaVnQNbhetIA3NUht2z0e1wgOK5w==
   dependencies:
-    "@fluentui/react-avatar" "^9.6.7"
-    "@fluentui/react-button" "^9.3.63"
+    "@fluentui/react-avatar" "^9.6.9"
+    "@fluentui/react-button" "^9.3.65"
     "@fluentui/react-icons" "^2.0.224"
-    "@fluentui/react-jsx-runtime" "^9.0.25"
-    "@fluentui/react-tabster" "^9.17.1"
+    "@fluentui/react-jsx-runtime" "^9.0.27"
+    "@fluentui/react-tabster" "^9.17.3"
     "@fluentui/react-theme" "^9.1.16"
-    "@fluentui/react-utilities" "^9.15.6"
+    "@fluentui/react-utilities" "^9.16.1"
     "@griffel/react" "^1.5.14"
     "@swc/helpers" "^0.5.1"
 
-"@fluentui/react-aria@^9.7.1":
-  version "9.7.1"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-aria/-/react-aria-9.7.1.tgz#4c6058affab9ce2b217a542191563c14232c458a"
-  integrity sha512-LuupqbV/6ZWd/6t8xIKa/yg8CbIvp98T1GYw/eyseDk26dBvNY0Ue11O5Z5uN3fwVCR1a92cO0aFyPcv4fmaHA==
+"@fluentui/react-aria@^9.7.3":
+  version "9.7.3"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-aria/-/react-aria-9.7.3.tgz#2955c1d3afa3976346931e9f763a537202efc6ab"
+  integrity sha512-YwyPNEcBDCdY6YzhrIrtlSrLs2Le7X1jLq9em8OnqHeiO22dBmg5xlBJoAMwJ8awCpI9xhu1PhU/2VJY4YqNuA==
   dependencies:
     "@fluentui/keyboard-keys" "^9.0.7"
-    "@fluentui/react-shared-contexts" "^9.13.2"
-    "@fluentui/react-tabster" "^9.17.1"
-    "@fluentui/react-utilities" "^9.15.6"
+    "@fluentui/react-shared-contexts" "^9.14.0"
+    "@fluentui/react-tabster" "^9.17.3"
+    "@fluentui/react-utilities" "^9.16.1"
     "@swc/helpers" "^0.5.1"
 
-"@fluentui/react-avatar@^9.6.7":
-  version "9.6.7"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-avatar/-/react-avatar-9.6.7.tgz#57582379d98d45c879ac5edef93634aa3cf69eb2"
-  integrity sha512-8eZn9muu8a30v/C+ygZShpAQpTUefH+C4sW4hSUbuIIdalpU/CGkAe9iDLO+8dMxGQCXx1Y873ipNRsyDBCrLg==
+"@fluentui/react-avatar@^9.6.9":
+  version "9.6.9"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-avatar/-/react-avatar-9.6.9.tgz#6a78d91db7e0957ae4b6d74b7d30d5c59ce8729b"
+  integrity sha512-3aZeUhGOg+UlHsp2x//G4VKRWKclcsZvX6L9UVnHsA/nQqRw7C5Bfo9iFNsEeJ3R5W5mFA6LyEFWedJ7QdAmdQ==
   dependencies:
-    "@fluentui/react-badge" "^9.2.20"
-    "@fluentui/react-context-selector" "^9.1.47"
+    "@fluentui/react-badge" "^9.2.22"
+    "@fluentui/react-context-selector" "^9.1.49"
     "@fluentui/react-icons" "^2.0.224"
-    "@fluentui/react-jsx-runtime" "^9.0.25"
-    "@fluentui/react-popover" "^9.8.31"
-    "@fluentui/react-shared-contexts" "^9.13.2"
-    "@fluentui/react-tabster" "^9.17.1"
+    "@fluentui/react-jsx-runtime" "^9.0.27"
+    "@fluentui/react-popover" "^9.8.33"
+    "@fluentui/react-shared-contexts" "^9.14.0"
+    "@fluentui/react-tabster" "^9.17.3"
     "@fluentui/react-theme" "^9.1.16"
-    "@fluentui/react-tooltip" "^9.4.9"
-    "@fluentui/react-utilities" "^9.15.6"
+    "@fluentui/react-tooltip" "^9.4.11"
+    "@fluentui/react-utilities" "^9.16.1"
     "@griffel/react" "^1.5.14"
     "@swc/helpers" "^0.5.1"
 
-"@fluentui/react-badge@^9.2.20":
-  version "9.2.20"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-badge/-/react-badge-9.2.20.tgz#0f3bae29df81d237bb94e680e1a6065549d5cec3"
-  integrity sha512-6qLLEr1D/ZXwF7kBXb+iOh2Cke+0N2tJXCxYoLUEjtOlUDHvEMl32oO5b8WQZMVGGQCTGY192LxT8vAPqxREyg==
+"@fluentui/react-badge@^9.2.22":
+  version "9.2.22"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-badge/-/react-badge-9.2.22.tgz#fef91f2eee1220fb3fb61a25e7f455f94885d6bb"
+  integrity sha512-zzimP5mZiiCOm8expUTzD6yvvKbnKq22PK/L6+oNpifrvQnDwJF/0nwXQVjA3+icNoYTaHe/q0fFivpXV+Js6g==
   dependencies:
     "@fluentui/react-icons" "^2.0.224"
-    "@fluentui/react-jsx-runtime" "^9.0.25"
-    "@fluentui/react-shared-contexts" "^9.13.2"
+    "@fluentui/react-jsx-runtime" "^9.0.27"
+    "@fluentui/react-shared-contexts" "^9.14.0"
     "@fluentui/react-theme" "^9.1.16"
-    "@fluentui/react-utilities" "^9.15.6"
+    "@fluentui/react-utilities" "^9.16.1"
     "@griffel/react" "^1.5.14"
     "@swc/helpers" "^0.5.1"
 
-"@fluentui/react-breadcrumb@^9.0.9":
-  version "9.0.9"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-breadcrumb/-/react-breadcrumb-9.0.9.tgz#8bbd4a8144c3aaf35437d417451c64e5074c0e33"
-  integrity sha512-xNOGoVHGihjfFeio9FhE2urYE+aRKjqkYDRTqZu9dWwRnjhAO90V9QXztTgJjxPCf+PYNzJH/39Sm0NKOxynyg==
+"@fluentui/react-breadcrumb@^9.0.11":
+  version "9.0.11"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-breadcrumb/-/react-breadcrumb-9.0.11.tgz#b2ee3dd8a023caebdd4653d384bed57773d08dc4"
+  integrity sha512-L+AQqZz1gqkScD8IW1CjZWGNrDaHDc/gSv+PrvgSZeGDPibGj6TnLygJ7BKM+rQ+Hc2SbCogKbERpQZCbrSFvA==
   dependencies:
-    "@fluentui/react-aria" "^9.7.1"
-    "@fluentui/react-button" "^9.3.63"
+    "@fluentui/react-aria" "^9.7.3"
+    "@fluentui/react-button" "^9.3.65"
     "@fluentui/react-icons" "^2.0.224"
-    "@fluentui/react-jsx-runtime" "^9.0.25"
-    "@fluentui/react-link" "^9.2.5"
-    "@fluentui/react-shared-contexts" "^9.13.2"
-    "@fluentui/react-tabster" "^9.17.1"
+    "@fluentui/react-jsx-runtime" "^9.0.27"
+    "@fluentui/react-link" "^9.2.7"
+    "@fluentui/react-shared-contexts" "^9.14.0"
+    "@fluentui/react-tabster" "^9.17.3"
     "@fluentui/react-theme" "^9.1.16"
-    "@fluentui/react-utilities" "^9.15.6"
+    "@fluentui/react-utilities" "^9.16.1"
     "@griffel/react" "^1.5.14"
     "@swc/helpers" "^0.5.1"
 
-"@fluentui/react-button@^9.3.63":
-  version "9.3.63"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-button/-/react-button-9.3.63.tgz#8d4f320b815fae30c41502cb258e8e829a281a7f"
-  integrity sha512-Yw+LwQMEnXUMpHKjpW1aRC7RqSfcpWK4ytS0SPiu1TrFuvc/3meCPsXnIYhdlZrlBeRQdNucSaWNGBHAUmGt9w==
+"@fluentui/react-button@^9.3.65":
+  version "9.3.65"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-button/-/react-button-9.3.65.tgz#2cdaf64224aaea87d9e9b3dcf708912d4dde7526"
+  integrity sha512-3VOt29AugkfR7VMnkKON449E7Sn/nvc6BBT4kJDGKQY+Nm5d2p9e4HmHp1UaM9zRPt47lagTY2WFJNrKKSe/BA==
   dependencies:
     "@fluentui/keyboard-keys" "^9.0.7"
-    "@fluentui/react-aria" "^9.7.1"
+    "@fluentui/react-aria" "^9.7.3"
     "@fluentui/react-icons" "^2.0.224"
-    "@fluentui/react-jsx-runtime" "^9.0.25"
-    "@fluentui/react-shared-contexts" "^9.13.2"
-    "@fluentui/react-tabster" "^9.17.1"
+    "@fluentui/react-jsx-runtime" "^9.0.27"
+    "@fluentui/react-shared-contexts" "^9.14.0"
+    "@fluentui/react-tabster" "^9.17.3"
     "@fluentui/react-theme" "^9.1.16"
-    "@fluentui/react-utilities" "^9.15.6"
+    "@fluentui/react-utilities" "^9.16.1"
     "@griffel/react" "^1.5.14"
     "@swc/helpers" "^0.5.1"
 
-"@fluentui/react-card@^9.0.62":
-  version "9.0.62"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-card/-/react-card-9.0.62.tgz#cef0238e91a8fbed4199f3d35e71fda6fbff0fd6"
-  integrity sha512-PIYrhwTN+LbMf3dOQviOQLulOwyUa8QwXCL/ISSdrqb4AQcGA7ldcBxvRNi/XXw/Z+Z6Pxj2h1fkT5vtlow7Yg==
+"@fluentui/react-card@^9.0.64":
+  version "9.0.64"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-card/-/react-card-9.0.64.tgz#508c1db2234b9a93595165537e5c327563b6a112"
+  integrity sha512-TB/Zk+tLDUPNyAd2y8BvN0T2nroimtBOpB5GTK72E5sWPk0kaKIHwBEfXxNFGdGXcw0TAmVNqYi4ks37vh0Rgg==
   dependencies:
     "@fluentui/keyboard-keys" "^9.0.7"
-    "@fluentui/react-jsx-runtime" "^9.0.25"
-    "@fluentui/react-tabster" "^9.17.1"
+    "@fluentui/react-jsx-runtime" "^9.0.27"
+    "@fluentui/react-tabster" "^9.17.3"
     "@fluentui/react-theme" "^9.1.16"
-    "@fluentui/react-utilities" "^9.15.6"
+    "@fluentui/react-utilities" "^9.16.1"
     "@griffel/react" "^1.5.14"
     "@swc/helpers" "^0.5.1"
 
-"@fluentui/react-checkbox@^9.2.6":
-  version "9.2.6"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-checkbox/-/react-checkbox-9.2.6.tgz#f5a8460a145b33ebf8623e69e39bcbb88cc268b9"
-  integrity sha512-4P+YqtByqb41EhyWwQaizyc+lBtFj7e4ufcn6xLYbMI6bKrvODN1vsk1XbzFGxP18aWp2Ivf4d0INIlmR1T21w==
+"@fluentui/react-checkbox@^9.2.8":
+  version "9.2.8"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-checkbox/-/react-checkbox-9.2.8.tgz#d7224ab19f8514aab5019aedbb5251b0507fd988"
+  integrity sha512-L4aWzeZdi98d0ZhgNPtxghfhasQv1qlxIRMaPxtwvk5TN6i9YmRF8vf5Pmf0PESjT+zp3VPcisHcIfcqG26SmQ==
   dependencies:
-    "@fluentui/react-field" "^9.1.48"
+    "@fluentui/react-field" "^9.1.50"
     "@fluentui/react-icons" "^2.0.224"
-    "@fluentui/react-jsx-runtime" "^9.0.25"
-    "@fluentui/react-label" "^9.1.56"
-    "@fluentui/react-shared-contexts" "^9.13.2"
-    "@fluentui/react-tabster" "^9.17.1"
+    "@fluentui/react-jsx-runtime" "^9.0.27"
+    "@fluentui/react-label" "^9.1.58"
+    "@fluentui/react-shared-contexts" "^9.14.0"
+    "@fluentui/react-tabster" "^9.17.3"
     "@fluentui/react-theme" "^9.1.16"
-    "@fluentui/react-utilities" "^9.15.6"
+    "@fluentui/react-utilities" "^9.16.1"
     "@griffel/react" "^1.5.14"
     "@swc/helpers" "^0.5.1"
 
-"@fluentui/react-combobox@^9.6.0":
-  version "9.6.0"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-combobox/-/react-combobox-9.6.0.tgz#2374c7fbd341f256ebeb28b494e66868efda53b7"
-  integrity sha512-nPqM7qhyDpv5KjD70IUosi1vkFlunxPYTopi0imc8MJLnRzp2yhkuL8+lLUTfVLFy3T4ZVrWBoOhpy2Fu+YBHQ==
+"@fluentui/react-combobox@^9.7.0":
+  version "9.7.0"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-combobox/-/react-combobox-9.7.0.tgz#df0503d664cc38882ac3f7c83a96033f5f37ca5b"
+  integrity sha512-YmTdg04rvsg2+Dkw3ob+YLnS9rm3TLVMMNYTH0T64/FM3qirHntIXGbhMZXP5Cdo14gzQwr/e78NjBRKfYO4Wg==
   dependencies:
     "@fluentui/keyboard-keys" "^9.0.7"
-    "@fluentui/react-context-selector" "^9.1.47"
-    "@fluentui/react-field" "^9.1.48"
+    "@fluentui/react-context-selector" "^9.1.49"
+    "@fluentui/react-field" "^9.1.50"
     "@fluentui/react-icons" "^2.0.224"
-    "@fluentui/react-jsx-runtime" "^9.0.25"
-    "@fluentui/react-portal" "^9.4.8"
-    "@fluentui/react-positioning" "^9.12.2"
-    "@fluentui/react-shared-contexts" "^9.13.2"
-    "@fluentui/react-tabster" "^9.17.1"
+    "@fluentui/react-jsx-runtime" "^9.0.27"
+    "@fluentui/react-portal" "^9.4.10"
+    "@fluentui/react-positioning" "^9.12.4"
+    "@fluentui/react-shared-contexts" "^9.14.0"
+    "@fluentui/react-tabster" "^9.17.3"
     "@fluentui/react-theme" "^9.1.16"
-    "@fluentui/react-utilities" "^9.15.6"
+    "@fluentui/react-utilities" "^9.16.1"
     "@griffel/react" "^1.5.14"
     "@swc/helpers" "^0.5.1"
 
-"@fluentui/react-components@^9.44.4":
-  version "9.44.4"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-components/-/react-components-9.44.4.tgz#9a20f56382aa939c02860f93b784151cb3d9fb6e"
-  integrity sha512-a4PT8/fz6BtRHKRZWO0j9DxYLpU9ms3kGQ/xbRLRf5R4jL2GOD2ZZPnWS9wAYaOu9HBoUMM6fVuLNoISwfjOGQ==
+"@fluentui/react-components@^9.45.0":
+  version "9.45.0"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-components/-/react-components-9.45.0.tgz#6c9489fccc0748982f7b27803f060c69a4abc6ea"
+  integrity sha512-Y+Laj1dvRcCp/nWT0DExRXoh7oKTX458g6oltrGjhIHikq4D6/kssK5tfhCyknPLwIlVSYi5J+G6L3NfvI8a8w==
   dependencies:
-    "@fluentui/react-accordion" "^9.3.36"
-    "@fluentui/react-alert" "9.0.0-beta.102"
-    "@fluentui/react-avatar" "^9.6.7"
-    "@fluentui/react-badge" "^9.2.20"
-    "@fluentui/react-breadcrumb" "^9.0.9"
-    "@fluentui/react-button" "^9.3.63"
-    "@fluentui/react-card" "^9.0.62"
-    "@fluentui/react-checkbox" "^9.2.6"
-    "@fluentui/react-combobox" "^9.6.0"
-    "@fluentui/react-dialog" "^9.9.5"
-    "@fluentui/react-divider" "^9.2.56"
-    "@fluentui/react-drawer" "^9.0.9"
-    "@fluentui/react-field" "^9.1.48"
-    "@fluentui/react-image" "^9.1.53"
-    "@fluentui/react-infobutton" "9.0.0-beta.86"
-    "@fluentui/react-infolabel" "^9.0.14"
-    "@fluentui/react-input" "^9.4.58"
-    "@fluentui/react-label" "^9.1.56"
-    "@fluentui/react-link" "^9.2.5"
-    "@fluentui/react-menu" "^9.12.43"
-    "@fluentui/react-message-bar" "^9.0.14"
-    "@fluentui/react-overflow" "^9.1.6"
-    "@fluentui/react-persona" "^9.2.66"
-    "@fluentui/react-popover" "^9.8.31"
-    "@fluentui/react-portal" "^9.4.8"
-    "@fluentui/react-positioning" "^9.12.2"
-    "@fluentui/react-progress" "^9.1.58"
-    "@fluentui/react-provider" "^9.13.6"
-    "@fluentui/react-radio" "^9.2.1"
-    "@fluentui/react-select" "^9.1.58"
-    "@fluentui/react-shared-contexts" "^9.13.2"
-    "@fluentui/react-skeleton" "^9.0.46"
-    "@fluentui/react-slider" "^9.1.63"
-    "@fluentui/react-spinbutton" "^9.2.58"
-    "@fluentui/react-spinner" "^9.3.36"
-    "@fluentui/react-switch" "^9.1.63"
-    "@fluentui/react-table" "^9.11.3"
-    "@fluentui/react-tabs" "^9.4.4"
-    "@fluentui/react-tabster" "^9.17.1"
-    "@fluentui/react-tags" "^9.0.20"
-    "@fluentui/react-text" "^9.4.5"
-    "@fluentui/react-textarea" "^9.3.58"
+    "@fluentui/react-accordion" "^9.3.38"
+    "@fluentui/react-alert" "9.0.0-beta.104"
+    "@fluentui/react-avatar" "^9.6.9"
+    "@fluentui/react-badge" "^9.2.22"
+    "@fluentui/react-breadcrumb" "^9.0.11"
+    "@fluentui/react-button" "^9.3.65"
+    "@fluentui/react-card" "^9.0.64"
+    "@fluentui/react-checkbox" "^9.2.8"
+    "@fluentui/react-combobox" "^9.7.0"
+    "@fluentui/react-dialog" "^9.9.7"
+    "@fluentui/react-divider" "^9.2.58"
+    "@fluentui/react-drawer" "^9.1.1"
+    "@fluentui/react-field" "^9.1.50"
+    "@fluentui/react-image" "^9.1.55"
+    "@fluentui/react-infobutton" "9.0.0-beta.88"
+    "@fluentui/react-infolabel" "^9.0.16"
+    "@fluentui/react-input" "^9.4.60"
+    "@fluentui/react-label" "^9.1.58"
+    "@fluentui/react-link" "^9.2.7"
+    "@fluentui/react-menu" "^9.12.45"
+    "@fluentui/react-message-bar" "^9.0.16"
+    "@fluentui/react-overflow" "^9.1.8"
+    "@fluentui/react-persona" "^9.2.68"
+    "@fluentui/react-popover" "^9.8.33"
+    "@fluentui/react-portal" "^9.4.10"
+    "@fluentui/react-positioning" "^9.12.4"
+    "@fluentui/react-progress" "^9.1.60"
+    "@fluentui/react-provider" "^9.13.8"
+    "@fluentui/react-radio" "^9.2.3"
+    "@fluentui/react-select" "^9.1.60"
+    "@fluentui/react-shared-contexts" "^9.14.0"
+    "@fluentui/react-skeleton" "^9.0.48"
+    "@fluentui/react-slider" "^9.1.65"
+    "@fluentui/react-spinbutton" "^9.2.60"
+    "@fluentui/react-spinner" "^9.3.38"
+    "@fluentui/react-switch" "^9.1.65"
+    "@fluentui/react-table" "^9.11.5"
+    "@fluentui/react-tabs" "^9.4.6"
+    "@fluentui/react-tabster" "^9.17.3"
+    "@fluentui/react-tags" "^9.0.22"
+    "@fluentui/react-text" "^9.4.7"
+    "@fluentui/react-textarea" "^9.3.60"
     "@fluentui/react-theme" "^9.1.16"
-    "@fluentui/react-toast" "^9.3.25"
-    "@fluentui/react-toolbar" "^9.1.64"
-    "@fluentui/react-tooltip" "^9.4.9"
-    "@fluentui/react-tree" "^9.4.23"
-    "@fluentui/react-utilities" "^9.15.6"
-    "@fluentui/react-virtualizer" "9.0.0-alpha.64"
+    "@fluentui/react-toast" "^9.3.27"
+    "@fluentui/react-toolbar" "^9.1.66"
+    "@fluentui/react-tooltip" "^9.4.11"
+    "@fluentui/react-tree" "^9.4.25"
+    "@fluentui/react-utilities" "^9.16.1"
+    "@fluentui/react-virtualizer" "9.0.0-alpha.66"
     "@griffel/react" "^1.5.14"
     "@swc/helpers" "^0.5.1"
 
-"@fluentui/react-context-selector@^9.1.47":
-  version "9.1.47"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-context-selector/-/react-context-selector-9.1.47.tgz#ffaba02beff1879c3fa01893798a32b938120438"
-  integrity sha512-sjI2tu8ELjna1oIIgWc4Xa/pF9fTnaA27DtlcqZnAPInv/UyHbsZCE0V4jc3NQMBofWKpK2gypXtEGHmTCYsFg==
+"@fluentui/react-context-selector@^9.1.49":
+  version "9.1.49"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-context-selector/-/react-context-selector-9.1.49.tgz#2da7d5f4edd5d1560c7144bca879691cb52488cf"
+  integrity sha512-u4wRNfnyfuZDalVEESBPFQ0Ue4yYu+ozkPQvuEV6kriQGnAQQyyVbIidOCuP7Sja0nBwgM8eAzK0uX/slmmj3Q==
   dependencies:
-    "@fluentui/react-utilities" "^9.15.6"
+    "@fluentui/react-utilities" "^9.16.1"
     "@swc/helpers" "^0.5.1"
 
-"@fluentui/react-dialog@^9.9.5":
-  version "9.9.5"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-dialog/-/react-dialog-9.9.5.tgz#d260ae68313970bce168185f213529889d8ada14"
-  integrity sha512-TADvVSw0rP+dI/keaLNZ+dMbqYdkIHR4D/Uu7sBjIyaaJtGvb/oNeDtNjk2BXO6ObaAGnQvxs6AJkJQ1mvklkg==
+"@fluentui/react-dialog@^9.9.7":
+  version "9.9.7"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-dialog/-/react-dialog-9.9.7.tgz#a138e72617756c36554cefd3cc29570c841ec00f"
+  integrity sha512-5/6MeaHOYpx8Vt0auMJGLCjn6O1IYtl6IhwdwRNXL6AS1o4F24IKXdWZPtiHWuvzbuZAQd3+5nRDUE5KC9We6A==
   dependencies:
     "@fluentui/keyboard-keys" "^9.0.7"
-    "@fluentui/react-aria" "^9.7.1"
-    "@fluentui/react-context-selector" "^9.1.47"
+    "@fluentui/react-aria" "^9.7.3"
+    "@fluentui/react-context-selector" "^9.1.49"
     "@fluentui/react-icons" "^2.0.224"
-    "@fluentui/react-jsx-runtime" "^9.0.25"
-    "@fluentui/react-portal" "^9.4.8"
-    "@fluentui/react-shared-contexts" "^9.13.2"
-    "@fluentui/react-tabster" "^9.17.1"
+    "@fluentui/react-jsx-runtime" "^9.0.27"
+    "@fluentui/react-portal" "^9.4.10"
+    "@fluentui/react-shared-contexts" "^9.14.0"
+    "@fluentui/react-tabster" "^9.17.3"
     "@fluentui/react-theme" "^9.1.16"
-    "@fluentui/react-utilities" "^9.15.6"
+    "@fluentui/react-utilities" "^9.16.1"
     "@griffel/react" "^1.5.14"
     "@swc/helpers" "^0.5.1"
     react-transition-group "^4.4.1"
 
-"@fluentui/react-divider@^9.2.56":
-  version "9.2.56"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-divider/-/react-divider-9.2.56.tgz#3dbc8e910e354ca46611d8adaaa3f54f32a90f7c"
-  integrity sha512-5QTzBltI+WGgLGfQYjmk7YfzR1zIIUhS2Pz+RUriBmovAijJRWNX3Wa4NUcTiP/sQJden0cKxHKNbHzoofOcLg==
+"@fluentui/react-divider@^9.2.58":
+  version "9.2.58"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-divider/-/react-divider-9.2.58.tgz#675a68cb7353131d753104e41c3ab444f1cd10c3"
+  integrity sha512-y1ECy1zM4imKhpyOyUGugB+J30tfySO5hhrsIcpaiUQxRjE4IhZf2ZG6EqAQYLinJ+hV06yLZoazekljlvk6yw==
   dependencies:
-    "@fluentui/react-jsx-runtime" "^9.0.25"
-    "@fluentui/react-shared-contexts" "^9.13.2"
+    "@fluentui/react-jsx-runtime" "^9.0.27"
+    "@fluentui/react-shared-contexts" "^9.14.0"
     "@fluentui/react-theme" "^9.1.16"
-    "@fluentui/react-utilities" "^9.15.6"
+    "@fluentui/react-utilities" "^9.16.1"
     "@griffel/react" "^1.5.14"
     "@swc/helpers" "^0.5.1"
 
-"@fluentui/react-drawer@^9.0.9":
-  version "9.0.9"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-drawer/-/react-drawer-9.0.9.tgz#c80e10ac962a2ca15b7cf7fee3a832657c8b9cb8"
-  integrity sha512-uF4EpNFKiKbPVcpdFM/j4XhAI4Aj0nbve8aARlD3WgCsmPjKEhIsfRY6o1qxdrAbhbb/s6ZvhUa+SuhoE9dQlA==
+"@fluentui/react-drawer@^9.1.1":
+  version "9.1.1"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-drawer/-/react-drawer-9.1.1.tgz#df56a6581c2c2739c3274740350722bf051d03fb"
+  integrity sha512-3zvbbeaLLJZa4MXRpW8Ta4DFZ5457Tq9/4a0CqsIW/+8EuwtJwO+FB5a0DS6j0q6kN4mjkWF19OvzMkJsSTRVw==
   dependencies:
-    "@fluentui/react-dialog" "^9.9.5"
-    "@fluentui/react-jsx-runtime" "^9.0.25"
-    "@fluentui/react-motion-preview" "^0.5.8"
-    "@fluentui/react-shared-contexts" "^9.13.2"
-    "@fluentui/react-tabster" "^9.17.1"
+    "@fluentui/react-dialog" "^9.9.7"
+    "@fluentui/react-jsx-runtime" "^9.0.27"
+    "@fluentui/react-motion-preview" "^0.5.10"
+    "@fluentui/react-shared-contexts" "^9.14.0"
+    "@fluentui/react-tabster" "^9.17.3"
     "@fluentui/react-theme" "^9.1.16"
-    "@fluentui/react-utilities" "^9.15.6"
+    "@fluentui/react-utilities" "^9.16.1"
     "@griffel/react" "^1.5.14"
     "@swc/helpers" "^0.5.1"
 
-"@fluentui/react-field@^9.1.48":
-  version "9.1.48"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-field/-/react-field-9.1.48.tgz#b73b554bc166ae5cbb8fc3a7eb22f58f3ab4e604"
-  integrity sha512-J8TUP730WDlyPXbea1m13aB4seDUIxeLAEZyFYx2igmSzCnA8LTAtsOyqHFC8EcR1/twmIB+jdD1XG7n9JpR2g==
+"@fluentui/react-field@^9.1.50":
+  version "9.1.50"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-field/-/react-field-9.1.50.tgz#37f043b76214704551e9bcef7851547f06ec161e"
+  integrity sha512-2mbx7YReMWvrgi3set9KepLLgMyNJ7StLu/HiHMM3jkcgPt3mGfwoJEsEKt+xd8eUAo4b82F7t+tHI4f9yzJaQ==
   dependencies:
-    "@fluentui/react-context-selector" "^9.1.47"
+    "@fluentui/react-context-selector" "^9.1.49"
     "@fluentui/react-icons" "^2.0.224"
-    "@fluentui/react-jsx-runtime" "^9.0.25"
-    "@fluentui/react-label" "^9.1.56"
+    "@fluentui/react-jsx-runtime" "^9.0.27"
+    "@fluentui/react-label" "^9.1.58"
     "@fluentui/react-theme" "^9.1.16"
-    "@fluentui/react-utilities" "^9.15.6"
+    "@fluentui/react-utilities" "^9.16.1"
     "@griffel/react" "^1.5.14"
     "@swc/helpers" "^0.5.1"
 
@@ -1622,433 +1622,433 @@
     "@griffel/react" "^1.0.0"
     tslib "^2.1.0"
 
-"@fluentui/react-image@^9.1.53":
-  version "9.1.53"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-image/-/react-image-9.1.53.tgz#8ae4929582fb15494879fd8bace1f303e3f259b2"
-  integrity sha512-kw9SU6bnzyIxzkAZIvgJK+jSlvOa5U5wR6D6ZmAdKZD9P9b2CryhUPK3nRzwm5dEgl3iChPRpu3pLSqXpnlj/Q==
+"@fluentui/react-image@^9.1.55":
+  version "9.1.55"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-image/-/react-image-9.1.55.tgz#9d888101bda586a268fbd0ac66305da505c70f33"
+  integrity sha512-hYP61OWLuGSJNPOGJXtphbiDESfLB+/vsODKQsJhrDRJ2CSNMAfNznPHucqGRRN6AWQOI/BynJDS5F22Y//7CQ==
   dependencies:
-    "@fluentui/react-jsx-runtime" "^9.0.25"
-    "@fluentui/react-shared-contexts" "^9.13.2"
+    "@fluentui/react-jsx-runtime" "^9.0.27"
+    "@fluentui/react-shared-contexts" "^9.14.0"
     "@fluentui/react-theme" "^9.1.16"
-    "@fluentui/react-utilities" "^9.15.6"
+    "@fluentui/react-utilities" "^9.16.1"
     "@griffel/react" "^1.5.14"
     "@swc/helpers" "^0.5.1"
 
-"@fluentui/react-infobutton@9.0.0-beta.86":
-  version "9.0.0-beta.86"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-infobutton/-/react-infobutton-9.0.0-beta.86.tgz#29e8f4f5a2b494afec34d7ff0458dbbf4faa6cde"
-  integrity sha512-nzo1rBNDyFHwa4Ik4W+AnzwE2ua6+5uQxH2OQTLS4PlGnIycaecGgjZBRr0Kk8vO5fAPrBtbEAPVAdxMj54SvQ==
+"@fluentui/react-infobutton@9.0.0-beta.88":
+  version "9.0.0-beta.88"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-infobutton/-/react-infobutton-9.0.0-beta.88.tgz#1be7149ba09fad12ab12afe941c109b8f0d6906b"
+  integrity sha512-NVZyfrLtoFNu7cGkp2ORWsxJiCk1JgN4CVBDj03QSIh14EsPMwphYgDwfQ8TZOF2Nub0DGtC7/tF8IUlb/aP6g==
   dependencies:
     "@fluentui/react-icons" "^2.0.224"
-    "@fluentui/react-jsx-runtime" "^9.0.25"
-    "@fluentui/react-label" "^9.1.56"
-    "@fluentui/react-popover" "^9.8.31"
-    "@fluentui/react-tabster" "^9.17.1"
+    "@fluentui/react-jsx-runtime" "^9.0.27"
+    "@fluentui/react-label" "^9.1.58"
+    "@fluentui/react-popover" "^9.8.33"
+    "@fluentui/react-tabster" "^9.17.3"
     "@fluentui/react-theme" "^9.1.16"
-    "@fluentui/react-utilities" "^9.15.6"
+    "@fluentui/react-utilities" "^9.16.1"
     "@griffel/react" "^1.5.14"
     "@swc/helpers" "^0.5.1"
 
-"@fluentui/react-infolabel@^9.0.14":
-  version "9.0.14"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-infolabel/-/react-infolabel-9.0.14.tgz#5514186729860b08e72d57605115f4557c1f8c9a"
-  integrity sha512-MOEi5Tat2XLz3CnUuZBkwAAFK6sPqmwX04gT9cRpg917yE2zv8RTolh+Png8Ah14Gtg+H7fN3Xe+3XmEVJiE9w==
+"@fluentui/react-infolabel@^9.0.16":
+  version "9.0.16"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-infolabel/-/react-infolabel-9.0.16.tgz#146413b29008294c10bfa3f77cb69d81195bd8e7"
+  integrity sha512-UCY+2vB4vOn0LfVhbgkyNG0EiuKIe0PdxEAtLU2PqosHLkaLKnYDKJdiIS/oaFmyNtGHmMxRkigvZpZ7h74f9g==
   dependencies:
     "@fluentui/react-icons" "^2.0.224"
-    "@fluentui/react-jsx-runtime" "^9.0.25"
-    "@fluentui/react-label" "^9.1.56"
-    "@fluentui/react-popover" "^9.8.31"
-    "@fluentui/react-tabster" "^9.17.1"
+    "@fluentui/react-jsx-runtime" "^9.0.27"
+    "@fluentui/react-label" "^9.1.58"
+    "@fluentui/react-popover" "^9.8.33"
+    "@fluentui/react-tabster" "^9.17.3"
     "@fluentui/react-theme" "^9.1.16"
-    "@fluentui/react-utilities" "^9.15.6"
+    "@fluentui/react-utilities" "^9.16.1"
     "@griffel/react" "^1.5.14"
     "@swc/helpers" "^0.5.1"
 
-"@fluentui/react-input@^9.4.58":
-  version "9.4.58"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-input/-/react-input-9.4.58.tgz#611e159def607d7db9bdfe601395de8b8233b2cb"
-  integrity sha512-MC114o+qKDXhP+KZydubcTrUSDu8DywYn3oV+QS6HCNGReTIO0M+hygGKqHYEHCvyMOEb/K/oLyUlZZdXoWdrQ==
+"@fluentui/react-input@^9.4.60":
+  version "9.4.60"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-input/-/react-input-9.4.60.tgz#f831e05ae9a587fc90b4604c3875afa3081b66f2"
+  integrity sha512-kuk24K0X0gckTCssXoiWvZsTFVpZJv+WPl2fkjxeffzmFfBZtJUFQkXeC4/hcAg+aScjZnEtqjHjwDEbjZqkeA==
   dependencies:
-    "@fluentui/react-field" "^9.1.48"
-    "@fluentui/react-jsx-runtime" "^9.0.25"
-    "@fluentui/react-shared-contexts" "^9.13.2"
+    "@fluentui/react-field" "^9.1.50"
+    "@fluentui/react-jsx-runtime" "^9.0.27"
+    "@fluentui/react-shared-contexts" "^9.14.0"
     "@fluentui/react-theme" "^9.1.16"
-    "@fluentui/react-utilities" "^9.15.6"
+    "@fluentui/react-utilities" "^9.16.1"
     "@griffel/react" "^1.5.14"
     "@swc/helpers" "^0.5.1"
 
-"@fluentui/react-jsx-runtime@^9.0.25":
-  version "9.0.25"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-jsx-runtime/-/react-jsx-runtime-9.0.25.tgz#9ccedb1ad7e0c3a661578f565db06360b05c6225"
-  integrity sha512-FPWYfA2OLzlpAOYLdeS9oEENGCcD5kW1Bn7EQcgA1AJVHxHfcZqRqojhGGQcTh08Xh8tPMF2cLIzXiGuxdcr9w==
+"@fluentui/react-jsx-runtime@^9.0.27":
+  version "9.0.27"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-jsx-runtime/-/react-jsx-runtime-9.0.27.tgz#f7748587a696183c2838a3c8773fff097f75f37c"
+  integrity sha512-9wxsWxVI7RLXsdK+7lzp7TK0FJKnrrj+Igxn0prqAvXdBRiFcuycoCJaHzC4Ka+Hsiol8NQg6xaIR59a28lmyQ==
   dependencies:
-    "@fluentui/react-utilities" "^9.15.6"
+    "@fluentui/react-utilities" "^9.16.1"
     "@swc/helpers" "^0.5.1"
     react-is "^17.0.2"
 
-"@fluentui/react-label@^9.1.56":
-  version "9.1.56"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-label/-/react-label-9.1.56.tgz#0b5fe578093d351ea73b5da78f1569696bd59576"
-  integrity sha512-q7mo8bpc3JEUCl0yarwYYCeVUypfmfQ6OJbJhT+WNUITz7jhOkHCMCsWb9BNoyVBEMBGrypV/LqAqyDQykgDCw==
+"@fluentui/react-label@^9.1.58":
+  version "9.1.58"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-label/-/react-label-9.1.58.tgz#7d1a1bd875e8625fe525ef0ab218d211cb2f1bd3"
+  integrity sha512-0ouSMop4vpXJzMvAyfmIr3TgDM/W1k+GFm8ZPD5fDQCopSJ+h3kvUZg5pqaXpBwamvZ16+qRARfTNITp2U7Rjw==
   dependencies:
-    "@fluentui/react-jsx-runtime" "^9.0.25"
-    "@fluentui/react-shared-contexts" "^9.13.2"
+    "@fluentui/react-jsx-runtime" "^9.0.27"
+    "@fluentui/react-shared-contexts" "^9.14.0"
     "@fluentui/react-theme" "^9.1.16"
-    "@fluentui/react-utilities" "^9.15.6"
+    "@fluentui/react-utilities" "^9.16.1"
     "@griffel/react" "^1.5.14"
     "@swc/helpers" "^0.5.1"
 
-"@fluentui/react-link@^9.2.5":
-  version "9.2.5"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-link/-/react-link-9.2.5.tgz#59ec2f809cc5f41479886ac2f1c25362ba3e4dd4"
-  integrity sha512-p5dz5EigggczOwuQqAU9stfp5CkPcYxMemWj2aizrUKJdMfpLY2FqBTlnCUmIIn2ZTjkJaUeD4xE6W/bMsFyiA==
+"@fluentui/react-link@^9.2.7":
+  version "9.2.7"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-link/-/react-link-9.2.7.tgz#9fa90ac3dfe6f58fe6c97ca5410dc77b64d5e996"
+  integrity sha512-z4X9dcUc/7FlqDxbGKbOfWubru+QimtzgMtlVxZ30pkC959hfIbFpbBY6Me76UOuFiOZxUPdfyY/73ekhhhVxw==
   dependencies:
     "@fluentui/keyboard-keys" "^9.0.7"
-    "@fluentui/react-jsx-runtime" "^9.0.25"
-    "@fluentui/react-shared-contexts" "^9.13.2"
-    "@fluentui/react-tabster" "^9.17.1"
+    "@fluentui/react-jsx-runtime" "^9.0.27"
+    "@fluentui/react-shared-contexts" "^9.14.0"
+    "@fluentui/react-tabster" "^9.17.3"
     "@fluentui/react-theme" "^9.1.16"
-    "@fluentui/react-utilities" "^9.15.6"
+    "@fluentui/react-utilities" "^9.16.1"
     "@griffel/react" "^1.5.14"
     "@swc/helpers" "^0.5.1"
 
-"@fluentui/react-menu@^9.12.43":
-  version "9.12.43"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-menu/-/react-menu-9.12.43.tgz#38bf6f300f2c36a685e859f6ae358fd60ff7b9b5"
-  integrity sha512-2B2TCJ9C3AtWuwxo2wPA4iIFDLL2swgFMrRIN/itZWGWmcuznt+yydZhNXxR7kPb97onOOia0UG4PeynwHQEzA==
+"@fluentui/react-menu@^9.12.45":
+  version "9.12.45"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-menu/-/react-menu-9.12.45.tgz#75c3ff0556b4dd9323a94f908fa4b58328d37cc7"
+  integrity sha512-qhpmuvAB4DUmmC5lNMakVvZjTdj/GZnH6WctNGZp94iCZLhcnIQcM9l0PvRpUpU1v3irXRyE5QV+x+wXC0awTw==
   dependencies:
     "@fluentui/keyboard-keys" "^9.0.7"
-    "@fluentui/react-aria" "^9.7.1"
-    "@fluentui/react-context-selector" "^9.1.47"
+    "@fluentui/react-aria" "^9.7.3"
+    "@fluentui/react-context-selector" "^9.1.49"
     "@fluentui/react-icons" "^2.0.224"
-    "@fluentui/react-jsx-runtime" "^9.0.25"
-    "@fluentui/react-portal" "^9.4.8"
-    "@fluentui/react-positioning" "^9.12.2"
-    "@fluentui/react-shared-contexts" "^9.13.2"
-    "@fluentui/react-tabster" "^9.17.1"
+    "@fluentui/react-jsx-runtime" "^9.0.27"
+    "@fluentui/react-portal" "^9.4.10"
+    "@fluentui/react-positioning" "^9.12.4"
+    "@fluentui/react-shared-contexts" "^9.14.0"
+    "@fluentui/react-tabster" "^9.17.3"
     "@fluentui/react-theme" "^9.1.16"
-    "@fluentui/react-utilities" "^9.15.6"
+    "@fluentui/react-utilities" "^9.16.1"
     "@griffel/react" "^1.5.14"
     "@swc/helpers" "^0.5.1"
 
-"@fluentui/react-message-bar@^9.0.14":
-  version "9.0.14"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-message-bar/-/react-message-bar-9.0.14.tgz#6b8c43f8939070b5e44f9cf95cbf2359575eb4a1"
-  integrity sha512-OOAepPTnd40QOIT/eAABTbk309gnBDV0i6jBz5Oz4FOcikBvWVcvtKri8RjOAo7a+d7MFOg4vFu/3n8cbOg5rg==
+"@fluentui/react-message-bar@^9.0.16":
+  version "9.0.16"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-message-bar/-/react-message-bar-9.0.16.tgz#64b3396fa68db73cff73f8f1f6684c692c8cf70d"
+  integrity sha512-R1VnqcFwu0pM2Yk8rjkN48Lx/n44UFD13BuY8/JeEuU8XQ8hLnEBVtdHjzRPJk+iM5in2ScMMQj4Z0nWyCRM1Q==
   dependencies:
-    "@fluentui/react-button" "^9.3.63"
+    "@fluentui/react-button" "^9.3.65"
     "@fluentui/react-icons" "^2.0.224"
-    "@fluentui/react-jsx-runtime" "^9.0.25"
-    "@fluentui/react-shared-contexts" "^9.13.2"
+    "@fluentui/react-jsx-runtime" "^9.0.27"
+    "@fluentui/react-shared-contexts" "^9.14.0"
     "@fluentui/react-theme" "^9.1.16"
-    "@fluentui/react-utilities" "^9.15.6"
+    "@fluentui/react-utilities" "^9.16.1"
     "@griffel/react" "^1.5.14"
     "@swc/helpers" "^0.5.1"
     react-transition-group "^4.4.1"
 
-"@fluentui/react-motion-preview@^0.5.8":
-  version "0.5.8"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-motion-preview/-/react-motion-preview-0.5.8.tgz#3740b037d1810b83e27d300ea7bf2731fe9824e8"
-  integrity sha512-cNh9HGsH/bLrFG+IXIdsFHSQKErE0dtnZrjYTHYjbDIjo0AnUTT3N9jBCuMppfri6kiVbd14L6fnppthEYs1hQ==
+"@fluentui/react-motion-preview@^0.5.10":
+  version "0.5.10"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-motion-preview/-/react-motion-preview-0.5.10.tgz#d8a7bb86f443426fe41d24084adcec6f1a3782d8"
+  integrity sha512-6iwF3N4hB6IxCoFVusgA2mp6mrTknwcsVGNYEQw1YF5WgGOMF3M0N1xNpN61/SYziT6HSUaI38NaA7LI3Dp3Sw==
   dependencies:
-    "@fluentui/react-jsx-runtime" "^9.0.25"
-    "@fluentui/react-shared-contexts" "^9.13.2"
+    "@fluentui/react-jsx-runtime" "^9.0.27"
+    "@fluentui/react-shared-contexts" "^9.14.0"
     "@fluentui/react-theme" "^9.1.16"
-    "@fluentui/react-utilities" "^9.15.6"
+    "@fluentui/react-utilities" "^9.16.1"
     "@griffel/react" "^1.5.14"
     "@swc/helpers" "^0.5.1"
 
-"@fluentui/react-overflow@^9.1.6":
-  version "9.1.6"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-overflow/-/react-overflow-9.1.6.tgz#7f48aebfbc7ccec2441025a1087b4740d16d570b"
-  integrity sha512-kBDBQan7aDWvZJIYxXoNtUXOR4JsetaMxzNjM8DZfHC3k5k9E/jftxEughDRCA4TGirNQSsR02VPXl3DhZ35ng==
+"@fluentui/react-overflow@^9.1.8":
+  version "9.1.8"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-overflow/-/react-overflow-9.1.8.tgz#4405b3daccc3620b4e26ef4453d9d56d4ab78f04"
+  integrity sha512-W8L68+0bUtfGr72LRx+U05EZLO0E8VMfscDiNKiEjDrOqdBnqNAIDN86825wrN77HH2wvILN07EhPOauqzz8YQ==
   dependencies:
     "@fluentui/priority-overflow" "^9.1.11"
-    "@fluentui/react-context-selector" "^9.1.47"
+    "@fluentui/react-context-selector" "^9.1.49"
     "@fluentui/react-theme" "^9.1.16"
-    "@fluentui/react-utilities" "^9.15.6"
+    "@fluentui/react-utilities" "^9.16.1"
     "@griffel/react" "^1.5.14"
     "@swc/helpers" "^0.5.1"
 
-"@fluentui/react-persona@^9.2.66":
-  version "9.2.66"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-persona/-/react-persona-9.2.66.tgz#b6ff520f4cf1fd19ed03c309d04bdb1331c77467"
-  integrity sha512-mcGSPuzAvCI9gvwjG6r/7A9bl4qBNtK4gKoRjC8Kh212cRNyN9np6oumFZs8OfYrcIgFl/P43K6bKx2Z+dW9zw==
+"@fluentui/react-persona@^9.2.68":
+  version "9.2.68"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-persona/-/react-persona-9.2.68.tgz#97f27f09d90ea3d8dc092e1a49dff81571f45234"
+  integrity sha512-CYtDiZ34GGaw7lZ85uHZOuYXzkY21VHN6cUlGY1TJn98+Xz+y7JoVLIG7KZHHp2JzmmjtwjvgnqAdOun5LrWig==
   dependencies:
-    "@fluentui/react-avatar" "^9.6.7"
-    "@fluentui/react-badge" "^9.2.20"
-    "@fluentui/react-jsx-runtime" "^9.0.25"
-    "@fluentui/react-shared-contexts" "^9.13.2"
+    "@fluentui/react-avatar" "^9.6.9"
+    "@fluentui/react-badge" "^9.2.22"
+    "@fluentui/react-jsx-runtime" "^9.0.27"
+    "@fluentui/react-shared-contexts" "^9.14.0"
     "@fluentui/react-theme" "^9.1.16"
-    "@fluentui/react-utilities" "^9.15.6"
+    "@fluentui/react-utilities" "^9.16.1"
     "@griffel/react" "^1.5.14"
     "@swc/helpers" "^0.5.1"
 
-"@fluentui/react-popover@^9.8.31":
-  version "9.8.31"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-popover/-/react-popover-9.8.31.tgz#ff30717b6430ab030f00449e154efd6cf37787e3"
-  integrity sha512-Av8X2QfZwg8rSZdC5mehEHOCzrLOy24/hdQMiRcEAXR1wiJgJrVnOx7GObGADzP2lCYa0+KoGJ2H4LA8FBSc3g==
+"@fluentui/react-popover@^9.8.33":
+  version "9.8.33"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-popover/-/react-popover-9.8.33.tgz#c45027576bb152780dec3c59cb25a2996be728f6"
+  integrity sha512-0yPX6KCdMEGmrvJnQles5iTKN0OZ2vNSPVdkbyEKIUKj5DrNK1cMZEV/7Tgrtn922fx3/74FLMqEpEDTdrvQ/Q==
   dependencies:
     "@fluentui/keyboard-keys" "^9.0.7"
-    "@fluentui/react-aria" "^9.7.1"
-    "@fluentui/react-context-selector" "^9.1.47"
-    "@fluentui/react-jsx-runtime" "^9.0.25"
-    "@fluentui/react-portal" "^9.4.8"
-    "@fluentui/react-positioning" "^9.12.2"
-    "@fluentui/react-shared-contexts" "^9.13.2"
-    "@fluentui/react-tabster" "^9.17.1"
+    "@fluentui/react-aria" "^9.7.3"
+    "@fluentui/react-context-selector" "^9.1.49"
+    "@fluentui/react-jsx-runtime" "^9.0.27"
+    "@fluentui/react-portal" "^9.4.10"
+    "@fluentui/react-positioning" "^9.12.4"
+    "@fluentui/react-shared-contexts" "^9.14.0"
+    "@fluentui/react-tabster" "^9.17.3"
     "@fluentui/react-theme" "^9.1.16"
-    "@fluentui/react-utilities" "^9.15.6"
+    "@fluentui/react-utilities" "^9.16.1"
     "@griffel/react" "^1.5.14"
     "@swc/helpers" "^0.5.1"
 
-"@fluentui/react-portal@^9.4.8":
-  version "9.4.8"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-portal/-/react-portal-9.4.8.tgz#8d632e502a8eea08c77e4f3fe04a9818719c484e"
-  integrity sha512-aXeoTBMi/+1lLOHD1e1InTZuVYUt8ZQ34IxXASaF4w7qbBHGeaCB9wMzSPu5d3jpUWhM1iRXVJngYdio5zFKsQ==
+"@fluentui/react-portal@^9.4.10":
+  version "9.4.10"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-portal/-/react-portal-9.4.10.tgz#cd82502e65381bfbc3a26240855fcae26b5d6a24"
+  integrity sha512-k8fTRv9wTPSPCuNBFE2HxIhXsVYoG6Azb6Ib2xaDK+nczoW2WbsmNmwBJGEGi8UKjIoQzV+95KsYQ9me+uqKPA==
   dependencies:
-    "@fluentui/react-shared-contexts" "^9.13.2"
-    "@fluentui/react-tabster" "^9.17.1"
-    "@fluentui/react-utilities" "^9.15.6"
+    "@fluentui/react-shared-contexts" "^9.14.0"
+    "@fluentui/react-tabster" "^9.17.3"
+    "@fluentui/react-utilities" "^9.16.1"
     "@griffel/react" "^1.5.14"
     "@swc/helpers" "^0.5.1"
     use-disposable "^1.0.1"
 
-"@fluentui/react-positioning@^9.12.2":
-  version "9.12.2"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-positioning/-/react-positioning-9.12.2.tgz#d43389f1acfa54ad7a061c5f275a3e2f292c5a14"
-  integrity sha512-lBlnyf3NAaX6bYq0PI5Ifie9/km68CtZywMvgHprZE9UkBZbGFwQLzemxQkAYoYhwXoebaQA5a5ODwDbUvwPWg==
+"@fluentui/react-positioning@^9.12.4":
+  version "9.12.4"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-positioning/-/react-positioning-9.12.4.tgz#338f1c092e1d6c6ff179e29bed9079176cd93289"
+  integrity sha512-qQAjHF/FJFs2TyK0x08t0iFtDQlGNGH0OFC3jrG1xIFEe3nFPoeYeNT3zxOmj+D7bvlcJTIITcoe++YQTnCf4w==
   dependencies:
     "@floating-ui/devtools" "0.2.1"
     "@floating-ui/dom" "^1.2.0"
-    "@fluentui/react-shared-contexts" "^9.13.2"
+    "@fluentui/react-shared-contexts" "^9.14.0"
     "@fluentui/react-theme" "^9.1.16"
-    "@fluentui/react-utilities" "^9.15.6"
+    "@fluentui/react-utilities" "^9.16.1"
     "@griffel/react" "^1.5.14"
     "@swc/helpers" "^0.5.1"
 
-"@fluentui/react-progress@^9.1.58":
-  version "9.1.58"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-progress/-/react-progress-9.1.58.tgz#4b2c9e21ecd50681e693dc4eb6cae00f9f9e5f87"
-  integrity sha512-eemljzCw/dIpyHVaeMtTep9gmoa43fJ91wJ29g9/u5ZkmIrtfbCkWmTtdk5NbnvSRQK1Kdk08dxZsIuzm/lbmA==
+"@fluentui/react-progress@^9.1.60":
+  version "9.1.60"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-progress/-/react-progress-9.1.60.tgz#702d08c16eae74354153a330fa3f678e8ad7801e"
+  integrity sha512-9wC7lWdo3S8rhxKWlIhcYAzsZNw+rL2HvNJTvEvFxXcOG7nJxP/3mGclV/jCCwDoPDnt9BT+40pGK84eD0BNIA==
   dependencies:
-    "@fluentui/react-field" "^9.1.48"
-    "@fluentui/react-jsx-runtime" "^9.0.25"
-    "@fluentui/react-shared-contexts" "^9.13.2"
+    "@fluentui/react-field" "^9.1.50"
+    "@fluentui/react-jsx-runtime" "^9.0.27"
+    "@fluentui/react-shared-contexts" "^9.14.0"
     "@fluentui/react-theme" "^9.1.16"
-    "@fluentui/react-utilities" "^9.15.6"
+    "@fluentui/react-utilities" "^9.16.1"
     "@griffel/react" "^1.5.14"
     "@swc/helpers" "^0.5.1"
 
-"@fluentui/react-provider@^9.13.6":
-  version "9.13.6"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-provider/-/react-provider-9.13.6.tgz#bc2a63f5ab50e8a2f5f72795378fc1ecfa0445a4"
-  integrity sha512-i7dDEc28xQKGD/5pFZYZEY+v/u2sGs5x8sTH/cuW0kA6PuU8OQxcwTtRo7NA1JoUWvPaRNJD+8AVhZmh/CZCpQ==
+"@fluentui/react-provider@^9.13.8":
+  version "9.13.8"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-provider/-/react-provider-9.13.8.tgz#aa0308ba8a6781a2e6f6edc2e23424fe6b8269f6"
+  integrity sha512-FCvDMjs/BNAcqJuHU+kN/lqLB2RDQ/LQo29ltfLKFlTR1nTUNJvPMOVhjj6eEt+t81628LOYhbbaXOj9rYtfGg==
   dependencies:
     "@fluentui/react-icons" "^2.0.224"
-    "@fluentui/react-jsx-runtime" "^9.0.25"
-    "@fluentui/react-shared-contexts" "^9.13.2"
-    "@fluentui/react-tabster" "^9.17.1"
+    "@fluentui/react-jsx-runtime" "^9.0.27"
+    "@fluentui/react-shared-contexts" "^9.14.0"
+    "@fluentui/react-tabster" "^9.17.3"
     "@fluentui/react-theme" "^9.1.16"
-    "@fluentui/react-utilities" "^9.15.6"
+    "@fluentui/react-utilities" "^9.16.1"
     "@griffel/core" "^1.14.1"
     "@griffel/react" "^1.5.14"
     "@swc/helpers" "^0.5.1"
 
-"@fluentui/react-radio@^9.2.1":
-  version "9.2.1"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-radio/-/react-radio-9.2.1.tgz#0abd3f3412ff129900a0c72d071221da8461ffd3"
-  integrity sha512-iw3QASrgfCaGkSCJDZ1KowJUIhj7eMAx91rOu1x3uzPUyRFo/P7nqYPWg+pTZmZdphjItCpcE4L09VxQ7+Y6tw==
+"@fluentui/react-radio@^9.2.3":
+  version "9.2.3"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-radio/-/react-radio-9.2.3.tgz#1fcf3cd8dee74a9b5e9470b856eef9e8acebdad2"
+  integrity sha512-8eKeUL0ZNr792Q6NGWPp7dpOV2IFcjAQ2oWR2/bruQVu8LMzYYKe2o6pQWdCag6UGPZuszkms9Xl7zPdDQBUdA==
   dependencies:
-    "@fluentui/react-field" "^9.1.48"
-    "@fluentui/react-jsx-runtime" "^9.0.25"
-    "@fluentui/react-label" "^9.1.56"
-    "@fluentui/react-shared-contexts" "^9.13.2"
-    "@fluentui/react-tabster" "^9.17.1"
+    "@fluentui/react-field" "^9.1.50"
+    "@fluentui/react-jsx-runtime" "^9.0.27"
+    "@fluentui/react-label" "^9.1.58"
+    "@fluentui/react-shared-contexts" "^9.14.0"
+    "@fluentui/react-tabster" "^9.17.3"
     "@fluentui/react-theme" "^9.1.16"
-    "@fluentui/react-utilities" "^9.15.6"
+    "@fluentui/react-utilities" "^9.16.1"
     "@griffel/react" "^1.5.14"
     "@swc/helpers" "^0.5.1"
 
-"@fluentui/react-select@^9.1.58":
-  version "9.1.58"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-select/-/react-select-9.1.58.tgz#123446a9b6e0dbaf8c863c82f0cf18d3b2e9a861"
-  integrity sha512-/4LBOZhAfKfus+6mf09fAAVZlHaKz9hawnRgYeENIC7/ZqWQe8ea5m+xZj9MTsjXzFLmdmzItuz6e360g0Xepg==
+"@fluentui/react-select@^9.1.60":
+  version "9.1.60"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-select/-/react-select-9.1.60.tgz#0fb7d5625de9cf0b3310e65375bd9670fbf30f0f"
+  integrity sha512-4HfRRTlGStOgtO00RY6jmOwz6MXnoa9gtjkV7StLmJZ2U5NTjVUrnp2dP1Vjb6hO13xaihWGEYyYKnsQ3R7kIw==
   dependencies:
-    "@fluentui/react-field" "^9.1.48"
+    "@fluentui/react-field" "^9.1.50"
     "@fluentui/react-icons" "^2.0.224"
-    "@fluentui/react-jsx-runtime" "^9.0.25"
-    "@fluentui/react-shared-contexts" "^9.13.2"
+    "@fluentui/react-jsx-runtime" "^9.0.27"
+    "@fluentui/react-shared-contexts" "^9.14.0"
     "@fluentui/react-theme" "^9.1.16"
-    "@fluentui/react-utilities" "^9.15.6"
+    "@fluentui/react-utilities" "^9.16.1"
     "@griffel/react" "^1.5.14"
     "@swc/helpers" "^0.5.1"
 
-"@fluentui/react-shared-contexts@^9.13.2":
-  version "9.13.2"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-shared-contexts/-/react-shared-contexts-9.13.2.tgz#45351ccf67d5bb5d362f74e4dfffa0a7b3c5dcca"
-  integrity sha512-78aEZdff7vaUOmeRyMDPc/Ml+kbwn02BiRLPQhqgYtCyjy0V3YBpmYfqxO8N5hUIZcFTedyOaHWpzVeEYxpNmA==
+"@fluentui/react-shared-contexts@^9.14.0":
+  version "9.14.0"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-shared-contexts/-/react-shared-contexts-9.14.0.tgz#b239bb969bcf26617a02b513d4863a2669242916"
+  integrity sha512-P9yhg31WYfB1W66/gD3+qVCLBsyIEcOzQvKVaIQvd9UhF67lNW4kMXUB6YVOk5PV0Og4hXnkH/vuHl7YMD9RHw==
   dependencies:
     "@fluentui/react-theme" "^9.1.16"
     "@swc/helpers" "^0.5.1"
 
-"@fluentui/react-skeleton@^9.0.46":
-  version "9.0.46"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-skeleton/-/react-skeleton-9.0.46.tgz#f2fd5ce6d06e5ebc462db952df61a2fb449a8c56"
-  integrity sha512-LshgVaBg1JjlzpgB5eUJZC965uX9nbEeXacFdxY+X9D457Hu68j+muNOUQ1RHB32ZrMIxukGfseWt0+Wz+j4QQ==
+"@fluentui/react-skeleton@^9.0.48":
+  version "9.0.48"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-skeleton/-/react-skeleton-9.0.48.tgz#e2148aa72353359e028f6c86dec60a0515c2fd9c"
+  integrity sha512-P0Rw5hIOn5CrZIWg7nVoK3gamxFhZI80KcRVaWap4O3gLo5C8nKHJWOtyBQZ5WKH+S6hoEGZ2USL6CoyXslxeQ==
   dependencies:
-    "@fluentui/react-field" "^9.1.48"
-    "@fluentui/react-jsx-runtime" "^9.0.25"
-    "@fluentui/react-shared-contexts" "^9.13.2"
+    "@fluentui/react-field" "^9.1.50"
+    "@fluentui/react-jsx-runtime" "^9.0.27"
+    "@fluentui/react-shared-contexts" "^9.14.0"
     "@fluentui/react-theme" "^9.1.16"
-    "@fluentui/react-utilities" "^9.15.6"
+    "@fluentui/react-utilities" "^9.16.1"
     "@griffel/react" "^1.5.14"
     "@swc/helpers" "^0.5.1"
 
-"@fluentui/react-slider@^9.1.63":
-  version "9.1.63"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-slider/-/react-slider-9.1.63.tgz#72c082168b8cad5ff706599380b4692a99401512"
-  integrity sha512-8toNPnd5HpM6TK/uxDTHmgznk4fw4AaSbIRBYGhnUpu5n+IbqIkEZ00q4Wb+/m2G7BOVYz2PTpv1NRRoaf0GGQ==
+"@fluentui/react-slider@^9.1.65":
+  version "9.1.65"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-slider/-/react-slider-9.1.65.tgz#03366dceacc898f321cdffab54212592b3670a46"
+  integrity sha512-7kuJMIojxCmNOuiRmQwh9iiXx8zwxkrgvsWmReRIBX0WB6w1VqMcuuikq2Z2ISgNPmepCX8W+qDfx8Ne4F/HtQ==
   dependencies:
-    "@fluentui/react-field" "^9.1.48"
-    "@fluentui/react-jsx-runtime" "^9.0.25"
-    "@fluentui/react-shared-contexts" "^9.13.2"
-    "@fluentui/react-tabster" "^9.17.1"
+    "@fluentui/react-field" "^9.1.50"
+    "@fluentui/react-jsx-runtime" "^9.0.27"
+    "@fluentui/react-shared-contexts" "^9.14.0"
+    "@fluentui/react-tabster" "^9.17.3"
     "@fluentui/react-theme" "^9.1.16"
-    "@fluentui/react-utilities" "^9.15.6"
+    "@fluentui/react-utilities" "^9.16.1"
     "@griffel/react" "^1.5.14"
     "@swc/helpers" "^0.5.1"
 
-"@fluentui/react-spinbutton@^9.2.58":
-  version "9.2.58"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-spinbutton/-/react-spinbutton-9.2.58.tgz#81e694a67bdef6abdf7a23a42be1039815081df6"
-  integrity sha512-5oheMykqKizeldgwNectm/n/JW9DsryVEiGdW4Ag59EZL9QP8534s33L4RyyHnq/ta2QBVycGZmKad2dC50wMw==
+"@fluentui/react-spinbutton@^9.2.60":
+  version "9.2.60"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-spinbutton/-/react-spinbutton-9.2.60.tgz#da653187f20b0ddbce369ebfdd42454459e0052b"
+  integrity sha512-0IIxEH0CTf4fNMoyvMa37bc63+0ZlznlsNy8lF3hujAT8Z9sUKVMH68e6tGUuXGJIkCUyDKU8HA+9FF2DyPvNA==
   dependencies:
     "@fluentui/keyboard-keys" "^9.0.7"
-    "@fluentui/react-field" "^9.1.48"
+    "@fluentui/react-field" "^9.1.50"
     "@fluentui/react-icons" "^2.0.224"
-    "@fluentui/react-jsx-runtime" "^9.0.25"
-    "@fluentui/react-shared-contexts" "^9.13.2"
+    "@fluentui/react-jsx-runtime" "^9.0.27"
+    "@fluentui/react-shared-contexts" "^9.14.0"
     "@fluentui/react-theme" "^9.1.16"
-    "@fluentui/react-utilities" "^9.15.6"
+    "@fluentui/react-utilities" "^9.16.1"
     "@griffel/react" "^1.5.14"
     "@swc/helpers" "^0.5.1"
 
-"@fluentui/react-spinner@^9.3.36":
-  version "9.3.36"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-spinner/-/react-spinner-9.3.36.tgz#c49b1980ea21c171b02f8b7c02f81fb9ee4ad584"
-  integrity sha512-t5+zKCa8ZIYDVdYNSGxisMjLCZgYJiRV8Gd+FYRnhK+WRKJFqGK/VYctEyJsf41FoEtKuK/lN6Y/sUq4xqhB2g==
+"@fluentui/react-spinner@^9.3.38":
+  version "9.3.38"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-spinner/-/react-spinner-9.3.38.tgz#3d52c555531b33da36e8df9b1e1cb62f80e53959"
+  integrity sha512-dPJr7/rgU2Qe/K2BciJTAEwEd0ytGpCw3VOVyK2T25w7Jw5RAHmgP+mbw+7se44Mr6sd1LH76mh5sfmQ3tODgw==
   dependencies:
-    "@fluentui/react-jsx-runtime" "^9.0.25"
-    "@fluentui/react-label" "^9.1.56"
-    "@fluentui/react-shared-contexts" "^9.13.2"
+    "@fluentui/react-jsx-runtime" "^9.0.27"
+    "@fluentui/react-label" "^9.1.58"
+    "@fluentui/react-shared-contexts" "^9.14.0"
     "@fluentui/react-theme" "^9.1.16"
-    "@fluentui/react-utilities" "^9.15.6"
+    "@fluentui/react-utilities" "^9.16.1"
     "@griffel/react" "^1.5.14"
     "@swc/helpers" "^0.5.1"
 
-"@fluentui/react-switch@^9.1.63":
-  version "9.1.63"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-switch/-/react-switch-9.1.63.tgz#1f3dc55d13aab1e473aa7664248f732a4eeaaffe"
-  integrity sha512-FmnaWyykRPKnQIfVICdRo6pcP4gQ85rHs/JDRwewgPrFOu00N/u2MvW4X7M1Kc0eMKyCDjgwKaSQJGyHVkXmaw==
+"@fluentui/react-switch@^9.1.65":
+  version "9.1.65"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-switch/-/react-switch-9.1.65.tgz#4900662f73e773db6a05e69af5b1cf40dad367ec"
+  integrity sha512-P0DwogD6hZJ3O005zCFPDoFXuzkrpKMrAeQGh9X0fqFP5JyHXVCgAAZQOLcphbbT9QukoEF5irN2Z4L9gBn57A==
   dependencies:
-    "@fluentui/react-field" "^9.1.48"
+    "@fluentui/react-field" "^9.1.50"
     "@fluentui/react-icons" "^2.0.224"
-    "@fluentui/react-jsx-runtime" "^9.0.25"
-    "@fluentui/react-label" "^9.1.56"
-    "@fluentui/react-shared-contexts" "^9.13.2"
-    "@fluentui/react-tabster" "^9.17.1"
+    "@fluentui/react-jsx-runtime" "^9.0.27"
+    "@fluentui/react-label" "^9.1.58"
+    "@fluentui/react-shared-contexts" "^9.14.0"
+    "@fluentui/react-tabster" "^9.17.3"
     "@fluentui/react-theme" "^9.1.16"
-    "@fluentui/react-utilities" "^9.15.6"
+    "@fluentui/react-utilities" "^9.16.1"
     "@griffel/react" "^1.5.14"
     "@swc/helpers" "^0.5.1"
 
-"@fluentui/react-table@^9.11.3":
-  version "9.11.3"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-table/-/react-table-9.11.3.tgz#c4771dffeebd39404302ec6ca905d8d8ee669fe5"
-  integrity sha512-RsRqvg1zGnNpSQO7xYTscc/YUsbF3Ir2EJj6d6GhZQMb7nf+EJJJLf6uP9hKMVCu8sK5JAhz+M17+9wDmnvlvQ==
+"@fluentui/react-table@^9.11.5":
+  version "9.11.5"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-table/-/react-table-9.11.5.tgz#a2a2f994c58b0fa209ceace8553e6a16c0e728b6"
+  integrity sha512-roQRITOtl1aqXlachS2oTraVE45x3KdDrX0KyQGCdcQRxNprXJW6dIK9QjlbAL6yAsAMDafmFA4y9uRxl408dQ==
   dependencies:
     "@fluentui/keyboard-keys" "^9.0.7"
-    "@fluentui/react-aria" "^9.7.1"
-    "@fluentui/react-avatar" "^9.6.7"
-    "@fluentui/react-checkbox" "^9.2.6"
-    "@fluentui/react-context-selector" "^9.1.47"
+    "@fluentui/react-aria" "^9.7.3"
+    "@fluentui/react-avatar" "^9.6.9"
+    "@fluentui/react-checkbox" "^9.2.8"
+    "@fluentui/react-context-selector" "^9.1.49"
     "@fluentui/react-icons" "^2.0.224"
-    "@fluentui/react-jsx-runtime" "^9.0.25"
-    "@fluentui/react-radio" "^9.2.1"
-    "@fluentui/react-shared-contexts" "^9.13.2"
-    "@fluentui/react-tabster" "^9.17.1"
+    "@fluentui/react-jsx-runtime" "^9.0.27"
+    "@fluentui/react-radio" "^9.2.3"
+    "@fluentui/react-shared-contexts" "^9.14.0"
+    "@fluentui/react-tabster" "^9.17.3"
     "@fluentui/react-theme" "^9.1.16"
-    "@fluentui/react-utilities" "^9.15.6"
+    "@fluentui/react-utilities" "^9.16.1"
     "@griffel/react" "^1.5.14"
     "@swc/helpers" "^0.5.1"
 
-"@fluentui/react-tabs@^9.4.4":
-  version "9.4.4"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-tabs/-/react-tabs-9.4.4.tgz#e14a842d93f464d8b4ce3a2e2c816bfbd077ed98"
-  integrity sha512-pboxo0Uxp7NIpwlybc0POAoQKt/SDSSYz8Y79wdxzEGr7IEXrj/q43GY7venkgN8vMQQ4RUyq62TrkS2KyPGTA==
+"@fluentui/react-tabs@^9.4.6":
+  version "9.4.6"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-tabs/-/react-tabs-9.4.6.tgz#2043725b52dc1d2b2311381c3898dc9f121d868b"
+  integrity sha512-LQvibLeJFyqKKiOjZUkRvbfLtsVosUhNUdh1SCQUPxQVpEPSK6XgwK0A1+jjoVhKn+PAJakxRINgnvqQD8pQBA==
   dependencies:
-    "@fluentui/react-context-selector" "^9.1.47"
-    "@fluentui/react-jsx-runtime" "^9.0.25"
-    "@fluentui/react-shared-contexts" "^9.13.2"
-    "@fluentui/react-tabster" "^9.17.1"
+    "@fluentui/react-context-selector" "^9.1.49"
+    "@fluentui/react-jsx-runtime" "^9.0.27"
+    "@fluentui/react-shared-contexts" "^9.14.0"
+    "@fluentui/react-tabster" "^9.17.3"
     "@fluentui/react-theme" "^9.1.16"
-    "@fluentui/react-utilities" "^9.15.6"
+    "@fluentui/react-utilities" "^9.16.1"
     "@griffel/react" "^1.5.14"
     "@swc/helpers" "^0.5.1"
 
-"@fluentui/react-tabster@^9.17.1":
-  version "9.17.1"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-tabster/-/react-tabster-9.17.1.tgz#6add90df4c046ab46737c44b9adf2e888ea1ea74"
-  integrity sha512-T3ETXTjZ196zeT1vTgI0/BlKyDXMwksZk9rhJySsrfHB9Zit9Y35HXF1GM+OqEVM4z5xW1ukEWq88R3mZ116tw==
+"@fluentui/react-tabster@^9.17.3":
+  version "9.17.3"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-tabster/-/react-tabster-9.17.3.tgz#54e11bda4b4f1276dbd81fc72f6594035c5b0d54"
+  integrity sha512-cFcUYrkGW15w5yXzCPTTVG/7x5kNXxnhQXuh8SPyCc9JZeG7XI3+hy1T37PsXGxNS4KN9ePHkBHzgDfYO4gzYQ==
   dependencies:
-    "@fluentui/react-shared-contexts" "^9.13.2"
+    "@fluentui/react-shared-contexts" "^9.14.0"
     "@fluentui/react-theme" "^9.1.16"
-    "@fluentui/react-utilities" "^9.15.6"
+    "@fluentui/react-utilities" "^9.16.1"
     "@griffel/react" "^1.5.14"
     "@swc/helpers" "^0.5.1"
     keyborg "^2.3.0"
     tabster "^5.0.1"
 
-"@fluentui/react-tags@^9.0.20":
-  version "9.0.20"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-tags/-/react-tags-9.0.20.tgz#0644ba46df4a8950742b469fca5d3de1c08437fe"
-  integrity sha512-BAT6iJCPj+0qmI9PSdXN2TwvlKdR2Hetl/oE6aNQJYrqRdqQu4dwBZuuqdH7Dc2ej86070fefBZu+xSZxnjptg==
+"@fluentui/react-tags@^9.0.22":
+  version "9.0.22"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-tags/-/react-tags-9.0.22.tgz#e346cf575e42f4631124181c10ced29fc3b15e79"
+  integrity sha512-gQIOCVu3HIfGjtAmwOnwBEnTsNyRBU8Pvs6EugpUyyqkRjzbm5TnL3LtiUy4f6/+NuaRqcYAvhwpdUhrlciwcA==
   dependencies:
     "@fluentui/keyboard-keys" "^9.0.7"
-    "@fluentui/react-aria" "^9.7.1"
-    "@fluentui/react-avatar" "^9.6.7"
+    "@fluentui/react-aria" "^9.7.3"
+    "@fluentui/react-avatar" "^9.6.9"
     "@fluentui/react-icons" "^2.0.224"
-    "@fluentui/react-jsx-runtime" "^9.0.25"
-    "@fluentui/react-shared-contexts" "^9.13.2"
-    "@fluentui/react-tabster" "^9.17.1"
+    "@fluentui/react-jsx-runtime" "^9.0.27"
+    "@fluentui/react-shared-contexts" "^9.14.0"
+    "@fluentui/react-tabster" "^9.17.3"
     "@fluentui/react-theme" "^9.1.16"
-    "@fluentui/react-utilities" "^9.15.6"
+    "@fluentui/react-utilities" "^9.16.1"
     "@griffel/react" "^1.5.14"
     "@swc/helpers" "^0.5.1"
 
-"@fluentui/react-text@^9.4.5":
-  version "9.4.5"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-text/-/react-text-9.4.5.tgz#f410a9e154696924edf3f4b04159cf45ead25952"
-  integrity sha512-t2Ixri15Q/cFXR+0p5vrqXTLo7dUZ0tdbyUSSWjSSqCqBFrfJAL1gVMFw8MfO88je/cpqU03DaYwFYezuI6CEw==
+"@fluentui/react-text@^9.4.7":
+  version "9.4.7"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-text/-/react-text-9.4.7.tgz#12056098f99e838e09bb48416be5c41c28d9f1a1"
+  integrity sha512-c6uJ98B35L8sviYxhQj1i+LW+HVNDdco2ImS9VLv/Duo4HiYs1G2y1YhtBDDiGxLe2moIvfg9ajDzMZV29aXFw==
   dependencies:
-    "@fluentui/react-jsx-runtime" "^9.0.25"
-    "@fluentui/react-shared-contexts" "^9.13.2"
+    "@fluentui/react-jsx-runtime" "^9.0.27"
+    "@fluentui/react-shared-contexts" "^9.14.0"
     "@fluentui/react-theme" "^9.1.16"
-    "@fluentui/react-utilities" "^9.15.6"
+    "@fluentui/react-utilities" "^9.16.1"
     "@griffel/react" "^1.5.14"
     "@swc/helpers" "^0.5.1"
 
-"@fluentui/react-textarea@^9.3.58":
-  version "9.3.58"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-textarea/-/react-textarea-9.3.58.tgz#93a67a401e34855df012e89714e41a41ebed4a28"
-  integrity sha512-YJRVCb50HK0WpmTBRUL7lUXOZhCzJpA7owFM3/pDOWIXGoVaXlvXcVSRYMIFSlJa4hMweGtlZncnY/9/r3+35w==
+"@fluentui/react-textarea@^9.3.60":
+  version "9.3.60"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-textarea/-/react-textarea-9.3.60.tgz#b4be0407f02f822165f9230988034e760a15d40d"
+  integrity sha512-wH4MBWT4EOgNH9FXTjcgH34oANUaoduhmVjffnxaPl3R767Ak0fZPG7kky7yrLMjTDUSwILsEj/q+hsN6o+7Ag==
   dependencies:
-    "@fluentui/react-field" "^9.1.48"
-    "@fluentui/react-jsx-runtime" "^9.0.25"
-    "@fluentui/react-shared-contexts" "^9.13.2"
+    "@fluentui/react-field" "^9.1.50"
+    "@fluentui/react-jsx-runtime" "^9.0.27"
+    "@fluentui/react-shared-contexts" "^9.14.0"
     "@fluentui/react-theme" "^9.1.16"
-    "@fluentui/react-utilities" "^9.15.6"
+    "@fluentui/react-utilities" "^9.16.1"
     "@griffel/react" "^1.5.14"
     "@swc/helpers" "^0.5.1"
 
@@ -2060,95 +2060,95 @@
     "@fluentui/tokens" "1.0.0-alpha.13"
     "@swc/helpers" "^0.5.1"
 
-"@fluentui/react-toast@^9.3.25":
-  version "9.3.25"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-toast/-/react-toast-9.3.25.tgz#3070733ced349a3fc83b698c06ae482c0b9b5318"
-  integrity sha512-CUVl1d4D8uvLt+yOyceJkbQSqC327gCQ4Ytr1uh3VogOMXIj0j3guAJ3MDGsRvGBRp6EoehrXFvIqCmgfkTQKA==
+"@fluentui/react-toast@^9.3.27":
+  version "9.3.27"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-toast/-/react-toast-9.3.27.tgz#e1a4b58dd2ccf652248238ddd36634031af7475e"
+  integrity sha512-DbRAYyL5Bd/pcFiGHPpK+rQMyc4LBll9YBy496l97dGDO2HmqFuiwP74V1KznxLcr4inCNWwThIJws5VLFsJLg==
   dependencies:
     "@fluentui/keyboard-keys" "^9.0.7"
-    "@fluentui/react-aria" "^9.7.1"
+    "@fluentui/react-aria" "^9.7.3"
     "@fluentui/react-icons" "^2.0.224"
-    "@fluentui/react-jsx-runtime" "^9.0.25"
-    "@fluentui/react-portal" "^9.4.8"
-    "@fluentui/react-shared-contexts" "^9.13.2"
-    "@fluentui/react-tabster" "^9.17.1"
+    "@fluentui/react-jsx-runtime" "^9.0.27"
+    "@fluentui/react-portal" "^9.4.10"
+    "@fluentui/react-shared-contexts" "^9.14.0"
+    "@fluentui/react-tabster" "^9.17.3"
     "@fluentui/react-theme" "^9.1.16"
-    "@fluentui/react-utilities" "^9.15.6"
+    "@fluentui/react-utilities" "^9.16.1"
     "@griffel/react" "^1.5.14"
     "@swc/helpers" "^0.5.1"
     react-transition-group "^4.4.1"
 
-"@fluentui/react-toolbar@^9.1.64":
-  version "9.1.64"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-toolbar/-/react-toolbar-9.1.64.tgz#9444061fb5094c035c96e0e02c68bb2a6e0bd587"
-  integrity sha512-zUjcqdn2Vf0AhstlMx35r75nKUuWM+sM0ox/fjd5WKSRLGjiJtgTIb3X5iRPBoRGLMyAchMrDRFDlhEwV13yBg==
+"@fluentui/react-toolbar@^9.1.66":
+  version "9.1.66"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-toolbar/-/react-toolbar-9.1.66.tgz#2124805360a3c187d905e958b2a27df5d46bfc09"
+  integrity sha512-ooNTp1R5MBZwiVK8fiJu29gE48vUx4NbXdwB2yHcCprasG3asjuoKQfOYM4+1NfFA0DetVrbK8L46IBeZyeBvA==
   dependencies:
-    "@fluentui/react-button" "^9.3.63"
-    "@fluentui/react-context-selector" "^9.1.47"
-    "@fluentui/react-divider" "^9.2.56"
-    "@fluentui/react-jsx-runtime" "^9.0.25"
-    "@fluentui/react-radio" "^9.2.1"
-    "@fluentui/react-shared-contexts" "^9.13.2"
-    "@fluentui/react-tabster" "^9.17.1"
+    "@fluentui/react-button" "^9.3.65"
+    "@fluentui/react-context-selector" "^9.1.49"
+    "@fluentui/react-divider" "^9.2.58"
+    "@fluentui/react-jsx-runtime" "^9.0.27"
+    "@fluentui/react-radio" "^9.2.3"
+    "@fluentui/react-shared-contexts" "^9.14.0"
+    "@fluentui/react-tabster" "^9.17.3"
     "@fluentui/react-theme" "^9.1.16"
-    "@fluentui/react-utilities" "^9.15.6"
+    "@fluentui/react-utilities" "^9.16.1"
     "@griffel/react" "^1.5.14"
     "@swc/helpers" "^0.5.1"
 
-"@fluentui/react-tooltip@^9.4.9":
-  version "9.4.9"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-tooltip/-/react-tooltip-9.4.9.tgz#46f836c2a3899e4eda6cd3072894933a733d6291"
-  integrity sha512-02KKSv23L1ZshmCQj7Zeol1V2Vh8cil75K+zVFFrBOpseUCzpC34ito6YXWNCxOr8CAlLpxZozEBzL8Fy7OjEQ==
+"@fluentui/react-tooltip@^9.4.11":
+  version "9.4.11"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-tooltip/-/react-tooltip-9.4.11.tgz#260b4ae30d410774b488636fa2ca858a613e862f"
+  integrity sha512-HXm8yYuAHJuczeFExco0WQSjO3DzDj5AJxqICHF8qtbtihUKfWpPnKM1qQWR+yJR2zc2jzvOEIzZXEkxSG+fSg==
   dependencies:
     "@fluentui/keyboard-keys" "^9.0.7"
-    "@fluentui/react-jsx-runtime" "^9.0.25"
-    "@fluentui/react-portal" "^9.4.8"
-    "@fluentui/react-positioning" "^9.12.2"
-    "@fluentui/react-shared-contexts" "^9.13.2"
-    "@fluentui/react-tabster" "^9.17.1"
+    "@fluentui/react-jsx-runtime" "^9.0.27"
+    "@fluentui/react-portal" "^9.4.10"
+    "@fluentui/react-positioning" "^9.12.4"
+    "@fluentui/react-shared-contexts" "^9.14.0"
+    "@fluentui/react-tabster" "^9.17.3"
     "@fluentui/react-theme" "^9.1.16"
-    "@fluentui/react-utilities" "^9.15.6"
+    "@fluentui/react-utilities" "^9.16.1"
     "@griffel/react" "^1.5.14"
     "@swc/helpers" "^0.5.1"
 
-"@fluentui/react-tree@^9.4.23":
-  version "9.4.23"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-tree/-/react-tree-9.4.23.tgz#5d17cbdc549ea67038bb92067b7e9dde6d5067a8"
-  integrity sha512-ehccDPZUywGavPlgH6AbNnOXKp40VlTOVkDSS7k3j3eImFcK28yjy46IUB5YblUZPdU6QMXop3CkJX2/Q8fR3g==
+"@fluentui/react-tree@^9.4.25":
+  version "9.4.25"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-tree/-/react-tree-9.4.25.tgz#5c251d9733fdbb0662ed30402afbdfc0b763fd1f"
+  integrity sha512-7IMqnOiNFMRuPujnbxJUYD8AEh0z1OGXkdNkAeLyj3pkwuvQs9+TbaNtv5Z372YN+kwYF4EYalYcPuNsRlx7cQ==
   dependencies:
     "@fluentui/keyboard-keys" "^9.0.7"
-    "@fluentui/react-aria" "^9.7.1"
-    "@fluentui/react-avatar" "^9.6.7"
-    "@fluentui/react-button" "^9.3.63"
-    "@fluentui/react-checkbox" "^9.2.6"
-    "@fluentui/react-context-selector" "^9.1.47"
+    "@fluentui/react-aria" "^9.7.3"
+    "@fluentui/react-avatar" "^9.6.9"
+    "@fluentui/react-button" "^9.3.65"
+    "@fluentui/react-checkbox" "^9.2.8"
+    "@fluentui/react-context-selector" "^9.1.49"
     "@fluentui/react-icons" "^2.0.224"
-    "@fluentui/react-jsx-runtime" "^9.0.25"
-    "@fluentui/react-radio" "^9.2.1"
-    "@fluentui/react-shared-contexts" "^9.13.2"
-    "@fluentui/react-tabster" "^9.17.1"
+    "@fluentui/react-jsx-runtime" "^9.0.27"
+    "@fluentui/react-radio" "^9.2.3"
+    "@fluentui/react-shared-contexts" "^9.14.0"
+    "@fluentui/react-tabster" "^9.17.3"
     "@fluentui/react-theme" "^9.1.16"
-    "@fluentui/react-utilities" "^9.15.6"
+    "@fluentui/react-utilities" "^9.16.1"
     "@griffel/react" "^1.5.14"
     "@swc/helpers" "^0.5.1"
 
-"@fluentui/react-utilities@^9.15.6":
-  version "9.15.6"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-utilities/-/react-utilities-9.15.6.tgz#ddc01fc63cfef0388f54f9d0b87b7ab04eece094"
-  integrity sha512-Hli0iiA/gaWwADMe7NRD6TSy7KvL3bgek8j1sYkE9BiUI89GqyfJwU2Tm0it04iiCYvQ5WWrXPcRYyZ3/MHtpA==
+"@fluentui/react-utilities@^9.16.1":
+  version "9.16.1"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-utilities/-/react-utilities-9.16.1.tgz#75cd865d3584af1ca7e5ac6b9cce9f558fb17b2c"
+  integrity sha512-2wdwmgTFcVy14ZLbRNJ8Q6dCCBLekkJ8Znnok68gKRLDcwpPT3UjSraoU+DGjOA5BMfPppZBU8Yb5GqdIfd48g==
   dependencies:
     "@fluentui/keyboard-keys" "^9.0.7"
-    "@fluentui/react-shared-contexts" "^9.13.2"
+    "@fluentui/react-shared-contexts" "^9.14.0"
     "@swc/helpers" "^0.5.1"
 
-"@fluentui/react-virtualizer@9.0.0-alpha.64":
-  version "9.0.0-alpha.64"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-virtualizer/-/react-virtualizer-9.0.0-alpha.64.tgz#5ae058c7eb95c079799b6a4635127da684906701"
-  integrity sha512-QEoBUI6FMwWhG6U4688SbSCtRFV2nuqpM9O2+5QWhzv+TTdPj0VGHqEOBy0XmsNot/UivusNfi94AVQ3s4aSTA==
+"@fluentui/react-virtualizer@9.0.0-alpha.66":
+  version "9.0.0-alpha.66"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-virtualizer/-/react-virtualizer-9.0.0-alpha.66.tgz#e52194a08a3051f179c605386e2c72c12644b17b"
+  integrity sha512-x/ZOAIAwctt7pvOBIzS4iZGU0ahiPhQFS7iAHksFkF9LimneaV92A/02dW0Cy4v7dv9wZNoosQwhS05Yx3DVDQ==
   dependencies:
-    "@fluentui/react-jsx-runtime" "^9.0.25"
-    "@fluentui/react-shared-contexts" "^9.13.2"
-    "@fluentui/react-utilities" "^9.15.6"
+    "@fluentui/react-jsx-runtime" "^9.0.27"
+    "@fluentui/react-shared-contexts" "^9.14.0"
+    "@fluentui/react-utilities" "^9.16.1"
     "@griffel/react" "^1.5.14"
     "@swc/helpers" "^0.5.1"
 


### PR DESCRIPTION
1. Bumps `@fluentui/react-components` to 9.45.0 (the actual required release is 9.44.5 [Release](https://github.com/microsoft/fluentui/releases/tag/%40fluentui%2Freact-components_v9.44.5)), as https://github.com/microsoft/fluentui/pull/30322 is required by `react-tree-grid`
2. Bumps `@fluentui/react-utilities` to 9.16.0 ([Release](https://github.com/microsoft/fluentui/releases/tag/%40fluentui%2Freact-utilities_v9.16.0))