### PR TITLE
feat(nx-plugin): redo playwright executor/generator setup to accept all nx flags and make it work

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -3,6 +3,7 @@
     "nrwl.angular-console",
     "esbenp.prettier-vscode",
     "dbaeumer.vscode-eslint",
-    "firsttris.vscode-jest-runner"
+    "firsttris.vscode-jest-runner",
+    "ms-playwright.playwright"
   ]
 }

--- a/nx.json
+++ b/nx.json
@@ -41,7 +41,7 @@
     },
     "component-test": {
       "cache": true,
-      "inputs": ["default", "^production",  "{projectRoot}/playwright.config.ts"]
+      "inputs": ["default", "^production", "{projectRoot}/playwright.config.ts"]
     }
   },
   "namedInputs": {

--- a/nx.json
+++ b/nx.json
@@ -38,6 +38,10 @@
     },
     "type-check": {
       "dependsOn": ["^type-check"]
+    },
+    "component-test": {
+      "cache": true,
+      "inputs": ["default", "^production",  "{projectRoot}/playwright.config.ts"]
     }
   },
   "namedInputs": {

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "eslint": "8.48.0",
     "eslint-config-prettier": "9.1.0",
     "eslint-plugin-import": "^2.27.5",
+    "eslint-plugin-playwright": "^0.15.3",
     "jest": "^29.4.1",
     "jest-environment-jsdom": "^29.4.1",
     "jsonc-eslint-parser": "^2.1.0",

--- a/packages/nx-plugin/src/executors/playwright/executor.ts
+++ b/packages/nx-plugin/src/executors/playwright/executor.ts
@@ -1,7 +1,14 @@
-import { execSync } from 'child_process';
-import { ExecutorContext } from '@nx/devkit';
-import { PlaywrightExecutorSchema } from './schema';
+import { execSync, fork } from 'node:child_process';
+import {
+  type ExecutorContext,
+  getPackageManagerCommand,
+  names,
+  output,
+  workspaceRoot,
+} from '@nx/devkit';
 import { playwrightExecutor } from '@nx/playwright';
+
+import { type PlaywrightExecutorSchema } from './schema';
 
 export default async function runExecutor(
   options: PlaywrightExecutorSchema,
@@ -11,19 +18,112 @@ export default async function runExecutor(
     return playwrightExecutor(options, context);
   }
 
+  return playwrightCTExecutor(options, context);
+}
+
+/**
+ *
+ * Most of this code is copied from https://github.com/nrwl/nx/blob/master/packages/playwright/src/executors/playwright/playwright.impl.ts
+ */
+function playwrightCTExecutor(
+  options: PlaywrightExecutorSchema,
+  context: ExecutorContext
+) {
   if (!context.projectsConfigurations || !context.projectName) {
     throw new Error('no project configurations');
   }
 
-  const { root } = context.projectsConfigurations.projects[context.projectName];
+  const projectRoot =
+    context.projectsConfigurations.projects[context.projectName].root;
 
-  if (!root) {
-    throw new Error('No root root found in projects configurations');
+  if (!projectRoot) {
+    throw new Error(
+      `Unable to find the Project Root for ${context.projectName}. Is it set in the project.json?`
+    );
   }
 
-  execSync(`npx playwright test`, { cwd: root });
+  if (!options.skipInstall) {
+    output.log({
+      title: 'Ensuring Playwright is installed.',
+      bodyLines: ['use --skipInstall to skip installation.'],
+    });
+    const pmc = getPackageManagerCommand();
+    execSync(`${pmc.exec} playwright install`, {
+      cwd: workspaceRoot,
+      stdio: 'inherit',
+    });
+  }
 
-  return {
-    success: true,
-  };
+  const args = createArgs(options);
+
+  const childProcess = runPlaywright(args, context.root);
+  childProcess.stdout?.on('data', (message) => {
+    process.stdout.write(message);
+  });
+  childProcess.stderr?.on('data', (message) => {
+    process.stderr.write(message);
+  });
+
+  return new Promise<{ success: boolean }>((resolve) => {
+    childProcess.on('close', (code) => {
+      resolve({ success: code === 0 });
+    });
+  });
+}
+
+/**
+ *
+ * Most of this code is copied from https://github.com/nrwl/nx/blob/master/packages/playwright/src/executors/playwright/playwright.impl.ts
+ */
+function createArgs(
+  opts: PlaywrightExecutorSchema,
+  exclude: string[] = ['skipInstall', 'testingType']
+): string[] {
+  const args: string[] = [];
+
+  const { testFiles, ...rest } = opts;
+  if (testFiles) {
+    args.push(...testFiles);
+  }
+
+  for (const key in rest) {
+    if (exclude.includes(key)) continue;
+
+    const value = opts[key as keyof typeof rest];
+    // NOTE: playwright doesn't accept pascalCase args, only kebab-case
+    const arg = names(key).fileName;
+
+    if (Array.isArray(value)) {
+      args.push(...value.map((v) => `--${arg}=${v.trim()}`));
+    } else if (typeof value === 'boolean') {
+      // NOTE: playwright don't accept --arg=false, instead just don't pass the arg.
+      if (value) {
+        args.push(`--${arg}`);
+      }
+    } else {
+      args.push(`--${arg}=${value}`);
+    }
+  }
+
+  return args;
+}
+
+/**
+ *
+ * Most of this code is copied from https://github.com/nrwl/nx/blob/master/packages/playwright/src/executors/playwright/playwright.impl.ts
+ */
+function runPlaywright(args: string[], cwd: string) {
+  try {
+    const cli = require.resolve('@playwright/experimental-ct-core/cli');
+
+    return fork(cli, ['test', ...args], {
+      stdio: ['pipe', 'pipe', 'pipe', 'ipc'],
+      cwd,
+    });
+  } catch (e) {
+    console.error(e);
+    throw new Error(
+      'Unable to run playwright component tests. Is @playwright/experimental-ct-core installed?'
+    );
+  }
 }

--- a/packages/nx-plugin/src/executors/playwright/schema.d.ts
+++ b/packages/nx-plugin/src/executors/playwright/schema.d.ts
@@ -5,4 +5,55 @@ export interface PlaywrightExecutorSchema extends NxPlaywrightExecutorSchema {
    * @default 'component'
    */
   testingType: 'component' | 'e2e';
+
+  // ============ BELOW API COPIED FROM https://github.com/nrwl/nx/blob/master/packages/playwright/src/executors/playwright/playwright.impl.ts ============
+
+  /*
+   * if 'projects' is configured then that name needs to be provided instead of
+   * all, chromium, firefox, webkit
+   **/
+  browser?: 'all' | 'chromium' | 'firefox' | 'webkit' | string;
+  config?: string;
+  debug?: boolean;
+  forbidOnly?: boolean;
+  fullyParallel?: boolean;
+  grep?: string;
+  globalTimeout?: number;
+  grepInvert?: string;
+  testFiles?: string[];
+  headed?: boolean;
+  ignoreSnapshots?: boolean;
+  workers?: string;
+  list?: boolean;
+  maxFailures?: number | boolean;
+  noDeps?: boolean;
+  output?: string;
+  passWithNoTests?: boolean;
+  project?: string[];
+  quiet?: boolean;
+  repeatEach?: number;
+  reporter?:
+    | 'list'
+    | 'line'
+    | 'dot'
+    | 'json'
+    | 'junit'
+    | 'null'
+    | 'github'
+    | 'html'
+    | 'blob';
+  retries?: number;
+  shard?: string;
+  timeout?: number;
+  trace?:
+    | 'on'
+    | 'off'
+    | 'on-first-retry'
+    | 'on-all-retries'
+    | 'retain-on-failure';
+  updateSnapshots?: boolean;
+  ui?: boolean;
+  uiHost?: string;
+  uiPort?: string;
+  skipInstall?: boolean;
 }

--- a/packages/nx-plugin/src/executors/playwright/schema.json
+++ b/packages/nx-plugin/src/executors/playwright/schema.json
@@ -11,7 +11,7 @@
       "enum": ["component", "e2e"],
       "default": "component"
     },
-     "browser": {
+    "browser": {
       "type": "string",
       "description": "Browser to use for tests, one of 'all', 'chromium', 'firefox' or 'webkit'. If a playwright config is provided/discovered then the browserName value is expected from the configured 'projects'",
       "x-priority": "important"

--- a/packages/nx-plugin/src/executors/playwright/schema.json
+++ b/packages/nx-plugin/src/executors/playwright/schema.json
@@ -10,6 +10,164 @@
       "description": "Specify the type of tests to execute.",
       "enum": ["component", "e2e"],
       "default": "component"
+    },
+     "browser": {
+      "type": "string",
+      "description": "Browser to use for tests, one of 'all', 'chromium', 'firefox' or 'webkit'. If a playwright config is provided/discovered then the browserName value is expected from the configured 'projects'",
+      "x-priority": "important"
+    },
+    "config": {
+      "type": "string",
+      "description": "Configuration file, or a test directory with optional",
+      "x-completion-type": "file",
+      "x-completion-glob": "playwright?(*)@(.js|.cjs|.mjs|.ts|.cts|.mtx)",
+      "x-priority": "important"
+    },
+    "debug": {
+      "type": "boolean",
+      "description": "Run tests with Playwright Inspector. Shortcut for 'PWDEBUG=1' environment variable and '--timeout=0',--max-failures=1 --headed --workers=1' options"
+    },
+    "forbidOnly": {
+      "type": "boolean",
+      "description": "Fail if test.only is called"
+    },
+    "fullyParallel": {
+      "type": "boolean",
+      "description": "Run all tests in parallel"
+    },
+    "grep": {
+      "alias": "g",
+      "type": "string",
+      "description": "Only run tests matching this regular expression"
+    },
+    "globalTimeout": {
+      "type": "number",
+      "description": "Maximum time this test suite can run in milliseconds"
+    },
+    "grepInvert": {
+      "alias": "gv",
+      "type": "string",
+      "description": "Only run tests that do not match this regular expression"
+    },
+    "testFiles": {
+      "alias": "t",
+      "type": "array",
+      "description": "Test files to run",
+      "items": {
+        "type": "string"
+      }
+    },
+    "headed": {
+      "type": "boolean",
+      "description": "Run tests in headed browsers",
+      "x-priority": "important"
+    },
+    "ignoreSnapshots": {
+      "type": "boolean",
+      "description": "Ignore screenshot and snapshot expectations"
+    },
+    "workers": {
+      "alias": "j",
+      "type": "string",
+      "description": "Number of concurrent workers or percentage of logical CPU cores, use 1 to run in a single worker"
+    },
+    "list": {
+      "type": "boolean",
+      "description": "Collect all the tests and report them, but do not run"
+    },
+    "maxFailures": {
+      "alias": "x",
+      "oneOf": [{ "type": "number" }, { "type": "boolean" }],
+      "description": "Stop after the first N failures"
+    },
+    "noDeps": {
+      "type": "boolean",
+      "description": "Do not run project dependencies"
+    },
+    "output": {
+      "type": "string",
+      "description": "Folder for output artifacts"
+    },
+    "passWithNoTests": {
+      "type": "boolean",
+      "description": "Makes test run succeed even if no tests were found",
+      "default": true
+    },
+    "project": {
+      "description": "Only run tests from the specified list of projects",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "quiet": {
+      "alias": "q",
+      "type": "boolean",
+      "description": "Suppress stdio"
+    },
+    "repeatEach": {
+      "type": "number",
+      "description": "Run each test N times"
+    },
+    "reporter": {
+      "type": "string",
+      "enum": [
+        "list",
+        "line",
+        "dot",
+        "json",
+        "junit",
+        "null",
+        "github",
+        "html",
+        "blob"
+      ],
+      "description": "Reporter to use, comma-separated, can be 'list', 'line', 'dot', 'json', 'junit', 'null', 'github', 'html', 'blob'. To configure reporter options, use the playwright configuration."
+    },
+    "retries": {
+      "type": "number",
+      "description": "Maximum retry count for flaky tests, zero for no retries"
+    },
+    "shard": {
+      "type": "string",
+      "description": "Shard tests and execute only the selected shard, specify in the form 'current/all', 1-based, for example '3/5'"
+    },
+    "timeout": {
+      "type": "number",
+      "description": "Specify test timeout threshold in milliseconds, zero for unlimited"
+    },
+    "trace": {
+      "type": "string",
+      "enum": [
+        "on",
+        "off",
+        "on-first-retry",
+        "on-all-retries",
+        "retain-on-failure"
+      ],
+      "description": "Force tracing mode, can be 'on', 'off', 'on-first-retry', 'on-all-retries', 'retain-on-failure'"
+    },
+    "updateSnapshots": {
+      "alias": "u",
+      "type": "boolean",
+      "description": "Update snapshots with actual results. Snapshots will be created if missing."
+    },
+    "ui": {
+      "type": "boolean",
+      "description": "Run tests in interactive UI mode"
+    },
+    "uiHost": {
+      "type": "string",
+      "description": "Host to serve UI on; specifying this option opens UI in a browser tab"
+    },
+    "uiPort": {
+      "type": "string",
+      "description": "Port to serve UI on, 0 for any free port; specifying this option opens UI in a browser tab"
+    },
+    "skipInstall": {
+      "type": "boolean",
+      "description": "Skip running playwright install before running playwright tests. This is to ensure that playwright browsers are installed before running tests.",
+      "default": false
     }
   },
   "required": []

--- a/packages/nx-plugin/src/generators/playwright-component-configuration/files/playwright.config.ts.template
+++ b/packages/nx-plugin/src/generators/playwright-component-configuration/files/playwright.config.ts.template
@@ -1,6 +1,12 @@
 import { defineConfig, devices } from '@playwright/experimental-ct-react';
 
 /**
+ * Read environment variables from file.
+ * https://github.com/motdotla/dotenv
+ */
+// require('dotenv').config();
+
+/**
  * See https://playwright.dev/docs/test-configuration.
  */
 export default defineConfig({

--- a/packages/nx-plugin/src/generators/playwright-component-configuration/generator.spec.ts
+++ b/packages/nx-plugin/src/generators/playwright-component-configuration/generator.spec.ts
@@ -25,7 +25,7 @@ describe('playwright-component-configuration generator', () => {
     await libraryGenerator(tree, { name: 'hello', owner: '@MrWick' });
   });
 
-  it.only('should generate playwright config for component testing', async () => {
+  it('should generate playwright config for component testing', async () => {
     await generator(tree, options);
     const config = readProjectConfiguration(tree, 'hello');
 
@@ -40,8 +40,6 @@ describe('playwright-component-configuration generator', () => {
     expect(
       tree.exists(joinPathFragments(config.root, 'playwright.config.ts'))
     ).toBe(true);
-
-    console.log(config.targets);
 
     expect(config.targets?.['component-test']).toMatchInlineSnapshot(`
       {

--- a/packages/nx-plugin/src/generators/playwright-component-configuration/generator.ts
+++ b/packages/nx-plugin/src/generators/playwright-component-configuration/generator.ts
@@ -4,20 +4,67 @@ import {
   Tree,
   updateProjectConfiguration,
   readProjectConfiguration,
+  joinPathFragments,
+  ProjectConfiguration,
+  updateJson,
 } from '@nx/devkit';
 import * as path from 'path';
 import { PlaywrightComponentConfigurationGeneratorSchema } from './schema';
+
+interface Options extends PlaywrightComponentConfigurationGeneratorSchema {
+  projectConfig: ProjectConfiguration;
+}
 
 export default async function (
   tree: Tree,
   options: PlaywrightComponentConfigurationGeneratorSchema
 ) {
-  const config = readProjectConfiguration(tree, options.name);
+  const projectConfig = readProjectConfiguration(tree, options.name);
+
+  const normalizedOptions: Options = { projectConfig, ...options };
+
+  generateFiles(
+    tree,
+    path.join(__dirname, 'files'),
+    projectConfig.root,
+    options
+  );
+
+  addComponentTestTarget(tree, normalizedOptions);
+
+  addExtendsToLintConfig(tree, normalizedOptions);
+
+  await formatFiles(tree);
+}
+
+function addExtendsToLintConfig(tree: Tree, options: Options) {
+  const fileName = joinPathFragments(
+    options.projectConfig.root,
+    '.eslintrc.json'
+  );
+  updateJson(tree, fileName, (json) => {
+    json.overrides ??= [];
+    json.overrides.push({
+      files: ['src/**/*.spec.{ts,js,tsx,jsx}'],
+      extends: ['plugin:playwright/recommended'],
+      rules: {},
+    });
+
+    return json;
+  });
+}
+
+function addComponentTestTarget(tree: Tree, options: Options) {
+  const config = options.projectConfig;
 
   const targetDefinition = {
     executor: '@fluentui-contrib/nx-plugin:playwright',
     options: {
       testingType: 'component',
+      outputs: [`{workspaceRoot}/dist/.playwright/${config.root}`],
+      options: {
+        config: `${config.root}/playwright.config.ts`,
+      },
     },
   };
 
@@ -25,7 +72,4 @@ export default async function (
   config.targets['component-test'] = targetDefinition;
 
   updateProjectConfiguration(tree, options.name, { ...config });
-
-  generateFiles(tree, path.join(__dirname, 'files'), config.root, options);
-  await formatFiles(tree);
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7362,6 +7362,11 @@ eslint-plugin-import@^2.27.5:
     semver "^6.3.0"
     tsconfig-paths "^3.14.1"
 
+eslint-plugin-playwright@^0.15.3:
+  version "0.15.3"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-playwright/-/eslint-plugin-playwright-0.15.3.tgz#9fd8753688351bcaf41797eb6a7df8807fd5eb1b"
+  integrity sha512-LQMW5y0DLK5Fnpya7JR1oAYL2/7Y9wDiYw6VZqlKqcRGSgjbVKNqxraphk7ra1U3Bb5EK444xMgUlQPbMg2M1g==
+
 eslint-plugin-react-hooks@^4.3.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.0.tgz#4c3e697ad95b77e93f8646aaa1630c1ba607edd3"


### PR DESCRIPTION
**Before:**
our custom playwright executor wasn't working before.

**After:**

After detailed analysis of core nx/playwright plugin I realized that there are various additional gymnastics that need to happen which goes beyond simple `execSync` call.

Most of the implementation was copied from nx/playwright with our custom API modification + pointing to proper CLI for component test.

Last but not least CI needs to install playwright browsers so our executor will now handle this behind the scenes.

Generator was tweaked to incorporate new target changes including eslint setup to follow playwright best practices

## Related issues:

Follows https://github.com/microsoft/fluentui-contrib/pull/95