### PR TITLE
fix: iterations should be tracked with 1 indexing

### DIFF
--- a/change/@fluentui-contrib-houdini-utils-117ef41d-ff9b-42d8-a858-02d3dbda566d.json
+++ b/change/@fluentui-contrib-houdini-utils-117ef41d-ff9b-42d8-a858-02d3dbda566d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: iterations should be tracked with 1 indexing",
+  "packageName": "@fluentui-contrib/houdini-utils",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/houdini-utils/src/paint/fallback/animate.ts
+++ b/packages/houdini-utils/src/paint/fallback/animate.ts
@@ -31,7 +31,7 @@ const tick: TickFn = (
 ) => {
   let start = performance.now();
   const currentValues = new Map<string, string>();
-  let currentIteration = 0;
+  let currentIteration = 1;
 
   const raf = (time: number = performance.now()) => {
     const currentDuration = time - start;
@@ -84,7 +84,7 @@ const tick: TickFn = (
     };
 
     for (const animValue of anims) {
-      if (currentIteration >= animValue.keyframes[0].iterationCount) {
+      if (currentIteration > animValue.keyframes[0].iterationCount) {
         // We've completed all iterations - just render the last frame
         lastFrame(animValue);
       } else if (currentDuration <= animValue.keyframes[0].startTime) {


### PR DESCRIPTION
Iterations were tracked  with 0 indexing which resulted in a bug since iteration counts are defined with 1 indexing numbers.