### PR TITLE
chore(react-tree-grid): add role="application" on decorator

### DIFF
--- a/packages/react-tree-grid/.storybook/preview.tsx
+++ b/packages/react-tree-grid/.storybook/preview.tsx
@@ -8,7 +8,13 @@ const preview: Preview = {
   decorators: [
     (Story) => (
       <FluentProvider theme={webLightTheme}>
-        <Story />
+        {/*
+          TreeGrid must be wrapped around role="application",
+          to avoid some errors on JAWS
+        */}
+        <div role="application">
+          <Story />
+        </div>
       </FluentProvider>
     ),
   ],


### PR DESCRIPTION
1. Adds `role="application"` on decorator to avoid issues with JAWS, seems like treegrid examples have to be wrapped around `role="application"`