### PR TITLE
test(react-draggable-dialog): remove forced mocks

### DIFF
--- a/packages/react-draggable-dialog/src/components/DraggableDialog/DraggableDialog.test.tsx
+++ b/packages/react-draggable-dialog/src/components/DraggableDialog/DraggableDialog.test.tsx
@@ -5,18 +5,9 @@ import { DraggableDialog } from './DraggableDialog';
 import { useDraggableDialog } from './useDraggableDialog';
 import { DragEndEvent } from '@dnd-kit/core';
 
-jest.mock('@fluentui/react-components', () => ({
-  ...jest.requireActual('@fluentui/react-components'),
-  useId: jest.fn().mockReturnValue('draggable-dialog'),
-}));
-
 const dialogChild = React.createElement('div', null, 'Dialog Child');
 
 describe('DraggableDialog', () => {
-  afterAll(() => {
-    jest.resetAllMocks();
-  });
-
   it('should render', () => {
     const text = 'Context';
     const { getByText } = render(
@@ -49,13 +40,16 @@ describe('DraggableDialog', () => {
     expect(result.current.onDragStart).toBeInstanceOf(Function);
     expect(result.current.onDragEnd).toBeInstanceOf(Function);
     expect(result.current.dialogProps).toEqual({ children: dialogChild });
-    expect(result.current.contextValue).toEqual({
-      id: 'draggable-dialog',
+
+    const { id, ...values } = result.current.contextValue;
+
+    expect(values).toEqual({
       hasBeenDragged: false,
       hasDraggableParent: true,
       isDragging: false,
       position: { x: 0, y: 0 },
     });
+    expect(id).toEqual(expect.any(String));
 
     const sensorNames = result.current.sensors.map(({ sensor }) => sensor.name);
 
@@ -75,13 +69,15 @@ describe('DraggableDialog', () => {
       });
     });
 
-    expect(result.current.contextValue).toEqual({
-      id: 'draggable-dialog',
+    const { id, ...values } = result.current.contextValue;
+
+    expect(values).toEqual({
       hasBeenDragged: false,
       hasDraggableParent: true,
       isDragging: false,
       position: { x: 0, y: 0 },
     });
+    expect(id).toEqual(expect.any(String));
   });
 
   it('should return default values with announcements', () => {

--- a/packages/react-draggable-dialog/src/components/DraggableDialogHandle/DraggableDialogHandle.test.tsx
+++ b/packages/react-draggable-dialog/src/components/DraggableDialogHandle/DraggableDialogHandle.test.tsx
@@ -7,19 +7,15 @@ import * as contexts from '../../contexts/DraggableDialogContext';
 import * as dnd from '@dnd-kit/core';
 import { DraggableDialogHandleState } from './DraggableDialogHandle.types';
 
-jest.mock('../../contexts/DraggableDialogContext', () => {
-  return {
-    __esModule: true,
-    ...jest.requireActual('../../contexts/DraggableDialogContext'),
-  };
-});
+jest.mock('../../contexts/DraggableDialogContext', () => ({
+  __esModule: true,
+  ...jest.requireActual('../../contexts/DraggableDialogContext'),
+}));
 
-jest.mock('@dnd-kit/core', () => {
-  return {
-    __esModule: true,
-    ...jest.requireActual('@dnd-kit/core'),
-  };
-});
+jest.mock('@dnd-kit/core', () => ({
+  __esModule: true,
+  ...jest.requireActual('@dnd-kit/core'),
+}));
 
 describe('DraggableDialogHandle', () => {
   let consoleErrorSpy: jest.SpyInstance;

--- a/packages/react-draggable-dialog/src/components/DraggableDialogSurface/DraggableDialogSurface.test.tsx
+++ b/packages/react-draggable-dialog/src/components/DraggableDialogSurface/DraggableDialogSurface.test.tsx
@@ -5,12 +5,10 @@ import { DraggableDialogSurface } from './DraggableDialogSurface';
 import * as contexts from '../../contexts/DraggableDialogContext';
 import { useDraggableDialogSurface } from './useDraggableDialogSurface';
 
-jest.mock('../../contexts/DraggableDialogContext', () => {
-  return {
-    __esModule: true,
-    ...jest.requireActual('../../contexts/DraggableDialogContext'),
-  };
-});
+jest.mock('../../contexts/DraggableDialogContext', () => ({
+  __esModule: true,
+  ...jest.requireActual('../../contexts/DraggableDialogContext'),
+}));
 
 const getCustomEl = () => {
   const divEl = document.createElement('div');


### PR DESCRIPTION
A quick fix removing forced mocks for the entire react-components package