### PR TITLE
chore(react-tree-grid): follow up on a11y issue for Meet stories

### DIFF
--- a/packages/react-tree-grid/stories/Meet.stories.tsx
+++ b/packages/react-tree-grid/stories/Meet.stories.tsx
@@ -114,7 +114,8 @@ export const Meet = () => {
         <MeetingsSectionItem
           status="missed"
           header="All Hands with Sanjay Garg"
-          location="Thursday, 1 February · 11:05 - 12:00, Lenka Klugarova"
+          location="Thursday, 1 February · 11:05 - 12:00"
+          owner="Lenka Klugarova"
           description="Meeting summary is currently not available for this meeting."
           tasks={
             <Tooltip
@@ -159,7 +160,8 @@ export const Meet = () => {
       <MeetingsSection header="Thursday, 25 January">
         <MeetingsSectionItem
           header="Monthly Sync with Fluent Team"
-          location="Thursday, 25 January 2024 · 16:30 - 17:30, Amit Sehgal"
+          location="Thursday, 25 January 2024 · 16:30 - 17:30"
+          owner="Amit Sehgal"
           description="Meeting summary is currently not available for this meeting."
           tasks={
             <Tooltip
@@ -202,7 +204,8 @@ export const Meet = () => {
         />
         <MeetingsSectionItem
           header="TAX RETURN 2023: How to Prepare | Online Training (Option 1)"
-          location="Thursday, 25 January 2024 · 10:00 - 12:00, CZSK Comms"
+          location="Thursday, 25 January 2024 · 10:00 - 12:00"
+          owner="CZSK Comms"
           attachments={
             <Tooltip content="2 files" relationship="label">
               <InteractionTag shape="circular" size="small">
@@ -220,7 +223,8 @@ export const Meet = () => {
       <MeetingsSection header="Tuesday, 23 January">
         <MeetingsSectionItem
           header="CAP January Top of Mind with Jeff Teper"
-          location="Tuesday, 23 January 2024 · 23:05 - 23:30, Collaborative Apps and Platforms Executive Calendar"
+          location="Tuesday, 23 January 2024 · 23:05 - 23:30"
+          owner="Collaborative Apps and Platforms Executive Calendar"
           description="Meeting summary is currently not available for this meeting."
           attachments={
             <Tooltip content="2 files" relationship="label">
@@ -289,6 +293,7 @@ const MeetingsSection = (props: MeetingsSectionProps) => {
 type MeetingsSectionItemProps = {
   header: string;
   location: string;
+  owner: string;
   description?: React.ReactNode;
   status?: 'missed';
   tasks?: React.ReactNode;
@@ -299,12 +304,13 @@ const MeetingsSectionItem = (props: MeetingsSectionItemProps) => {
   const styles = useMeetingsSectionStyles();
   return (
     <TreeGridRow
-      aria-label={`${props.header}. ${props.location}. ${
+      aria-description={`Created by: ${props.owner}. ${
         props.status ? `Meeting status: ${props.status}` : ''
       }`}
       className={styles.sectionItem}
     >
       <TreeGridCell
+        aria-label={`${props.header}. ${props.location}`}
         className={mergeClasses(styles.header, styles.container)}
         header
       >
@@ -315,7 +321,7 @@ const MeetingsSectionItem = (props: MeetingsSectionItemProps) => {
         />
         <Button
           appearance="transparent"
-          aria-label={`Go to "${props.header}" meeting`}
+          aria-label="Go to meeting"
           className={mergeClasses(styles.noPadding, styles.title)}
         >
           <Body1Stronger>{props.header}</Body1Stronger>
@@ -329,7 +335,9 @@ const MeetingsSectionItem = (props: MeetingsSectionItemProps) => {
             <Caption1Stronger>Missed</Caption1Stronger>
           </Tag>
         )}
-        <Caption1 className={styles.location}>{props.location}</Caption1>
+        <Caption1 className={styles.location}>
+          {props.location}, {props.owner}
+        </Caption1>
         {props.description && (
           <Caption1 className={styles.description}>
             {props.description}


### PR DESCRIPTION
Modifies Meet story to be more accessible

1. adds `aria-label` to the rowheader cell instead of the row
2. add `aria-description` to the row, providing extra information
3. add simpler `aria-label` to the header button