### PR TITLE
feat(react-data-grid-react-window-grid): use VaraiableSizeGrid for body and VariableSizeList for header

### DIFF
--- a/change/@fluentui-contrib-react-data-grid-react-window-grid-746c1842-7b7b-4440-9d26-b7bcb5babe31.json
+++ b/change/@fluentui-contrib-react-data-grid-react-window-grid-746c1842-7b7b-4440-9d26-b7bcb5babe31.json
@@ -1,0 +1,7 @@
+{
+  "type": "major",
+  "comment": "feat(react-data-grid-react-window-grid) use VaraiableSizeGrid for body and VariableSizeList for header",
+  "packageName": "@fluentui-contrib/react-data-grid-react-window-grid",
+  "email": "fengqi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-data-grid-react-window-grid/README.md
+++ b/packages/react-data-grid-react-window-grid/README.md
@@ -1,7 +1,7 @@
 # react-data-grid-react-window-grid
 
 A variant of the Fluent UI [DataGrid](https://react.fluentui.dev/?path=/docs/components-datagrid--default) that is
-virtualized 2 dimentionally using [react-window](https://react-window.vercel.app/#/examples/grid/fixed-size).
+virtualized 2 dimentionally using [react-window](https://react-window.vercel.app/#/examples/grid/variable-size).
 
 ## Building
 
@@ -10,8 +10,8 @@ Run `nx build react-data-grid-react-window-grid` to build the library.
 ## What is different from `react-data-grid-react-window`?
 
 - `react-data-grid-react-window` support vertical virtualization using FixedSizeList in react-window
-- `react-data-grid-react-window-grid` support 2 dimentional virtualization (including both horizontal and vertical) using FixedSizeGrid in react-window.
-- `react-data-grid-react-window-grid` has a virtualized header as well using FixedSizeList in react-window
+- `react-data-grid-react-window-grid` support 2 dimentional virtualization (including both horizontal and vertical) using VariableSizeGrid in react-window.
+- `react-data-grid-react-window-grid` has a virtualized header as well using VariableSizeList in react-window
 
 ## `DataGridHeaderRow`
 

--- a/packages/react-data-grid-react-window-grid/src/components/DataGrid/renderDataGrid.tsx
+++ b/packages/react-data-grid-react-window-grid/src/components/DataGrid/renderDataGrid.tsx
@@ -5,7 +5,7 @@ import {
   DataGridContextValues,
 } from '@fluentui/react-components';
 import { HeaderListRefContextProvider } from '../../contexts/headerListRefContext';
-import { FixedSizeGrid, FixedSizeList } from 'react-window';
+import { VariableSizeGrid, VariableSizeList } from 'react-window';
 import { BodyRefContextProvider } from '../../contexts/bodyRefContext';
 /**
  * Render the final JSX of DataGrid
@@ -14,8 +14,8 @@ export const renderDataGrid_unstable = (
   state: DataGridState,
   contextValues: DataGridContextValues
 ) => {
-  const headerRef = React.useRef<FixedSizeList>(null);
-  const bodyRef = React.useRef<FixedSizeGrid>(null);
+  const headerRef = React.useRef<VariableSizeList>(null);
+  const bodyRef = React.useRef<VariableSizeGrid>(null);
   return (
     <HeaderListRefContextProvider value={headerRef}>
       <BodyRefContextProvider value={bodyRef}>

--- a/packages/react-data-grid-react-window-grid/src/components/DataGridBody/DataGridBody.types.ts
+++ b/packages/react-data-grid-react-window-grid/src/components/DataGridBody/DataGridBody.types.ts
@@ -8,8 +8,8 @@ import type {
   TableColumnDefinition,
 } from '@fluentui/react-components';
 import {
-  FixedSizeGrid,
-  FixedSizeGridProps,
+  VariableSizeGrid,
+  VariableSizeGridProps,
   GridChildComponentProps,
 } from 'react-window';
 
@@ -36,13 +36,13 @@ export type DataGridBodyProps<TItem = unknown> = Omit<
   'children'
 > & {
   /**
-   * The size of each row, rowHeight
+   * Returns the height of the specified row.
    */
-  rowHeight: number;
+  rowHeight: (index: number) => number;
   /**
-   * The width per column
+   * Returns the width of the specified column.
    */
-  columnWidth: number;
+  columnWidth: (index: number) => number;
   /**
    * The height of the virtualized container
    */
@@ -64,11 +64,11 @@ export type DataGridBodyProps<TItem = unknown> = Omit<
   ariaRowIndexStart?: number;
 
   /**
-   * Optional props to pass through to the FixedSizeGrid component from react-window
+   * Optional props to pass through to the VariableSizeGridProps component from react-window
    *
-   * @see https://react-window.vercel.app/#/api/FixedSizeGrid
+   * @see https://react-window.vercel.app/#/api/VariableSizeGrid
    */
-  gridProps?: Partial<FixedSizeGridProps>;
+  gridProps?: Partial<VariableSizeGridProps>;
 };
 
 /**
@@ -82,10 +82,10 @@ export type DataGridBodyState = Omit<DataGridBodyStateBase, 'renderRow'> &
       props: GridChildComponentProps<TableRowData<unknown>[]>
     ) => React.ReactElement;
   } & {
-    gridProps?: Partial<FixedSizeGridProps>;
+    gridProps?: Partial<VariableSizeGridProps>;
 
     /**
      * Ref of the virtualized list container ref
      */
-    gridRef: React.RefObject<FixedSizeGrid>;
+    gridRef: React.RefObject<VariableSizeGrid>;
   };

--- a/packages/react-data-grid-react-window-grid/src/components/DataGridBody/renderDataGridBody.tsx
+++ b/packages/react-data-grid-react-window-grid/src/components/DataGridBody/renderDataGridBody.tsx
@@ -4,7 +4,7 @@ import type {
   DataGridBodyState,
   DataGridBodySlots,
 } from './DataGridBody.types';
-import { FixedSizeGrid as Grid } from 'react-window';
+import { VariableSizeGrid as Grid } from 'react-window';
 
 /**
  * Render the final JSX of DataGridVirtualizedBody

--- a/packages/react-data-grid-react-window-grid/src/components/DataGridHeaderRow/DataGridHeaderRow.types.ts
+++ b/packages/react-data-grid-react-window-grid/src/components/DataGridHeaderRow/DataGridHeaderRow.types.ts
@@ -5,8 +5,8 @@ import {
   TableColumnDefinition,
 } from '@fluentui/react-components';
 import {
-  FixedSizeList,
-  FixedSizeListProps,
+  VariableSizeList,
+  VariableSizeListProps,
   ListChildComponentProps,
   ListProps,
 } from 'react-window';
@@ -26,9 +26,9 @@ export type DataGridHeaderRowProps<TItem = unknown> = Omit<
   'children'
 > & {
   /**
-   * The size of each column
+   * Returns the size of each column width.
    */
-  itemSize: number;
+  itemSize: (index: number) => number;
   /**
    * The height of the virtualized container
    */
@@ -43,12 +43,12 @@ export type DataGridHeaderRowProps<TItem = unknown> = Omit<
   children: HeaderCellRenderer<TItem>;
 
   /**
-   * Optional props to pass through to the FixedSizeList component from react-window
+   * Optional props to pass through to the VariableSizeList component from react-window
    *
-   * @see https://react-window.vercel.app/#/api/FixedSizeList
+   * @see https://react-window.vercel.app/#/api/VariableSizeList
    */
 
-  listProps?: Partial<FixedSizeListProps>;
+  listProps?: Partial<VariableSizeListProps>;
 };
 
 /**
@@ -66,5 +66,5 @@ export type DataGridHeaderRowState = Omit<DataGridRowState, 'renderCell'> &
      * Ref of the virtualized list container ref
      */
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    listRef: React.RefObject<FixedSizeList<any>>;
+    listRef: React.RefObject<VariableSizeList<any>>;
   } & Pick<ListProps, 'onScroll'>;

