### PR TITLE
BREAKING: Stopping a fallback animation should be imperative

### DIFF
--- a/change/@fluentui-contrib-houdini-utils-09b68852-bed9-4483-9f6c-f11a7abdb080.json
+++ b/change/@fluentui-contrib-houdini-utils-09b68852-bed9-4483-9f6c-f11a7abdb080.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "BREAKING: Stopping a fallback animation should be imperative",
+  "packageName": "@fluentui-contrib/houdini-utils",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/houdini-utils/CHANGELOG.json
+++ b/packages/houdini-utils/CHANGELOG.json
@@ -2,6 +2,21 @@
   "name": "@fluentui-contrib/houdini-utils",
   "entries": [
     {
+      "date": "Fri, 08 Mar 2024 11:55:38 GMT",
+      "tag": "@fluentui-contrib/houdini-utils_v0.1.1",
+      "version": "0.1.1",
+      "comments": {
+        "patch": [
+          {
+            "author": "lingfangao@hotmail.com",
+            "package": "@fluentui-contrib/houdini-utils",
+            "commit": "0d482594161a49a9eacddd288391332e01708c27",
+            "comment": "fix: re-export addModule"
+          }
+        ]
+      }
+    },
+    {
       "date": "Thu, 07 Mar 2024 13:28:23 GMT",
       "tag": "@fluentui-contrib/houdini-utils_v0.1.0",
       "version": "0.1.0",

--- a/packages/houdini-utils/CHANGELOG.md
+++ b/packages/houdini-utils/CHANGELOG.md
@@ -1,8 +1,16 @@
 # Change Log - @fluentui-contrib/houdini-utils
 
-This log was last generated on Thu, 07 Mar 2024 13:28:23 GMT and should not be manually modified.
+This log was last generated on Fri, 08 Mar 2024 11:55:38 GMT and should not be manually modified.
 
 <!-- Start content -->
+
+## 0.1.1
+
+Fri, 08 Mar 2024 11:55:38 GMT
+
+### Patches
+
+- fix: re-export addModule (lingfangao@hotmail.com)
 
 ## 0.1.0
 

--- a/packages/houdini-utils/package.json
+++ b/packages/houdini-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluentui-contrib/houdini-utils",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "dependencies": {
     "@swc/helpers": "~0.5.2"
   },

--- a/packages/houdini-utils/src/index.ts
+++ b/packages/houdini-utils/src/index.ts
@@ -1,4 +1,5 @@
-export { PaintWorklet, PaintWorkletGeometry } from './types';
+export { PaintWorklet } from './types';
+export type { PaintWorkletGeometry } from './types';
 export { registerPaintWorklet } from './paint/houdini/registerPaintWorklet';
 export { fallbackPaintAnimation } from './paint/fallback/fallbackPaintAnimation';
 export {

--- a/packages/houdini-utils/src/index.ts
+++ b/packages/houdini-utils/src/index.ts
@@ -9,3 +9,4 @@ export {
 } from './util/featureDetect';
 
 export { blobify } from './util/blobify';
+export { addModule } from './util/addModule';

--- a/packages/houdini-utils/src/paint/fallback/animate.ts
+++ b/packages/houdini-utils/src/paint/fallback/animate.ts
@@ -1,9 +1,19 @@
 import { createKeyframeAnimation } from './keyframe';
 import { arrayToRgba } from './util/css';
-import type { FallbackAnimationFn, TickFn } from '../../types';
+import type {
+  FallbackAnimation,
+  FallbackAnimationFn,
+  TickFn,
+} from '../../types';
 
 export const animate: FallbackAnimationFn = (params) => {
-  const { onComplete, isStopped, onUpdate, ...otherParams } = params;
+  const {
+    onComplete,
+    isStopped,
+    onUpdate,
+    iterationCount = 1,
+    ...otherParams
+  } = params;
   const result = createKeyframeAnimation(otherParams);
   if (!result) {
     console.error('Unable to create keyframe animation.');
@@ -12,7 +22,7 @@ export const animate: FallbackAnimationFn = (params) => {
 
   const { anims, overallDuration } = result;
 
-  tick(anims, overallDuration, onComplete, onUpdate, Infinity, isStopped);
+  tick(anims, overallDuration, onComplete, onUpdate, iterationCount, isStopped);
 };
 
 const stringifyValue = (value: number | number[]): string =>
@@ -34,79 +44,86 @@ const tick: TickFn = (
     const currentDuration = time - start;
     currentValues.clear();
 
+    const initialFrame = (animValue: FallbackAnimation) => {
+      for (const [key, value] of Object.entries(
+        animValue.keyframes[0].startValues
+      )) {
+        currentValues.set(key, stringifyValue(value));
+      }
+    };
+
+    const lastFrame = (animValue: FallbackAnimation) => {
+      for (const [key, value] of Object.entries(
+        animValue.keyframes[animValue.keyframes.length - 1].endValues
+      )) {
+        currentValues.set(key, stringifyValue(value));
+      }
+    };
+
+    const nextFrame = (animValue: FallbackAnimation) => {
+      const animData = animValue.keyframes.find(
+        (animData) =>
+          currentDuration >= animData.startTime &&
+          currentDuration <= animData.endTime
+      );
+
+      if (!animData) {
+        console.error(
+          'Could not find animData for currentDuration',
+          currentDuration
+        );
+        return;
+      }
+
+      for (const key of Object.keys(animData.startValues)) {
+        const startValue = animData.startValues[key];
+        const endValue = animData.endValues[key];
+        const value = animData.ease(
+          startValue,
+          endValue,
+          currentDuration - animData.startTime,
+          animData.duration
+        );
+
+        animValue.currentValues[key] = value;
+        currentValues.set(key, stringifyValue(value));
+      }
+    };
+
     for (const animValue of anims) {
       if (currentDuration <= animValue.keyframes[0].startTime) {
-        // We're before the first animation.
-        // Just use its initial values.
-        for (const [key, value] of Object.entries(
-          animValue.keyframes[0].startValues
-        )) {
-          currentValues.set(key, stringifyValue(value));
-        }
+        initialFrame(animValue);
       } else if (
         currentDuration >=
         animValue.keyframes[animValue.keyframes.length - 1].endTime
       ) {
         // We're after the last animation.
         // Just use its final values.
-        for (const [key, value] of Object.entries(
-          animValue.keyframes[animValue.keyframes.length - 1].endValues
-        )) {
-          currentValues.set(key, stringifyValue(value));
-        }
+        lastFrame(animValue);
       } else {
-        const animData = animValue.keyframes.find(
-          (animData) =>
-            currentDuration >= animData.startTime &&
-            currentDuration <= animData.endTime
-        );
-
-        if (!animData) {
-          console.error(
-            'Could not find animData for currentDuration',
-            currentDuration
-          );
-          return;
-        }
-
-        for (const key of Object.keys(animData.startValues)) {
-          const startValue = animData.startValues[key];
-          const endValue = animData.endValues[key];
-          const value = animData.ease(
-            startValue,
-            endValue,
-            currentDuration - animData.startTime,
-            animData.duration
-          );
-
-          animValue.currentValues[key] = value;
-          currentValues.set(key, stringifyValue(value));
-        }
+        nextFrame(animValue);
       }
+    }
+
+    if (isStopped()) {
+      for (const animValue of anims) {
+        initialFrame(animValue);
+      }
+      onComplete(currentValues);
+    } else if (
+      currentDuration >= overallDuration &&
+      currentIteration < iterationCount
+    ) {
+      currentIteration++;
+      start = performance.now();
+      requestAnimationFrame(raf);
+    } else if (currentDuration >= overallDuration) {
+      onComplete(currentValues);
+    } else {
+      requestAnimationFrame(raf);
     }
 
     onUpdate(currentValues);
-
-    if (isStopped() === true) {
-      if (currentDuration >= overallDuration) {
-        onComplete(currentValues);
-      } else {
-        requestAnimationFrame(raf);
-      }
-    } else {
-      if (currentDuration >= overallDuration) {
-        if (currentIteration < iterationCount) {
-          currentIteration++;
-          start = performance.now();
-          requestAnimationFrame(raf);
-          // how to reset this animation??
-        } else {
-          onComplete(currentValues);
-        }
-      } else {
-        requestAnimationFrame(raf);
-      }
-    }
   };
 
   raf();

--- a/packages/houdini-utils/src/paint/fallback/animate.ts
+++ b/packages/houdini-utils/src/paint/fallback/animate.ts
@@ -108,7 +108,11 @@ const tick: TickFn = (
       onComplete(currentValues);
     } else if (
       currentDuration >= overallDuration &&
-      anims.some(anim => anim.keyframes.some(keyframe => currentIteration < keyframe.iterationCount))
+      anims.some((anim) =>
+        anim.keyframes.some(
+          (keyframe) => currentIteration < keyframe.iterationCount
+        )
+      )
     ) {
       currentIteration++;
       start = performance.now();

--- a/packages/houdini-utils/src/paint/fallback/anims/play.ts
+++ b/packages/houdini-utils/src/paint/fallback/anims/play.ts
@@ -43,9 +43,9 @@ export const playAnim = (
 
   return (
     onComplete: CallbackFn,
-    isStopped: () => boolean,
     onUpdate?: CallbackFn
   ) => {
+    state.running = true;
     resizeObserver.observe(state.target);
 
     const onAnimUpdate: CallbackFn = (currentValues) => {
@@ -70,9 +70,10 @@ export const playAnim = (
     animate({
       ...animationParams,
       target: state.target,
-      isStopped,
+      isStopped: () => !state.running,
       onUpdate: onAnimUpdate,
       onComplete: (currentValues) => {
+        state.running = false;
         resizeObserver.unobserve(state.target);
         onComplete(currentValues);
       },

--- a/packages/houdini-utils/src/paint/fallback/anims/play.ts
+++ b/packages/houdini-utils/src/paint/fallback/anims/play.ts
@@ -41,10 +41,7 @@ export const playAnim = (
     }
   });
 
-  return (
-    onComplete: CallbackFn,
-    onUpdate?: CallbackFn
-  ) => {
+  return (onComplete: CallbackFn, onUpdate?: CallbackFn) => {
     state.running = true;
     resizeObserver.observe(state.target);
 

--- a/packages/houdini-utils/src/paint/fallback/fallbackPaintAnimation.ts
+++ b/packages/houdini-utils/src/paint/fallback/fallbackPaintAnimation.ts
@@ -20,6 +20,8 @@ const cannotDraw = {
   play: () => {},
   // eslint-disable-next-line @typescript-eslint/no-empty-function
   cleanup: () => {},
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  stop: () => {},
 };
 
 let flairFallbackId = 0;
@@ -35,6 +37,7 @@ export const fallbackPaintAnimation = (
     mode: 'to-data-url',
     id: `houdini-fallback-${++flairFallbackId}`,
     wrapper: null,
+    running: false,
   };
 
   // Non-Houdini fallbacks require a canvas element be present in the DOM.
@@ -70,6 +73,9 @@ export const fallbackPaintAnimation = (
   }
 
   const play = playAnim(state, paintWorklet, animationParams);
+  const stop = () => {
+    state.running = false;
+  };
   const cleanup = () => {
     state.ctx?.canvas.remove();
     if (state.wrapper?.childElementCount === 0) {
@@ -82,5 +88,6 @@ export const fallbackPaintAnimation = (
     canvas: state.ctx?.canvas ?? null,
     play,
     cleanup,
+    stop,
   };
 };

--- a/packages/houdini-utils/src/paint/fallback/keyframe.ts
+++ b/packages/houdini-utils/src/paint/fallback/keyframe.ts
@@ -21,8 +21,10 @@ export const createKeyframeAnimation: CreateKeyframeAnimationFn = ({
   delay,
   duration,
   timingFunction,
+  iterationCount = [1],
   target,
 }) => {
+  const iterations = iterationCount;
   const durations = duration.split(',').map(timeToNumber);
   const delays = delay.split(',').map(timeToNumber);
   const timingFunctions = timingFunction.split(',').map(processTimingFunction);
@@ -43,6 +45,7 @@ export const createKeyframeAnimation: CreateKeyframeAnimationFn = ({
       return;
     }
 
+    const iterationCount = iterations[animationIndex] ?? 1;
     const delay = delays[animationIndex] ?? 0;
     const duration = durations[animationIndex] ?? 0;
     const animDuration = delay + duration;
@@ -94,6 +97,7 @@ export const createKeyframeAnimation: CreateKeyframeAnimationFn = ({
       }
 
       anim.keyframes.push({
+        iterationCount,
         startTime,
         endTime,
         duration: endTime - startTime,

--- a/packages/houdini-utils/src/types.ts
+++ b/packages/houdini-utils/src/types.ts
@@ -14,7 +14,7 @@ export interface PaintWorkletGeometry {
 /**
  * Function that animates values.
  */
-export type FallbackAnimationFn = (params: FallbackAnimationParams) => void;
+export type FallbackAnimationFn = (params: FallbackAnimationParams & { isStopped: () => boolean }) => void;
 
 /**
  * Function that creates keyframe animation objects from CSS input.
@@ -56,8 +56,6 @@ export type FallbackAnimationParams = {
    * HTML element where the animation will be applied.
    */
   target: HTMLElement;
-
-  isStopped: () => boolean;
 
   /**
    * Callback function that will be called on every animation frame.
@@ -191,11 +189,8 @@ export type TickFn = (
 export type FallbackAnimationReturn = {
   id: string;
   canvas: HTMLCanvasElement | null;
-  play: (
-    onComplete: CallbackFn,
-    isStopped: () => boolean,
-    onUpdate?: CallbackFn
-  ) => void;
+  play: (onComplete: CallbackFn, onUpdate?: CallbackFn) => void;
+  stop: () => void;
   cleanup: () => void;
 };
 
@@ -205,4 +200,5 @@ export type FallbackAnimationState = {
   id: string;
   mode: 'moz-element' | 'webkit-canvas' | 'to-data-url';
   wrapper: HTMLElement | null;
+  running: boolean;
 };

--- a/packages/houdini-utils/src/types.ts
+++ b/packages/houdini-utils/src/types.ts
@@ -14,7 +14,9 @@ export interface PaintWorkletGeometry {
 /**
  * Function that animates values.
  */
-export type FallbackAnimationFn = (params: FallbackAnimationParams & { isStopped: () => boolean }) => void;
+export type FallbackAnimationFn = (
+  params: FallbackAnimationParams & { isStopped: () => boolean }
+) => void;
 
 /**
  * Function that creates keyframe animation objects from CSS input.

--- a/packages/houdini-utils/src/types.ts
+++ b/packages/houdini-utils/src/types.ts
@@ -28,9 +28,10 @@ export type CreateKeyframeAnimationFn = (
 export type FallbackAnimationParams = {
   /**
    * CSS animation-iteration-count longhand property
-   * @default 1
+   * The order of iteration counts should match the order of the animations.
+   * @default [1]
    */
-  iterationCount?: number;
+  iterationCount?: number[];
   /**
    * CSS keyframe animation steps.
    */
@@ -92,6 +93,11 @@ export type FallbackAnimationSteps = {
 };
 
 export type FallbackKeyframe = {
+  /**
+   * Number of times this keyframe will be played.
+   */
+  iterationCount: number;
+
   /**
    * Time in ms when the keyframe starts, including delay.
    */
@@ -184,7 +190,6 @@ export type TickFn = (
    */
   onUpdate: CallbackFn,
 
-  iterationCount: number,
   isStopped: () => boolean
 ) => void;
 

--- a/packages/houdini-utils/stories/Utils/Fallback.stories.tsx
+++ b/packages/houdini-utils/stories/Utils/Fallback.stories.tsx
@@ -53,7 +53,7 @@ export const fallback = (target: HTMLElement) => {
   return fallbackPaintAnimation(target, new MyPaintWorklet(), {
     duration: '1000ms',
     timingFunction: 'ease-in-out',
-    iterationCount: Infinity,
+    iterationCount: [Infinity],
     target,
     onComplete: () => null,
     onUpdate: () => null,

--- a/packages/houdini-utils/stories/Utils/FallbackWithDuration.stories.tsx
+++ b/packages/houdini-utils/stories/Utils/FallbackWithDuration.stories.tsx
@@ -8,7 +8,7 @@ import {
   PaintWorklet,
   PaintWorkletGeometry,
 } from '@fluentui-contrib/houdini-utils';
-import { Switch } from '@fluentui/react-components';
+import { Button } from '@fluentui/react-components';
 
 class MyPaintWorklet implements PaintWorklet {
   public static get inputProperties() {
@@ -53,7 +53,6 @@ export const fallback = (target: HTMLElement) => {
   return fallbackPaintAnimation(target, new MyPaintWorklet(), {
     duration: '1000ms',
     timingFunction: 'ease-in-out',
-    iterationCount: Infinity,
     target,
     onComplete: () => null,
     onUpdate: () => null,
@@ -90,7 +89,7 @@ const getBackgroundImage = (id: string) => {
   return undefined;
 };
 
-const useFallbackAnimation = () => {
+const useFallbackAnimation = (options: { onComplete: () => void }) => {
   const stateRef = React.useRef<'rest' | 'play'>('rest');
   const playRef = React.useRef<() => void>(() => null);
   const stopRef = React.useRef<() => void>(() => null);
@@ -108,6 +107,7 @@ const useFallbackAnimation = () => {
 
     const onComplete = () => {
       stateRef.current = 'rest';
+      options.onComplete();
     };
 
     let onUpdate: () => void = () => null;
@@ -138,24 +138,22 @@ const useFallbackAnimation = () => {
   };
 };
 
-export const Fallback = () => {
-  const { targetRef, play, stop } = useFallbackAnimation();
-  const [running, setRunning] = React.useState(true);
+export const FallbackWithDuration = () => {
+  const { targetRef, play } = useFallbackAnimation({
+    onComplete: () => setRunning(false),
+  });
+  const [running, setRunning] = React.useState(false);
   React.useEffect(() => {
     if (running) {
       play();
-    } else {
-      stop();
     }
   }, [running]);
 
   return (
     <>
-      <Switch
-        onChange={(e, data) => setRunning(data.checked)}
-        checked={running}
-        label="Toggle animation"
-      />
+      <Button disabled={running} onClick={() => setRunning(true)}>
+        Play
+      </Button>
       <div
         ref={targetRef}
         style={

--- a/packages/houdini-utils/stories/Utils/FallbackWithDuration.stories.tsx
+++ b/packages/houdini-utils/stories/Utils/FallbackWithDuration.stories.tsx
@@ -53,6 +53,7 @@ export const fallback = (target: HTMLElement) => {
   return fallbackPaintAnimation(target, new MyPaintWorklet(), {
     duration: '1000ms',
     timingFunction: 'ease-in-out',
+    iterationCount: [2],
     target,
     onComplete: () => null,
     onUpdate: () => null,

--- a/packages/houdini-utils/stories/Utils/index.stories.tsx
+++ b/packages/houdini-utils/stories/Utils/index.stories.tsx
@@ -3,6 +3,7 @@ import { Meta } from '@storybook/react';
 
 export { Default } from './Default.stories';
 export { Fallback } from './Fallback.stories';
+export { FallbackWithDuration } from './FallbackWithDuration.stories';
 
 const meta: Meta = {
   title: 'Houdini Utils',


### PR DESCRIPTION
Ths user will no longer need to provide a stopping condition. The fallback animation now returns its own imperative `stop` function

## Before

```ts
const animation = fallbackPaintAnimation({...options, isStopped: ()  => false});
const { id, play, canvas, cleanup } = animation(node);

let stopCondition = false;
const isStopped = () => stopCondition === true;
play(onComplete, isStopped, onUpdate);

const stop = () => stopCondition = true;

// stops the animation
stop();
```

## After

```ts
const animation = fallbackPaintAnimation({...options});
const { id, play, stop, canvas, cleanup } = animation(node);

play(onComplete, onUpdate);

// stops the animation
stop();
```