### PR TITLE
BREAKING: Remove unnecessary API and handle fallback image internally

### DIFF
--- a/change/@fluentui-contrib-houdini-utils-f257be28-ff99-4755-a95e-f22fef91a1db.json
+++ b/change/@fluentui-contrib-houdini-utils-f257be28-ff99-4755-a95e-f22fef91a1db.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "BREAKING: Remove unnecessary API and handle fallback image internally",
+  "packageName": "@fluentui-contrib/houdini-utils",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/houdini-utils/src/paint/fallback/anims/play.ts
+++ b/packages/houdini-utils/src/paint/fallback/anims/play.ts
@@ -10,16 +10,6 @@ import { hasMozElement, hasWebkitCanvas } from '../../../util/featureDetect';
 
 export type PlayAnimFn = () => (state: FallbackAnimationState) => () => void;
 
-const getBackgroundImage = (id: string) => {
-  if (hasMozElement()) {
-    return `-moz-element(#${id})`;
-  } else if (hasWebkitCanvas()) {
-    return `-webkit-canvas(${id})`;
-  }
-
-  return undefined;
-};
-
 export const playAnim = (
   state: FallbackAnimationState,
   paintWorklet: PaintWorklet,
@@ -73,9 +63,12 @@ export const playAnim = (
       }
       paintWorklet.paint(state.ctx, rect, props);
 
-      const backgroundImage = getBackgroundImage(state.id);
-      if (backgroundImage) {
-        state.target.style.backgroundImage = backgroundImage;
+      // Firefox and webkit both support using canvas as a background image
+      // For all other browsers, we'll use a data url
+      if (hasMozElement()) {
+        state.target.style.backgroundImage = `-moz-element(#${state.id})`;
+      } else if (hasWebkitCanvas()) {
+        state.target.style.backgroundImage = `-webkit-canvas(#${state.id})`;
       } else {
         const urlBackgroundImage = `url(${state.ctx.canvas.toDataURL(
           'image/png'

--- a/packages/houdini-utils/src/paint/fallback/anims/play.ts
+++ b/packages/houdini-utils/src/paint/fallback/anims/play.ts
@@ -6,8 +6,19 @@ import type {
   FallbackAnimationState,
   PaintWorklet,
 } from '../../../types';
+import { hasMozElement, hasWebkitCanvas } from '../../../util/featureDetect';
 
 export type PlayAnimFn = () => (state: FallbackAnimationState) => () => void;
+
+const getBackgroundImage = (id: string) => {
+  if (hasMozElement()) {
+    return `-moz-element(#${id})`;
+  } else if (hasWebkitCanvas()) {
+    return `-webkit-canvas(${id})`;
+  }
+
+  return undefined;
+};
 
 export const playAnim = (
   state: FallbackAnimationState,
@@ -61,6 +72,17 @@ export const playAnim = (
         props.set(key, value);
       }
       paintWorklet.paint(state.ctx, rect, props);
+
+      const backgroundImage = getBackgroundImage(state.id);
+      if (backgroundImage) {
+        state.target.style.backgroundImage = backgroundImage;
+      } else {
+        const urlBackgroundImage = `url(${state.ctx.canvas.toDataURL(
+          'image/png'
+        )})`;
+        state.target.style.backgroundImage = urlBackgroundImage;
+      }
+
       onUpdate?.(currentValues);
     };
 

--- a/packages/houdini-utils/src/types.ts
+++ b/packages/houdini-utils/src/types.ts
@@ -15,14 +15,35 @@ export interface PaintWorkletGeometry {
  * Function that animates values.
  */
 export type FallbackAnimationFn = (
-  params: FallbackAnimationParams & { isStopped: () => boolean }
+  params: FallbackAnimationParamsInternal & { isStopped: () => boolean }
 ) => void;
+
+export type FallbackKeyframeParams = Pick<
+  FallbackAnimationParams,
+  'animations' | 'delay' | 'duration' | 'iterationCount' | 'timingFunction'
+> & {
+  target: HTMLElement;
+};
+
+export type FallbackAnimationParamsInternal = FallbackKeyframeParams & {
+  target: HTMLElement;
+
+  /**
+   * Callback function that will be called on every animation frame.
+   */
+  onUpdate: CallbackFn;
+
+  /**
+   * Callback function that will be called when the animation is complete.
+   */
+  onComplete: CallbackFn;
+};
 
 /**
  * Function that creates keyframe animation objects from CSS input.
  */
 export type CreateKeyframeAnimationFn = (
-  params: CreateKeyframeAnimationParams
+  params: FallbackKeyframeParams
 ) => { anims: FallbackAnimation[]; overallDuration: number } | undefined;
 
 export type FallbackAnimationParams = {
@@ -54,21 +75,6 @@ export type FallbackAnimationParams = {
    * @see https://developer.mozilla.org/en-US/docs/Web/CSS/animation-timing-function
    */
   timingFunction: string;
-
-  /**
-   * HTML element where the animation will be applied.
-   */
-  target: HTMLElement;
-
-  /**
-   * Callback function that will be called on every animation frame.
-   */
-  onUpdate: CallbackFn;
-
-  /**
-   * Callback function that will be called when the animation is complete.
-   */
-  onComplete: CallbackFn;
 };
 
 export type CreateKeyframeAnimationParams = Omit<
@@ -196,7 +202,11 @@ export type TickFn = (
 export type FallbackAnimationReturn = {
   id: string;
   canvas: HTMLCanvasElement | null;
-  play: (onComplete: CallbackFn, onUpdate?: CallbackFn) => void;
+  /**
+   * @param onComplete Callback when animation completes
+   * @param onUpdate Update called on each new frame
+   */
+  play(onComplete: CallbackFn, onUpdate?: CallbackFn): void;
   stop: () => void;
   cleanup: () => void;
 };

--- a/packages/houdini-utils/stories/Utils/Fallback.stories.tsx
+++ b/packages/houdini-utils/stories/Utils/Fallback.stories.tsx
@@ -97,7 +97,7 @@ const useFallbackAnimation = () => {
     playRef.current = () => {
       if (stateRef.current === 'rest') {
         stateRef.current = 'play';
-        play(onComplete, () => null);
+        play(onComplete);
       }
     };
   }, []);

--- a/packages/houdini-utils/stories/Utils/FallbackWithDuration.stories.tsx
+++ b/packages/houdini-utils/stories/Utils/FallbackWithDuration.stories.tsx
@@ -54,9 +54,6 @@ export const fallback = (target: HTMLElement) => {
     duration: '1000ms',
     timingFunction: 'ease-in-out',
     iterationCount: [2],
-    target,
-    onComplete: () => null,
-    onUpdate: () => null,
     delay: '0',
     animations: [
       {

--- a/packages/houdini-utils/stories/Utils/FallbackWithDuration.stories.tsx
+++ b/packages/houdini-utils/stories/Utils/FallbackWithDuration.stories.tsx
@@ -3,8 +3,6 @@ import {
   blobify,
   registerPaintWorklet,
   fallbackPaintAnimation,
-  hasMozElement,
-  hasWebkitCanvas,
   PaintWorklet,
   PaintWorkletGeometry,
 } from '@fluentui-contrib/houdini-utils';
@@ -77,16 +75,6 @@ export const fallback = (target: HTMLElement) => {
   });
 };
 
-const getBackgroundImage = (id: string) => {
-  if (hasMozElement()) {
-    return `-moz-element(#${id})`;
-  } else if (hasWebkitCanvas()) {
-    return `-webkit-canvas(${id})`;
-  }
-
-  return undefined;
-};
-
 const useFallbackAnimation = (options: { onComplete: () => void }) => {
   const stateRef = React.useRef<'rest' | 'play'>('rest');
   const playRef = React.useRef<() => void>(() => null);
@@ -98,33 +86,19 @@ const useFallbackAnimation = (options: { onComplete: () => void }) => {
       return;
     }
 
-    const { id, play, stop, canvas, cleanup } = fallback(node);
+    const { play, stop, cleanup } = fallback(node);
     stopRef.current = stop;
     cleanupRef.current = cleanup;
-    const backgroundImage = getBackgroundImage(id);
 
     const onComplete = () => {
       stateRef.current = 'rest';
       options.onComplete();
     };
 
-    let onUpdate: () => void = () => null;
-
-    if (backgroundImage) {
-      node.style.backgroundImage = backgroundImage;
-    } else {
-      onUpdate = () => {
-        if (canvas) {
-          const backgroundImage = `url(${canvas.toDataURL('image/png')})`;
-          node.style.backgroundImage = backgroundImage;
-        }
-      };
-    }
-
     playRef.current = () => {
       if (stateRef.current === 'rest') {
         stateRef.current = 'play';
-        play(onComplete, onUpdate);
+        play(onComplete);
       }
     };
   }, []);


### PR DESCRIPTION
## Background image

Background images are now handled internally - this is no longer necessary in userland. However `onUpdate` can still be used for custom user handling

## API dedupication

The follow properties in the options of `fallbackPaintAnimation` were redundant:

* `target - this was the first argument of `fallbackPaintAnimation`
* `onComplete` - this can be set in the `play` function
* `onUpdate` - this can be set in the `play` function

