### PR TITLE
bugfix(react-tree-grid): header TreeGridCell should have role rowheader instead of columnheader

### DIFF
--- a/packages/react-tree-grid/src/components/TreeGrid/TreeGrid.spec.tsx
+++ b/packages/react-tree-grid/src/components/TreeGrid/TreeGrid.spec.tsx
@@ -19,15 +19,9 @@ test.describe('Click interaction', () => {
   test('should open/close subtree on row click', async ({ mount }) => {
     const component = await mount(<TreeGridExample />);
     await expect(component.getByTestId('level-1-row-1')).toBeVisible();
-    await component
-      .getByTestId('level-1-row-1')
-      .getByRole('columnheader')
-      .click();
+    await component.getByTestId('level-1-row-1').getByRole('rowheader').click();
     await expect(component.getByTestId('level-2-row-1')).toBeVisible();
-    await component
-      .getByTestId('level-1-row-1')
-      .getByRole('columnheader')
-      .click();
+    await component.getByTestId('level-1-row-1').getByRole('rowheader').click();
     await expect(component.getByTestId('level-2-row-1')).toBeHidden();
   });
   test('should not open/close subtree on button click', async ({ mount }) => {
@@ -43,10 +37,7 @@ test.describe('Click interaction', () => {
   test('should not open/close subtree on subtree click', async ({ mount }) => {
     const component = await mount(<TreeGridExample defaultOpen />);
     await expect(component.getByTestId('level-2-row-1')).toBeVisible();
-    await component
-      .getByTestId('level-2-row-1')
-      .getByRole('columnheader')
-      .click();
+    await component.getByTestId('level-2-row-1').getByRole('rowheader').click();
     await expect(component.getByTestId('level-2-row-1')).toBeVisible();
   });
   test('should not open/close subtree on subtree button click', async ({

--- a/packages/react-tree-grid/src/components/TreeGridCell/TreeGridCell.tsx
+++ b/packages/react-tree-grid/src/components/TreeGridCell/TreeGridCell.tsx
@@ -18,7 +18,7 @@ export const TreeGridCell: ForwardRefComponent<TreeGridCellProps> =
     const Root = slot.always(
       getIntrinsicElementProps('div', {
         ref,
-        role: header ? 'columnheader' : 'gridcell',
+        role: header ? 'rowheader' : 'gridcell',
         ...rest,
         className: mergeClasses('fui-TreeGridCell', className),
       }),

--- a/packages/react-tree-grid/stories/Default.stories.tsx
+++ b/packages/react-tree-grid/stories/Default.stories.tsx
@@ -38,7 +38,7 @@ export const Default = () => {
               <TreeGridCell className={styles.cell}>
                 <Menu>
                   <MenuTrigger disableButtonEnhancement>
-                    <Button>Toggle menu</Button>
+                    <Button>More Actions</Button>
                   </MenuTrigger>
 
                   <MenuPopover>

--- a/packages/react-tree-grid/stories/EmailInbox.stories.tsx
+++ b/packages/react-tree-grid/stories/EmailInbox.stories.tsx
@@ -60,10 +60,10 @@ export const EmailInbox = () => {
         subject={
           <>
             <Avatar aria-hidden color="colorful" name="Čestmír Ondřej" />{' '}
-            Implementing treegrid pattern
+            <span tabIndex={0}>Implementing treegrid pattern</span>
           </>
         }
-        summary="Here's attached the treegrid specs"
+        summary={<span tabIndex={0}>Here's attached the treegrid specs</span>}
         email="condrej@email.com"
         replies={
           <>
@@ -71,20 +71,22 @@ export const EmailInbox = () => {
               subject={
                 <>
                   <Avatar aria-hidden color="colorful" name="Maxim Tobiáš" />{' '}
-                  Re: Implementing treegrid pattern
+                  <span tabIndex={0}>Re: Implementing treegrid pattern</span>
                 </>
               }
-              summary="Thanks Čestmír, I'll take a look"
+              summary={
+                <span tabIndex={0}>Thanks Čestmír, I'll take a look</span>
+              }
               email="mtobias@email.com"
             />
             <Email
               subject={
                 <>
                   <Avatar aria-hidden color="colorful" name="Kristina Ctibor" />{' '}
-                  Re: Implementing treegrid pattern
+                  <span tabIndex={0}>Re: Implementing treegrid pattern</span>
                 </>
               }
-              summary="Great documentation!"
+              summary={<span tabIndex={0}>Great documentation!</span>}
               email="kctibor@email.com"
             />
           </>
@@ -93,21 +95,42 @@ export const EmailInbox = () => {
       <Email
         subject={
           <>
-            <Avatar aria-hidden color="colorful" name="E+D HR" /> E+D HR
+            <Avatar aria-hidden color="colorful" name="E+D HR" />{' '}
+            <span tabIndex={0}>E+D HR</span>
           </>
         }
-        summary="Career Jams Registration is now open"
+        summary={<span tabIndex={0}>Career Jams Registration is now open</span>}
         email="edhr@microsoft.com"
       />
       <Email
         subject={
           <>
             <Avatar aria-hidden color="colorful" name="Kristina Ctibor" />{' '}
-            Kristina Ctibor
+            <span tabIndex={0}>Kristina Ctibor</span>
           </>
         }
-        summary="Record Fluent UI demos for FW demo session"
+        summary={
+          <span tabIndex={0}>Record Fluent UI demos for FW demo session</span>
+        }
         email="kctibor@email.com"
+        replies={
+          <Email
+            subject={
+              <>
+                <Avatar aria-hidden color="colorful" name="Čestmír Ondřej" />{' '}
+                <span tabIndex={0}>
+                  Re: Record Fluent UI demos for FW demo session
+                </span>
+              </>
+            }
+            summary={
+              <span tabIndex={0}>
+                Here's the video to present treegrid in the FW demo session
+              </span>
+            }
+            email="condrej@email.com"
+          />
+        }
       />
     </TreeGrid>
   );
@@ -154,8 +177,8 @@ const Email = (props: EmailProps) => {
               )}
             </>
           )}
-          {props.subject}
         </span>
+        {props.subject}
       </TreeGridCell>
       <TreeGridCell className={tableCellStyle}>{props.summary}</TreeGridCell>
       <TreeGridCell className={tableCellStyle}>

--- a/packages/react-tree-grid/stories/Meet.stories.tsx
+++ b/packages/react-tree-grid/stories/Meet.stories.tsx
@@ -241,7 +241,7 @@ export const Meet = () => {
             >
               <Image
                 src="https://placehold.co/130x70"
-                alt="Image placeholder"
+                alt="Meeting recording"
               />
             </Button>
           }
@@ -308,12 +308,12 @@ const MeetingsSectionItem = (props: MeetingsSectionItemProps) => {
           icon={<CalendarRegular />}
           aria-hidden
         />
-        <Button
-          appearance="transparent"
+        <Body1Stronger
+          tabIndex={0}
           className={mergeClasses(styles.noPadding, styles.title)}
         >
-          <Body1Stronger>{props.header}</Body1Stronger>
-        </Button>
+          {props.header}
+        </Body1Stronger>
         {props.status === 'missed' && (
           <Tag
             className={mergeClasses(styles.missedTag, styles.tag)}


### PR DESCRIPTION
1. Fix wrong `role` on header `TreeGridCell`
2. updates stories to be more accessible