### PR TITLE
feat(react-draggable-dialog): split component logic into separate hooks

### DIFF
--- a/packages/react-draggable-dialog/src/components/DraggableDialog/DraggableDialog.tsx
+++ b/packages/react-draggable-dialog/src/components/DraggableDialog/DraggableDialog.tsx
@@ -1,92 +1,24 @@
 import * as React from 'react';
-import {
-  DndContext,
-  useSensor,
-  MouseSensor,
-  TouchSensor,
-  KeyboardSensor,
-  useSensors,
-  DragEndEvent,
-  PointerSensor,
-  Announcements,
-} from '@dnd-kit/core';
-import { Dialog, useId } from '@fluentui/react-components';
+import { DndContext } from '@dnd-kit/core';
+import { Dialog } from '@fluentui/react-components';
 
 import { DraggableDialogContextProvider } from '../../contexts/DraggableDialogContext';
 import { DraggableDialogProps } from './DraggableDialog.types';
-import { getParsedDraggableMargin, restrictToMarginModifier } from './utils';
+import { useDraggableDialog } from './useDraggableDialog';
 
+/**
+ * DraggableDialog is a wrapper around the Dialog component that makes it draggable.
+ */
 export const DraggableDialog: React.FC<DraggableDialogProps> = (props) => {
-  const { margin, keepInViewport, id, announcements } = {
-    id: useId('draggable-dialog-'),
-    keepInViewport: true,
-    ...props,
-    margin: getParsedDraggableMargin(props.margin),
-  };
-
-  const [isDragging, setIsDragging] = React.useState(false);
-  const [hasBeenDragged, setHasBeenDragged] = React.useState(false);
-  const [position, setPosition] = React.useState({ x: 0, y: 0 });
-
-  const mouseSensor = useSensor(MouseSensor);
-  const pointerSensor = useSensor(PointerSensor);
-  const touchSensor = useSensor(TouchSensor);
-  const keyboardSensor = useSensor(KeyboardSensor);
-  const sensors = useSensors(
-    pointerSensor,
-    mouseSensor,
-    touchSensor,
-    keyboardSensor
-  );
-
-  const contextValue = React.useMemo(
-    () => ({
-      isDragging,
-      hasBeenDragged,
-      position,
-      id,
-    }),
-    [isDragging, hasBeenDragged, position, id]
-  );
-
-  const onDragEnd = React.useCallback((event: DragEndEvent) => {
-    setPosition(({ x, y }) => ({
-      x: x + event.delta.x,
-      y: y + event.delta.y,
-    }));
-    setIsDragging(false);
-  }, []);
-
-  const onDragStart = React.useCallback(() => {
-    setHasBeenDragged(true);
-    setIsDragging(true);
-  }, []);
-
-  const modifiers = React.useMemo(() => {
-    return [restrictToMarginModifier({ margin, keepInViewport })];
-  }, [margin, keepInViewport]);
-
-  const accessibilityProps = React.useMemo(() => {
-    const { start, end } = announcements || {};
-
-    if (!announcements || (!start && !end)) {
-      return undefined;
-    }
-
-    const announcementsProps: Partial<Announcements> = {};
-
-    if (start) {
-      announcementsProps.onDragStart = () => start;
-    }
-
-    if (end) {
-      announcementsProps.onDragEnd = () => end;
-    }
-
-    return {
-      announcements: announcementsProps,
-    };
-  }, [announcements]);
+  const {
+    sensors,
+    modifiers,
+    onDragStart,
+    onDragEnd,
+    accessibilityProps,
+    contextValue,
+    dialogProps,
+  } = useDraggableDialog(props);
 
   return (
     <DndContext
@@ -97,7 +29,7 @@ export const DraggableDialog: React.FC<DraggableDialogProps> = (props) => {
       onDragEnd={onDragEnd}
     >
       <DraggableDialogContextProvider value={contextValue}>
-        <Dialog {...props} />
+        <Dialog {...dialogProps} />
       </DraggableDialogContextProvider>
     </DndContext>
   );

--- a/packages/react-draggable-dialog/src/components/DraggableDialog/DraggableDialog.types.ts
+++ b/packages/react-draggable-dialog/src/components/DraggableDialog/DraggableDialog.types.ts
@@ -1,4 +1,12 @@
+import {
+  Announcements,
+  DragEndEvent,
+  Modifier,
+  SensorDescriptor,
+  SensorOptions,
+} from '@dnd-kit/core';
 import { DialogProps } from '@fluentui/react-components';
+import { DraggableDialogContextValue } from '../../contexts/DraggableDialogContext';
 
 export type DraggableMarginAxis = {
   mainAxis?: number;
@@ -49,4 +57,47 @@ export type DraggableDialogProps = DialogProps & {
      */
     end?: string;
   };
+};
+
+/**
+ * Represents the state of a draggable dialog component.
+ */
+export type DraggableDialogState = {
+  /**
+   * Sensors used for the DndKit drag and drop system.
+   */
+  sensors: SensorDescriptor<SensorOptions>[];
+
+  /**
+   * The modifiers to apply to the draggable dialog.
+   */
+  modifiers: Modifier[];
+
+  /**
+   * Accessibility props to apply to the draggable dialog.
+   * Currently only used for screen reader announcements.
+   */
+  accessibilityProps?: {
+    announcements: Partial<Announcements>;
+  };
+
+  /**
+   * Event triggered when drag movement starts.
+   */
+  onDragStart: () => void;
+
+  /**
+   * Event triggered when drag movement finishes.
+   */
+  onDragEnd: (event: DragEndEvent) => void;
+
+  /**
+   * The context value to provide to child components.
+   */
+  contextValue: DraggableDialogContextValue;
+
+  /**
+   * The props to apply to the dialog.
+   */
+  dialogProps: DialogProps;
 };

--- a/packages/react-draggable-dialog/src/components/DraggableDialog/useDraggableDialog.ts
+++ b/packages/react-draggable-dialog/src/components/DraggableDialog/useDraggableDialog.ts
@@ -1,0 +1,128 @@
+import * as React from 'react';
+
+import {
+  Announcements,
+  DragEndEvent,
+  KeyboardSensor,
+  MouseSensor,
+  PointerSensor,
+  TouchSensor,
+  useSensor,
+  useSensors,
+} from '@dnd-kit/core';
+import { useId } from '@fluentui/react-components';
+
+import { getParsedDraggableMargin, restrictToMarginModifier } from './utils';
+import {
+  DraggableDialogProps,
+  DraggableDialogState,
+} from './DraggableDialog.types';
+
+/**
+ * This function is used to partition the props into two separate objects. The first object contains
+ * the props that are specific to the DraggableDialog component, and the second object contains the
+ * props that should be passed down to the Dialog component.
+ */
+const getPartitionedProps = (props: DraggableDialogProps) => {
+  const { margin, keepInViewport, id, announcements, ...dialogProps } = props;
+
+  const draggableDialogProps = {
+    id: useId('draggable-dialog-', id),
+    keepInViewport:
+      typeof keepInViewport === 'undefined' ? true : keepInViewport,
+    announcements,
+    margin: getParsedDraggableMargin(margin),
+  };
+
+  return {
+    draggableDialogProps,
+    dialogProps,
+  };
+};
+
+/**
+ * This hook is used to provide the necessary state and context values to the DraggableDialog component.
+ */
+export const useDraggableDialog = (
+  props: DraggableDialogProps
+): DraggableDialogState => {
+  const {
+    draggableDialogProps: { announcements, id, keepInViewport, margin },
+    dialogProps,
+  } = getPartitionedProps(props);
+
+  const [isDragging, setIsDragging] = React.useState(false);
+  const [hasBeenDragged, setHasBeenDragged] = React.useState(false);
+  const [position, setPosition] = React.useState({ x: 0, y: 0 });
+
+  const mouseSensor = useSensor(MouseSensor);
+  const pointerSensor = useSensor(PointerSensor);
+  const touchSensor = useSensor(TouchSensor);
+  const keyboardSensor = useSensor(KeyboardSensor);
+  const sensors = useSensors(
+    pointerSensor,
+    mouseSensor,
+    touchSensor,
+    keyboardSensor
+  );
+
+  const contextValue = React.useMemo(
+    () => ({
+      isDragging,
+      hasBeenDragged,
+      position,
+      id,
+      hasDialogParent: true,
+    }),
+    [isDragging, hasBeenDragged, position, id]
+  );
+
+  const onDragEnd = React.useCallback((event: DragEndEvent) => {
+    setPosition(({ x, y }) => ({
+      x: x + event.delta.x,
+      y: y + event.delta.y,
+    }));
+    setIsDragging(false);
+  }, []);
+
+  const onDragStart = React.useCallback(() => {
+    setHasBeenDragged(true);
+    setIsDragging(true);
+  }, []);
+
+  const modifiers = React.useMemo(() => {
+    return [restrictToMarginModifier({ margin, keepInViewport })];
+  }, [margin, keepInViewport]);
+
+  const accessibilityProps = React.useMemo(() => {
+    const { start, end } = announcements || {};
+
+    if (!announcements || (!start && !end)) {
+      return undefined;
+    }
+
+    const announcementsProps: Partial<Announcements> = {};
+
+    if (start) {
+      announcementsProps.onDragStart = () => start;
+    }
+
+    if (end) {
+      announcementsProps.onDragEnd = () => end;
+    }
+
+    return {
+      announcements: announcementsProps,
+    };
+  }, [announcements]);
+
+  return {
+    sensors,
+    modifiers,
+    accessibilityProps,
+    onDragStart,
+    onDragEnd,
+    contextValue,
+    dialogProps,
+  };
+};

--- a/packages/react-draggable-dialog/src/components/DraggableDialogHandle/DraggableDialogHandle.tsx
+++ b/packages/react-draggable-dialog/src/components/DraggableDialogHandle/DraggableDialogHandle.tsx
@@ -1,20 +1,20 @@
 import * as React from 'react';
-import { useDraggable } from '@dnd-kit/core';
 import { mergeClasses } from '@fluentui/react-components';
 
 import { DraggableDialogHandleProps } from './DraggableDialogHandle.types';
 import { useStyles } from './DraggableDialogHandle.styles';
-import { useDraggableDialogState } from '../../contexts/DraggableDialogContext';
+import { useDraggableDialogHandle } from './useDraggableDialogHandle';
 
+/**
+ * DraggableDialogHandle is the handle element that can be used to drag the DraggableDialog.
+ */
 export const DraggableDialogHandle: React.FC<DraggableDialogHandleProps> = ({
   children,
   className,
 }) => {
   const styles = useStyles();
-  const { id } = useDraggableDialogState();
-  const { setActivatorNodeRef, attributes, listeners } = useDraggable({
-    id,
-  });
+  const { setActivatorNodeRef, attributes, listeners } =
+    useDraggableDialogHandle();
 
   return React.cloneElement(children, {
     ref: setActivatorNodeRef,

--- a/packages/react-draggable-dialog/src/components/DraggableDialogHandle/DraggableDialogHandle.types.ts
+++ b/packages/react-draggable-dialog/src/components/DraggableDialogHandle/DraggableDialogHandle.types.ts
@@ -1,3 +1,4 @@
+import { SyntheticListenerMap } from '@dnd-kit/core/dist/hooks/utilities/useSyntheticListeners';
 import * as React from 'react';
 
 export type DraggableDialogHandleProps = React.HTMLAttributes<HTMLElement> & {
@@ -7,4 +8,21 @@ export type DraggableDialogHandleProps = React.HTMLAttributes<HTMLElement> & {
    * @required
    */
   children: React.ReactElement;
+};
+
+export type DraggableDialogHandleState = {
+  /**
+   * The ref to the activator node.
+   */
+  setActivatorNodeRef: React.RefCallback<HTMLElement>;
+
+  /**
+   * The attributes to apply to the activator node.
+   */
+  attributes: React.HTMLAttributes<HTMLElement>;
+
+  /**
+   * The event listeners to apply to the activator node.
+   */
+  listeners?: SyntheticListenerMap;
 };

--- a/packages/react-draggable-dialog/src/components/DraggableDialogHandle/useDraggableDialogHandle.ts
+++ b/packages/react-draggable-dialog/src/components/DraggableDialogHandle/useDraggableDialogHandle.ts
@@ -7,7 +7,7 @@ import { DraggableDialogHandleState } from './DraggableDialogHandle.types';
  * Returns the state needed to make a draggable dialog handle.
  */
 export const useDraggableDialogHandle = (): DraggableDialogHandleState => {
-  const { id, hasDialogParent } = useDraggableDialogState();
+  const { id } = useDraggableDialogState();
   const { setActivatorNodeRef, attributes, listeners } = useDraggable({
     id,
   });

--- a/packages/react-draggable-dialog/src/components/DraggableDialogHandle/useDraggableDialogHandle.ts
+++ b/packages/react-draggable-dialog/src/components/DraggableDialogHandle/useDraggableDialogHandle.ts
@@ -1,0 +1,20 @@
+import { useDraggable } from '@dnd-kit/core';
+
+import { useDraggableDialogState } from '../../contexts/DraggableDialogContext';
+import { DraggableDialogHandleState } from './DraggableDialogHandle.types';
+
+/**
+ * Returns the state needed to make a draggable dialog handle.
+ */
+export const useDraggableDialogHandle = (): DraggableDialogHandleState => {
+  const { id, hasDialogParent } = useDraggableDialogState();
+  const { setActivatorNodeRef, attributes, listeners } = useDraggable({
+    id,
+  });
+
+  return {
+    setActivatorNodeRef,
+    attributes,
+    listeners,
+  };
+};

--- a/packages/react-draggable-dialog/src/components/DraggableDialogSurface/DraggableDialogSurface.tsx
+++ b/packages/react-draggable-dialog/src/components/DraggableDialogSurface/DraggableDialogSurface.tsx
@@ -1,78 +1,24 @@
 import * as React from 'react';
-import { useDraggable } from '@dnd-kit/core';
-import { CSS } from '@dnd-kit/utilities';
-import {
-  DialogSurface,
-  mergeClasses,
-  useMergedRefs,
-} from '@fluentui/react-components';
+import { DialogSurface, mergeClasses } from '@fluentui/react-components';
 
 import { DraggableDialogSurfaceProps } from './DraggableDialogSurface.types';
 import { useStyles } from './DraggableDialogSurface.styles';
-import { useDraggableDialogState } from '../../contexts/DraggableDialogContext';
+import { useDraggableDialogSurface } from './useDraggableDialogSurface';
 
+/**
+ * DraggableDialogSurface is a wrapper around the DialogSurface component that,
+ * when composed with DraggableDialog, can be dragged.
+ */
 export const DraggableDialogSurface: React.FC<DraggableDialogSurfaceProps> = ({
   children,
   className,
 }) => {
   const styles = useStyles();
-  const ref = React.useRef<HTMLDivElement | null>(null);
-  const {
-    id,
-    hasBeenDragged,
-    isDragging,
-    position: { x, y },
-  } = useDraggableDialogState();
-  const { setNodeRef, transform } = useDraggable({
-    id,
-  });
-  const refs = useMergedRefs(setNodeRef as React.Ref<HTMLDivElement>, ref);
-
-  const style = React.useMemo(() => {
-    if (!hasBeenDragged) {
-      return;
-    }
-
-    const resetStyles = {
-      margin: 0,
-      transition: 'none',
-    };
-
-    if (ref.current) {
-      const baseStyles = {
-        ...resetStyles,
-        top: `calc(50% + ${y}px)`,
-        left: `calc(50% + ${x}px)`,
-        marginTop: -Math.ceil(ref.current.clientHeight / 2),
-        marginLeft: -Math.ceil(ref.current.clientWidth / 2),
-      };
-
-      if (isDragging) {
-        /* When the dialog is being dragged */
-        return {
-          ...baseStyles,
-          transform: CSS.Translate.toString(transform),
-        };
-      }
-
-      /* The final position of the dialog */
-      return baseStyles;
-    }
-
-    /* Restore a previously dragged dialog */
-    return {
-      ...resetStyles,
-      top: '50%',
-      left: '50%',
-      marginTop: y,
-      marginLeft: x,
-      transform: `translate3D(-50%, -50%, 0)`,
-    };
-  }, [transform, x, y, hasBeenDragged, isDragging]);
+  const { ref, style } = useDraggableDialogSurface();
 
   return (
     <DialogSurface
-      ref={refs}
+      ref={ref}
       style={style}
       className={mergeClasses(
         'fui-DraggableDialogSurface',

--- a/packages/react-draggable-dialog/src/components/DraggableDialogSurface/DraggableDialogSurface.types.ts
+++ b/packages/react-draggable-dialog/src/components/DraggableDialogSurface/DraggableDialogSurface.types.ts
@@ -1,3 +1,15 @@
 import { DialogSurfaceProps } from '@fluentui/react-components';
 
 export type DraggableDialogSurfaceProps = DialogSurfaceProps;
+
+export type DraggableDialogSurfaceState = {
+  /**
+   * Ref to the draggable dialog surface.
+   */
+  ref: React.RefObject<HTMLDivElement>;
+
+  /**
+   * Style to apply to the draggable dialog surface.
+   */
+  style: React.CSSProperties | undefined;
+};

--- a/packages/react-draggable-dialog/src/components/DraggableDialogSurface/useDraggableDialogSurface.ts
+++ b/packages/react-draggable-dialog/src/components/DraggableDialogSurface/useDraggableDialogSurface.ts
@@ -16,7 +16,6 @@ export const useDraggableDialogSurface = (): DraggableDialogSurfaceState => {
     hasBeenDragged,
     isDragging,
     position: { x, y },
-    hasDialogParent,
   } = useDraggableDialogState();
   const { setNodeRef, transform } = useDraggable({
     id,

--- a/packages/react-draggable-dialog/src/components/DraggableDialogSurface/useDraggableDialogSurface.ts
+++ b/packages/react-draggable-dialog/src/components/DraggableDialogSurface/useDraggableDialogSurface.ts
@@ -1,0 +1,71 @@
+import * as React from 'react';
+import { useDraggable } from '@dnd-kit/core';
+import { CSS } from '@dnd-kit/utilities';
+import { useMergedRefs } from '@fluentui/react-components';
+
+import { useDraggableDialogState } from '../../contexts/DraggableDialogContext';
+import { DraggableDialogSurfaceState } from './DraggableDialogSurface.types';
+
+/**
+ * Returns the state needed to make a draggable dialog surface.
+ */
+export const useDraggableDialogSurface = (): DraggableDialogSurfaceState => {
+  const ref = React.useRef<HTMLDivElement | null>(null);
+  const {
+    id,
+    hasBeenDragged,
+    isDragging,
+    position: { x, y },
+    hasDialogParent,
+  } = useDraggableDialogState();
+  const { setNodeRef, transform } = useDraggable({
+    id,
+  });
+
+  const style = React.useMemo(() => {
+    if (!hasBeenDragged) {
+      return;
+    }
+
+    const resetStyles = {
+      margin: 0,
+      transition: 'none',
+    };
+
+    if (ref.current) {
+      const baseStyles = {
+        ...resetStyles,
+        top: `calc(50% + ${y}px)`,
+        left: `calc(50% + ${x}px)`,
+        marginTop: -Math.ceil(ref.current.clientHeight / 2),
+        marginLeft: -Math.ceil(ref.current.clientWidth / 2),
+      };
+
+      if (isDragging) {
+        /* When the dialog is being dragged */
+        return {
+          ...baseStyles,
+          transform: CSS.Translate.toString(transform),
+        };
+      }
+
+      /* The final position of the dialog */
+      return baseStyles;
+    }
+
+    /* Restore a previously dragged dialog */
+    return {
+      ...resetStyles,
+      top: '50%',
+      left: '50%',
+      marginTop: y,
+      marginLeft: x,
+      transform: `translate3D(-50%, -50%, 0)`,
+    };
+  }, [transform, x, y, hasBeenDragged, isDragging]);
+
+  return {
+    ref: useMergedRefs(setNodeRef as React.Ref<HTMLDivElement>, ref),
+    style,
+  };
+};

--- a/packages/react-draggable-dialog/src/contexts/DraggableDialogContext.ts
+++ b/packages/react-draggable-dialog/src/contexts/DraggableDialogContext.ts
@@ -1,7 +1,6 @@
 import * as React from 'react';
 
 const draggableDialogContextDefaultValue = {
-  hasDialogParent: false,
   id: '',
   isDragging: false,
   hasBeenDragged: false,
@@ -25,6 +24,8 @@ export const useDraggableDialogContext = () => {
   );
 };
 
-export const useDraggableDialogState = () => useDraggableDialogContext();
+export const useDraggableDialogState = () => {
+  return useDraggableDialogContext();
+};
 
 export const DraggableDialogContextProvider = draggableDialogContext.Provider;

--- a/packages/react-draggable-dialog/src/contexts/DraggableDialogContext.ts
+++ b/packages/react-draggable-dialog/src/contexts/DraggableDialogContext.ts
@@ -1,6 +1,7 @@
 import * as React from 'react';
 
 const draggableDialogContextDefaultValue = {
+  hasDialogParent: false,
   id: '',
   isDragging: false,
   hasBeenDragged: false,
@@ -24,8 +25,6 @@ export const useDraggableDialogContext = () => {
   );
 };
 
-export const useDraggableDialogState = () => {
-  return useDraggableDialogContext();
-};
+export const useDraggableDialogState = () => useDraggableDialogContext();
 
 export const DraggableDialogContextProvider = draggableDialogContext.Provider;


### PR DESCRIPTION
This PR doesn't add any logic but splits the component into separate state hooks.
This change is needed to make it easy to test the state that goes into the components. Some components are renderless, which makes it impossible to test the state integrity without this change.