### PR TITLE
minor: add classname for react-window component to support styling by selector

### DIFF
--- a/change/@fluentui-contrib-react-data-grid-react-window-grid-d4508d9e-d1fb-4f71-b424-72cde2b05aef.json
+++ b/change/@fluentui-contrib-react-data-grid-react-window-grid-d4508d9e-d1fb-4f71-b424-72cde2b05aef.json
@@ -1,6 +1,6 @@
 {
   "type": "minor",
-  "comment": "feat: add classname for grid/list to support styling by selector",
+  "comment": "minor: add classname for grid/list to support styling by selector",
   "packageName": "@fluentui-contrib/react-data-grid-react-window-grid",
   "email": "chaxu@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@fluentui-contrib-react-data-grid-react-window-grid-d4508d9e-d1fb-4f71-b424-72cde2b05aef.json
+++ b/change/@fluentui-contrib-react-data-grid-react-window-grid-d4508d9e-d1fb-4f71-b424-72cde2b05aef.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: add classname for grid/list to support styling by selector",
+  "packageName": "@fluentui-contrib/react-data-grid-react-window-grid",
+  "email": "chaxu@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-data-grid-react-window-grid/src/components/DataGridBody/index.ts
+++ b/packages/react-data-grid-react-window-grid/src/components/DataGridBody/index.ts
@@ -2,3 +2,4 @@ export * from './DataGridBody';
 export * from './DataGridBody.types';
 export * from './renderDataGridBody';
 export * from './useDataGridBody';
+export { dataGridBodyGridClassName } from './useDataGridBodyStyles.styles';

--- a/packages/react-data-grid-react-window-grid/src/components/DataGridBody/renderDataGridBody.tsx
+++ b/packages/react-data-grid-react-window-grid/src/components/DataGridBody/renderDataGridBody.tsx
@@ -5,6 +5,7 @@ import type {
   DataGridBodySlots,
 } from './DataGridBody.types';
 import { VariableSizeGrid as Grid } from 'react-window';
+import { dataGridBodyGridClassName } from './useDataGridBodyStyles.styles';
 
 /**
  * Render the final JSX of DataGridVirtualizedBody
@@ -15,6 +16,7 @@ export const renderDataGridBody_unstable = (state: DataGridBodyState) => {
   return (
     <slots.root {...slotProps.root}>
       <Grid
+        className={dataGridBodyGridClassName}
         ref={state.gridRef}
         rowHeight={state.rowHeight}
         columnCount={state.columns.length}

--- a/packages/react-data-grid-react-window-grid/src/components/DataGridBody/useDataGridBodyStyles.styles.ts
+++ b/packages/react-data-grid-react-window-grid/src/components/DataGridBody/useDataGridBodyStyles.styles.ts
@@ -11,4 +11,5 @@ export const useDataGridBodyStyles_unstable = (
   return state;
 };
 
-export const dataGridBodyGridClassName = 'fui-DataGridReactWindowGridBody__grid';
+export const dataGridBodyGridClassName =
+  'fui-DataGridReactWindowGridBody__grid';

--- a/packages/react-data-grid-react-window-grid/src/components/DataGridBody/useDataGridBodyStyles.styles.ts
+++ b/packages/react-data-grid-react-window-grid/src/components/DataGridBody/useDataGridBodyStyles.styles.ts
@@ -10,3 +10,5 @@ export const useDataGridBodyStyles_unstable = (
   useDataGridBodyStylesBase_unstable({ ...state, renderRow: () => null });
   return state;
 };
+
+export const dataGridBodyGridClassName = 'fui-DataGridReactWindowGridBody__grid';

--- a/packages/react-data-grid-react-window-grid/src/components/DataGridHeaderRow/index.ts
+++ b/packages/react-data-grid-react-window-grid/src/components/DataGridHeaderRow/index.ts
@@ -1,3 +1,4 @@
 export * from './DataGridHeaderRow';
 export * from './DataGridHeaderRow.types';
 export * from './useDataGridHeaderRow';
+export { dataGridHeaderListClassName } from './renderDataGridHeaderRow';

--- a/packages/react-data-grid-react-window-grid/src/components/DataGridHeaderRow/renderDataGridHeaderRow.tsx
+++ b/packages/react-data-grid-react-window-grid/src/components/DataGridHeaderRow/renderDataGridHeaderRow.tsx
@@ -7,6 +7,8 @@ import {
 import { VariableSizeList as List } from 'react-window';
 import { DataGridHeaderRowState } from './DataGridHeaderRow.types';
 
+export const dataGridHeaderListClassName = 'fui-DataGridReactWindowGridHeader__list';
+
 /**
  * Render the final JSX of DataGridHeaderRow
  */
@@ -24,6 +26,7 @@ export const renderDataGridHeaderRow_unstable = (
       )}
       {
         <List
+          className={dataGridHeaderListClassName}
           ref={state.listRef}
           itemSize={state.itemSize}
           width={state.width}

--- a/packages/react-data-grid-react-window-grid/src/components/DataGridHeaderRow/renderDataGridHeaderRow.tsx
+++ b/packages/react-data-grid-react-window-grid/src/components/DataGridHeaderRow/renderDataGridHeaderRow.tsx
@@ -7,7 +7,8 @@ import {
 import { VariableSizeList as List } from 'react-window';
 import { DataGridHeaderRowState } from './DataGridHeaderRow.types';
 
-export const dataGridHeaderListClassName = 'fui-DataGridReactWindowGridHeader__list';
+export const dataGridHeaderListClassName =
+  'fui-DataGridReactWindowGridHeader__list';
 
 /**
  * Render the final JSX of DataGridHeaderRow

--- a/packages/react-data-grid-react-window-grid/src/index.ts
+++ b/packages/react-data-grid-react-window-grid/src/index.ts
@@ -28,7 +28,11 @@ export type {
   CellRenderer,
 } from './components/DataGridBody';
 
+export { dataGridBodyGridClassName } from './components/DataGridBody';
+
 export type {
   DataGridHeaderRowProps,
-  HeaderCellRenderer,
+  HeaderCellRenderer
 } from './components/DataGridHeaderRow';
+
+export { dataGridHeaderListClassName } from './components/DataGridHeaderRow';

--- a/packages/react-data-grid-react-window-grid/src/index.ts
+++ b/packages/react-data-grid-react-window-grid/src/index.ts
@@ -32,7 +32,7 @@ export { dataGridBodyGridClassName } from './components/DataGridBody';
 
 export type {
   DataGridHeaderRowProps,
-  HeaderCellRenderer
+  HeaderCellRenderer,
 } from './components/DataGridHeaderRow';
 
 export { dataGridHeaderListClassName } from './components/DataGridHeaderRow';


### PR DESCRIPTION
We have some requirements that need to add custom styles to the react-window Grid/List components in DataGrid. Add classname for those component so we can use CSS selector to add custom styles.