### PR TITLE
chore: mark root package.json as private in order to silence beachball and not publish something that should not be published by accident

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "fluentui-contrib",
+  "private": true,
   "version": "0.1.0",
   "license": "MIT",
   "scripts": {


### PR DESCRIPTION
see pr title