--- a/packages/react-data-grid-react-window-grid/src/components/DataGridHeaderRow/renderDataGridHeaderRow.tsx
+++ b/packages/react-data-grid-react-window-grid/src/components/DataGridHeaderRow/renderDataGridHeaderRow.tsx
@@ -4,7 +4,7 @@ import {
   useFluent,
   getSlots,
 } from '@fluentui/react-components';
-import { FixedSizeList as List } from 'react-window';
+import { VariableSizeList as List } from 'react-window';
 import { DataGridHeaderRowState } from './DataGridHeaderRow.types';
 
 /**

--- a/packages/react-data-grid-react-window-grid/src/contexts/bodyRefContext.ts
+++ b/packages/react-data-grid-react-window-grid/src/contexts/bodyRefContext.ts
@@ -1,13 +1,13 @@
 import * as React from 'react';
-import { FixedSizeGrid } from 'react-window';
+import { VariableSizeGrid } from 'react-window';
 
 const bodyRefContext: React.Context<
-  React.MutableRefObject<FixedSizeGrid | null>
-> = React.createContext<React.MutableRefObject<FixedSizeGrid | null>>({
+  React.MutableRefObject<VariableSizeGrid | null>
+> = React.createContext<React.MutableRefObject<VariableSizeGrid | null>>({
   current: null,
 });
 
-export const bodyRefContextDefaultValue: React.MutableRefObject<FixedSizeGrid | null> =
+export const bodyRefContextDefaultValue: React.MutableRefObject<VariableSizeGrid | null> =
   { current: null };
 
 export const useBodyRefContext = () =>

--- a/packages/react-data-grid-react-window-grid/src/contexts/headerListRefContext.ts
+++ b/packages/react-data-grid-react-window-grid/src/contexts/headerListRefContext.ts
@@ -1,14 +1,18 @@
 import * as React from 'react';
-import { FixedSizeList } from 'react-window';
+import { VariableSizeList } from 'react-window';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-const headerListRefContext: React.Context<React.RefObject<FixedSizeList<any>>> =
+const headerListRefContext: React.Context<
+  React.RefObject<VariableSizeList<any>>
+> =
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  React.createContext<React.RefObject<FixedSizeList<any>>>({ current: null });
+  React.createContext<React.RefObject<VariableSizeList<any>>>({
+    current: null,
+  });
 
 export const headerListRefContextDefaultValue: React.RefObject<
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  FixedSizeList<any>
+  VariableSizeList<any>
 > = { current: null };
 
 export const useHeaderListRefContext = () =>

--- a/packages/react-data-grid-react-window-grid/stories/DataGrid/VirtualizedDataGrid.stories.tsx
+++ b/packages/react-data-grid-react-window-grid/stories/DataGrid/VirtualizedDataGrid.stories.tsx
@@ -40,6 +40,9 @@ const useStyles = makeStyles({
 });
 
 const COLUMN_WIDTH = 120;
+const columnWidths = new Array(50).fill(COLUMN_WIDTH);
+const columnWidth = (index: number) => (index == 0 ? 200 : columnWidths[index]);
+const rowHeights = new Array(1000).fill(44);
 
 function getColumnDefinitions(
   columns: string[]
@@ -108,7 +111,7 @@ export const VirtualizedDataGrid: React.FunctionComponent = () => {
     >
       <DataGridHeader className={styles.tableHeader}>
         <DataGridHeaderRow<TableUIData>
-          itemSize={COLUMN_WIDTH}
+          itemSize={columnWidth}
           height={42}
           width={20000}
         >
@@ -126,10 +129,10 @@ export const VirtualizedDataGrid: React.FunctionComponent = () => {
         </DataGridHeaderRow>
       </DataGridHeader>
       <DataGridBody<TableUIData>
-        rowHeight={44}
+        rowHeight={(index) => rowHeights[index]}
         height={500}
         width={1000}
-        columnWidth={COLUMN_WIDTH}
+        columnWidth={columnWidth}
       >
         {cellRenderer}
       </DataGridBody>


### PR DESCRIPTION
use [VaraiableSizeGrid](https://react-window.vercel.app/#/examples/grid/variable-size) for body and [VariableSizeList](https://react-window.vercel.app/#/examples/list/variable-size) for header to make users of the grid in react-data-grid-react-window-grid have the ability for different column size of each column.
![variableSizeGrid](https://github.com/microsoft/fluentui-contrib/assets/44865230/80586408-f889-4714-993d-0a5aa8baa041)
