### PR TITLE
minor(react-data-grid-react-window-grid): bug fix on columnWidth not been called when rerendered

### DIFF
--- a/change/@fluentui-contrib-react-data-grid-react-window-grid-6e4cc41f-2239-4863-b583-e9c7ef52d150.json
+++ b/change/@fluentui-contrib-react-data-grid-react-window-grid-6e4cc41f-2239-4863-b583-e9c7ef52d150.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "minor(react-data-grid-react-window-grid): bug fix on columnWidth not been called when rerendered",
+  "packageName": "@fluentui-contrib/react-data-grid-react-window-grid",
+  "email": "fengqi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-data-grid-react-window-grid/src/components/DataGrid/DataGrid.tsx
+++ b/packages/react-data-grid-react-window-grid/src/components/DataGrid/DataGrid.tsx
@@ -4,8 +4,8 @@ import { renderDataGrid_unstable } from './renderDataGrid';
 import {
   useDataGridStyles_unstable,
   useDataGridContextValues_unstable,
-  DataGridProps,
 } from '@fluentui/react-components';
+import { DataGridProps } from './DataGrid.types';
 
 export const DataGrid = React.forwardRef<HTMLDivElement, DataGridProps>(
   (props, ref) => {

--- a/packages/react-data-grid-react-window-grid/src/components/DataGrid/DataGrid.types.ts
+++ b/packages/react-data-grid-react-window-grid/src/components/DataGrid/DataGrid.types.ts
@@ -1,10 +1,10 @@
 import {
-  DataGridProps as OldDataGridProps,
+  DataGridProps as BaseDataGridProps,
   DataGridState as BaseDataGridState,
 } from '@fluentui/react-components';
 import { RefObject } from 'react';
 import { VariableSizeGrid, VariableSizeList } from 'react-window';
-export type DataGridProps = OldDataGridProps & {
+export type DataGridProps = BaseDataGridProps & {
   bodyRef?: RefObject<VariableSizeGrid>;
   headerRef?: RefObject<VariableSizeList>;
 };

--- a/packages/react-data-grid-react-window-grid/src/components/DataGrid/DataGrid.types.ts
+++ b/packages/react-data-grid-react-window-grid/src/components/DataGrid/DataGrid.types.ts
@@ -1,0 +1,9 @@
+import { DataGridProps as OldDataGridProps, DataGridState as BaseDataGridState } from "@fluentui/react-components"
+import { RefObject } from "react"
+import { VariableSizeGrid, VariableSizeList } from "react-window"
+export type DataGridProps = OldDataGridProps & {
+  bodyRef?: RefObject<VariableSizeGrid>;
+  headerRef?: RefObject<VariableSizeList>;
+}
+
+export type DataGridState = BaseDataGridState & Required<Pick<DataGridProps, 'bodyRef' | 'headerRef'>>;

--- a/packages/react-data-grid-react-window-grid/src/components/DataGrid/DataGrid.types.ts
+++ b/packages/react-data-grid-react-window-grid/src/components/DataGrid/DataGrid.types.ts
@@ -1,9 +1,13 @@
-import { DataGridProps as OldDataGridProps, DataGridState as BaseDataGridState } from "@fluentui/react-components"
-import { RefObject } from "react"
-import { VariableSizeGrid, VariableSizeList } from "react-window"
+import {
+  DataGridProps as OldDataGridProps,
+  DataGridState as BaseDataGridState,
+} from '@fluentui/react-components';
+import { RefObject } from 'react';
+import { VariableSizeGrid, VariableSizeList } from 'react-window';
 export type DataGridProps = OldDataGridProps & {
   bodyRef?: RefObject<VariableSizeGrid>;
   headerRef?: RefObject<VariableSizeList>;
-}
+};
 
-export type DataGridState = BaseDataGridState & Required<Pick<DataGridProps, 'bodyRef' | 'headerRef'>>;
+export type DataGridState = BaseDataGridState &
+  Required<Pick<DataGridProps, 'bodyRef' | 'headerRef'>>;

--- a/packages/react-data-grid-react-window-grid/src/components/DataGrid/index.ts
+++ b/packages/react-data-grid-react-window-grid/src/components/DataGrid/index.ts
@@ -1,3 +1,4 @@
 export * from './DataGrid';
 export * from './useDataGrid';
 export * from './renderDataGrid';
+export * from './DataGrid.types';

--- a/packages/react-data-grid-react-window-grid/src/components/DataGrid/renderDataGrid.tsx
+++ b/packages/react-data-grid-react-window-grid/src/components/DataGrid/renderDataGrid.tsx
@@ -13,7 +13,6 @@ export const renderDataGrid_unstable = (
   state: DataGridState,
   contextValues: DataGridContextValues
 ) => {
-
   return (
     <HeaderListRefContextProvider value={state.headerRef}>
       <BodyRefContextProvider value={state.bodyRef}>

--- a/packages/react-data-grid-react-window-grid/src/components/DataGrid/renderDataGrid.tsx
+++ b/packages/react-data-grid-react-window-grid/src/components/DataGrid/renderDataGrid.tsx
@@ -1,12 +1,11 @@
 import * as React from 'react';
 import {
   renderDataGrid_unstable as renderDataGridBase,
-  DataGridState,
   DataGridContextValues,
 } from '@fluentui/react-components';
 import { HeaderListRefContextProvider } from '../../contexts/headerListRefContext';
-import { VariableSizeGrid, VariableSizeList } from 'react-window';
 import { BodyRefContextProvider } from '../../contexts/bodyRefContext';
+import { DataGridState } from './DataGrid.types';
 /**
  * Render the final JSX of DataGrid
  */
@@ -14,11 +13,10 @@ export const renderDataGrid_unstable = (
   state: DataGridState,
   contextValues: DataGridContextValues
 ) => {
-  const headerRef = React.useRef<VariableSizeList>(null);
-  const bodyRef = React.useRef<VariableSizeGrid>(null);
+
   return (
-    <HeaderListRefContextProvider value={headerRef}>
-      <BodyRefContextProvider value={bodyRef}>
+    <HeaderListRefContextProvider value={state.headerRef}>
+      <BodyRefContextProvider value={state.bodyRef}>
         {renderDataGridBase(state, contextValues)}
       </BodyRefContextProvider>
     </HeaderListRefContextProvider>

--- a/packages/react-data-grid-react-window-grid/src/components/DataGrid/useDataGrid.ts
+++ b/packages/react-data-grid-react-window-grid/src/components/DataGrid/useDataGrid.ts
@@ -1,7 +1,5 @@
 import * as React from 'react';
-import {
-  useDataGrid_unstable as useBaseState,
-} from '@fluentui/react-components';
+import { useDataGrid_unstable as useBaseState } from '@fluentui/react-components';
 import { useFluent, useScrollbarWidth } from '@fluentui/react-components';
 import { DataGridProps, DataGridState } from './DataGrid.types';
 import { VariableSizeGrid, VariableSizeList } from 'react-window';
@@ -35,12 +33,12 @@ export const useDataGrid_unstable = (
 
   const baseState = useBaseState(
     { ...props, 'aria-rowcount': props.items.length, containerWidthOffset },
-    ref,
+    ref
   );
 
   return {
     ...baseState,
     bodyRef: props.bodyRef ?? React.useRef<VariableSizeGrid>(null),
-    headerRef: props.headerRef ?? React.useRef<VariableSizeList>(null)
-  }
+    headerRef: props.headerRef ?? React.useRef<VariableSizeList>(null),
+  };
 };

--- a/packages/react-data-grid-react-window-grid/src/components/DataGrid/useDataGrid.ts
+++ b/packages/react-data-grid-react-window-grid/src/components/DataGrid/useDataGrid.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { useDataGrid_unstable as useBaseState } from '@fluentui/react-components';
+import { useDataGrid_unstable as useBaseState, useMergedRefs } from '@fluentui/react-components';
 import { useFluent, useScrollbarWidth } from '@fluentui/react-components';
 import { DataGridProps, DataGridState } from './DataGrid.types';
 import { VariableSizeGrid, VariableSizeList } from 'react-window';
@@ -36,9 +36,12 @@ export const useDataGrid_unstable = (
     ref
   );
 
+  const innerBodyRef = React.useRef<VariableSizeGrid>(null);
+  const innerHeaderRef = React.useRef<VariableSizeList>(null);
+
   return {
     ...baseState,
-    bodyRef: props.bodyRef ?? React.useRef<VariableSizeGrid>(null),
-    headerRef: props.headerRef ?? React.useRef<VariableSizeList>(null),
+    bodyRef: useMergedRefs(props.bodyRef, innerBodyRef),
+    headerRef: useMergedRefs(props.headerRef, innerHeaderRef),
   };
 };

--- a/packages/react-data-grid-react-window-grid/src/components/DataGrid/useDataGrid.ts
+++ b/packages/react-data-grid-react-window-grid/src/components/DataGrid/useDataGrid.ts
@@ -1,10 +1,10 @@
 import * as React from 'react';
 import {
   useDataGrid_unstable as useBaseState,
-  DataGridProps,
-  DataGridState,
 } from '@fluentui/react-components';
 import { useFluent, useScrollbarWidth } from '@fluentui/react-components';
+import { DataGridProps, DataGridState } from './DataGrid.types';
+import { VariableSizeGrid, VariableSizeList } from 'react-window';
 
 const TABLE_SELECTION_CELL_WIDTH = 44;
 
@@ -33,8 +33,14 @@ export const useDataGrid_unstable = (
     containerWidthOffset -= scrollbarWidth || 0;
   }
 
-  return useBaseState(
+  const baseState = useBaseState(
     { ...props, 'aria-rowcount': props.items.length, containerWidthOffset },
-    ref
+    ref,
   );
+
+  return {
+    ...baseState,
+    bodyRef: props.bodyRef ?? React.useRef<VariableSizeGrid>(null),
+    headerRef: props.headerRef ?? React.useRef<VariableSizeList>(null)
+  }
 };

--- a/packages/react-data-grid-react-window-grid/src/components/DataGrid/useDataGrid.ts
+++ b/packages/react-data-grid-react-window-grid/src/components/DataGrid/useDataGrid.ts
@@ -1,5 +1,8 @@
 import * as React from 'react';
-import { useDataGrid_unstable as useBaseState, useMergedRefs } from '@fluentui/react-components';
+import {
+  useDataGrid_unstable as useBaseState,
+  useMergedRefs,
+} from '@fluentui/react-components';
 import { useFluent, useScrollbarWidth } from '@fluentui/react-components';
 import { DataGridProps, DataGridState } from './DataGrid.types';
 import { VariableSizeGrid, VariableSizeList } from 'react-window';

--- a/packages/react-data-grid-react-window-grid/src/components/DataGridBody/DataGridBody.types.ts
+++ b/packages/react-data-grid-react-window-grid/src/components/DataGridBody/DataGridBody.types.ts
@@ -85,7 +85,7 @@ export type DataGridBodyState = Omit<DataGridBodyStateBase, 'renderRow'> &
     gridProps?: Partial<VariableSizeGridProps>;
 
     /**
-     * Ref of the virtualized list container ref
+     * Ref of the virtualized grid container ref
      */
     gridRef: React.RefObject<VariableSizeGrid>;
   };

--- a/packages/react-data-grid-react-window-grid/src/index.ts
+++ b/packages/react-data-grid-react-window-grid/src/index.ts
@@ -21,7 +21,7 @@ export type {
   DataGridRowProps,
 } from '@fluentui/react-components';
 
-export type { DataGridProps } from './components/DataGrid';
+export type { DataGridProps, DataGridState } from './components/DataGrid';
 
 export type {
   DataGridBodyProps,

--- a/packages/react-data-grid-react-window-grid/src/index.ts
+++ b/packages/react-data-grid-react-window-grid/src/index.ts
@@ -19,8 +19,11 @@ export type {
   DataGridHeaderProps,
   DataGridSelectionCellProps,
   DataGridRowProps,
-  DataGridProps,
 } from '@fluentui/react-components';
+
+export type {
+  DataGridProps,
+} from './components/DataGrid';
 
 export type {
   DataGridBodyProps,

--- a/packages/react-data-grid-react-window-grid/src/index.ts
+++ b/packages/react-data-grid-react-window-grid/src/index.ts
@@ -21,9 +21,7 @@ export type {
   DataGridRowProps,
 } from '@fluentui/react-components';
 
-export type {
-  DataGridProps,
-} from './components/DataGrid';
+export type { DataGridProps } from './components/DataGrid';
 
 export type {
   DataGridBodyProps,

--- a/packages/react-data-grid-react-window-grid/stories/DataGrid/VirtualizedDataGrid.stories.tsx
+++ b/packages/react-data-grid-react-window-grid/stories/DataGrid/VirtualizedDataGrid.stories.tsx
@@ -42,9 +42,7 @@ const useStyles = makeStyles({
   },
 });
 
-const COLUMN_WIDTH = 120;
-
-const rowHeights = new Array(1000).fill(44);
+const ROW_HEIGHT = 44;
 
 function getColumnDefinitions(
   columns: string[]
@@ -107,10 +105,8 @@ export const VirtualizedDataGrid: React.FunctionComponent = () => {
   const [width, setWidth] = React.useState(200);
   const columnWidth = React.useCallback(
     (index: number) =>
-      index == 0
-        ? 200
-        : new Array(columns.length).fill(true).map(() => width)[index],
-    [width, columns.length]
+      index == 0 ? 200 : width,
+    [width]
   );
   return (
     <>
@@ -152,7 +148,7 @@ export const VirtualizedDataGrid: React.FunctionComponent = () => {
           </DataGridHeaderRow>
         </DataGridHeader>
         <DataGridBody<TableUIData>
-          rowHeight={(index) => rowHeights[index]}
+          rowHeight={(index) => ROW_HEIGHT}
           height={500}
           width={1000}
           columnWidth={columnWidth}

--- a/packages/react-data-grid-react-window-grid/stories/DataGrid/VirtualizedDataGrid.stories.tsx
+++ b/packages/react-data-grid-react-window-grid/stories/DataGrid/VirtualizedDataGrid.stories.tsx
@@ -104,8 +104,7 @@ export const VirtualizedDataGrid: React.FunctionComponent = () => {
   const headerRef = React.useRef<VariableSizeList>(null);
   const [width, setWidth] = React.useState(200);
   const columnWidth = React.useCallback(
-    (index: number) =>
-      index == 0 ? 200 : width,
+    (index: number) => (index == 0 ? 200 : width),
     [width]
   );
   return (

--- a/packages/react-data-grid-react-window-grid/stories/DataGrid/VirtualizedDataGrid.stories.tsx
+++ b/packages/react-data-grid-react-window-grid/stories/DataGrid/VirtualizedDataGrid.stories.tsx
@@ -110,7 +110,7 @@ export const VirtualizedDataGrid: React.FunctionComponent = () => {
       index == 0
         ? 200
         : new Array(columns.length).fill(true).map(() => width)[index],
-    [width]
+    [width, columns.length]
   );
   return (
     <>

--- a/packages/react-data-grid-react-window-grid/stories/DataGrid/VirtualizedDataGrid.stories.tsx
+++ b/packages/react-data-grid-react-window-grid/stories/DataGrid/VirtualizedDataGrid.stories.tsx
@@ -38,7 +38,7 @@ const useStyles = makeStyles({
   },
   headerCell: {
     whiteSpace: 'nowrap',
-    boxSizing: 'border-box'
+    boxSizing: 'border-box',
   },
 });
 
@@ -104,52 +104,62 @@ export const VirtualizedDataGrid: React.FunctionComponent = () => {
   const styles = useStyles();
   const bodyRef = React.useRef<VariableSizeGrid>(null);
   const headerRef = React.useRef<VariableSizeList>(null);
-  const [ width, setWidth ] = React.useState(200);
-  const columnWidth = React.useCallback((index: number) => (index == 0 ? 200 : new Array(columns.length).fill(true).map(() => width)[index]), [width]) ;
-  return (<>
-  <Button onClick={()=> {
-    setWidth(100);
-    bodyRef.current?.resetAfterColumnIndex(0);
-    headerRef.current?.resetAfterIndex(0);
-  }}>Change column width</Button>
-  <DataGrid
-      noNativeElements
-      sortable
-      items={items}
-      columns={columns}
-      size={'medium'}
-      bodyRef={bodyRef}
-      headerRef={headerRef}
-    >
-      <DataGridHeader className={styles.tableHeader}>
-        <DataGridHeaderRow<TableUIData>
-          itemSize={columnWidth}
-          height={42}
-          width={1000}
-        >
-          {({ renderHeaderCell }, style) => {
-            return (
-              <DataGridHeaderCell
-                className={styles.headerCell}
-                as="div"
-                style={style}
-              >
-                {renderHeaderCell()}
-              </DataGridHeaderCell>
-            );
-          }}
-        </DataGridHeaderRow>
-      </DataGridHeader>
-      <DataGridBody<TableUIData>
-        rowHeight={(index) => rowHeights[index]}
-        height={500}
-        width={1000}
-        columnWidth={columnWidth}
+  const [width, setWidth] = React.useState(200);
+  const columnWidth = React.useCallback(
+    (index: number) =>
+      index == 0
+        ? 200
+        : new Array(columns.length).fill(true).map(() => width)[index],
+    [width]
+  );
+  return (
+    <>
+      <Button
+        onClick={() => {
+          setWidth(100);
+          bodyRef.current?.resetAfterColumnIndex(0);
+          headerRef.current?.resetAfterIndex(0);
+        }}
       >
-        {cellRenderer}
-      </DataGridBody>
-    </DataGrid>
-  </>
-
+        Change column width
+      </Button>
+      <DataGrid
+        noNativeElements
+        sortable
+        items={items}
+        columns={columns}
+        size={'medium'}
+        bodyRef={bodyRef}
+        headerRef={headerRef}
+      >
+        <DataGridHeader className={styles.tableHeader}>
+          <DataGridHeaderRow<TableUIData>
+            itemSize={columnWidth}
+            height={42}
+            width={1000}
+          >
+            {({ renderHeaderCell }, style) => {
+              return (
+                <DataGridHeaderCell
+                  className={styles.headerCell}
+                  as="div"
+                  style={style}
+                >
+                  {renderHeaderCell()}
+                </DataGridHeaderCell>
+              );
+            }}
+          </DataGridHeaderRow>
+        </DataGridHeader>
+        <DataGridBody<TableUIData>
+          rowHeight={(index) => rowHeights[index]}
+          height={500}
+          width={1000}
+          columnWidth={columnWidth}
+        >
+          {cellRenderer}
+        </DataGridBody>
+      </DataGrid>
+    </>
   );
 };

--- a/packages/react-data-grid-react-window-grid/stories/DataGrid/VirtualizedDataGrid.stories.tsx
+++ b/packages/react-data-grid-react-window-grid/stories/DataGrid/VirtualizedDataGrid.stories.tsx
@@ -15,7 +15,9 @@ import {
   TableCellLayout,
   TableColumnDefinition,
   createTableColumn,
+  Button,
 } from '@fluentui/react-components';
+import { VariableSizeGrid, VariableSizeList } from 'react-window';
 
 export default {
   component: DataGrid,
@@ -36,12 +38,12 @@ const useStyles = makeStyles({
   },
   headerCell: {
     whiteSpace: 'nowrap',
+    boxSizing: 'border-box'
   },
 });
 
 const COLUMN_WIDTH = 120;
-const columnWidths = new Array(50).fill(COLUMN_WIDTH);
-const columnWidth = (index: number) => (index == 0 ? 200 : columnWidths[index]);
+
 const rowHeights = new Array(1000).fill(44);
 
 function getColumnDefinitions(
@@ -100,20 +102,30 @@ export const VirtualizedDataGrid: React.FunctionComponent = () => {
   );
   const items = generateTableArrays(1000, 50);
   const styles = useStyles();
-
-  return (
-    <DataGrid
+  const bodyRef = React.useRef<VariableSizeGrid>(null);
+  const headerRef = React.useRef<VariableSizeList>(null);
+  const [ width, setWidth ] = React.useState(200);
+  const columnWidth = React.useCallback((index: number) => (index == 0 ? 200 : new Array(columns.length).fill(true).map(() => width)[index]), [width]) ;
+  return (<>
+  <Button onClick={()=> {
+    setWidth(100);
+    bodyRef.current?.resetAfterColumnIndex(0);
+    headerRef.current?.resetAfterIndex(0);
+  }}>Change column width</Button>
+  <DataGrid
       noNativeElements
       sortable
       items={items}
       columns={columns}
       size={'medium'}
+      bodyRef={bodyRef}
+      headerRef={headerRef}
     >
       <DataGridHeader className={styles.tableHeader}>
         <DataGridHeaderRow<TableUIData>
           itemSize={columnWidth}
           height={42}
-          width={20000}
+          width={1000}
         >
           {({ renderHeaderCell }, style) => {
             return (
@@ -137,5 +149,7 @@ export const VirtualizedDataGrid: React.FunctionComponent = () => {
         {cellRenderer}
       </DataGridBody>
     </DataGrid>
+  </>
+
   );
 };

--- a/packages/react-data-grid-react-window-grid/stories/DataGrid/VirtualizedDataGrid.stories.tsx
+++ b/packages/react-data-grid-react-window-grid/stories/DataGrid/VirtualizedDataGrid.stories.tsx
@@ -104,7 +104,7 @@ export const VirtualizedDataGrid: React.FunctionComponent = () => {
   const headerRef = React.useRef<VariableSizeList>(null);
   const [width, setWidth] = React.useState(200);
   const columnWidth = React.useCallback(
-    (index: number) => (index == 0 ? 200 : width),
+    (index: number) => (index === 0 ? 200 : width),
     [width]
   );
   return (


### PR DESCRIPTION
Fix issue #141, There is cache from 'react-window' for performance improvement reason. here is the doc how to force update:

> `resetAfterColumnIndex(index: number, shouldForceUpdate: boolean = true): void`
> VariableSizeGrid caches offsets and measurements for each column index for performance purposes. This method clears that 
> cached data for all columns after (and including) the specified index. It should be called whenever a column's width changes. (Note that this is not a typical occurrance.)
>
> By default the grid will automatically re-render after the index is reset. If you would like to delay this re-render until e.g. a state update has completed in the parent component, specify a value off false for the second, optional parameter.

Before fix the bug behaves:
![beforefixwidth](https://github.com/microsoft/fluentui-contrib/assets/44865230/ce053924-9359-42af-87d4-fa85ed6e71ca)
After fix:
![afterfixwidth](https://github.com/microsoft/fluentui-contrib/assets/44865230/fef7a45c-9b51-4bc3-b6f6-37876fa42af9)
