### PR TITLE
fix(nx-plugin): make `component` generator result pass ci checks

### DIFF
--- a/packages/nx-plugin/src/generators/component/files/stories/__componentName__/index.stories.tsx.template
+++ b/packages/nx-plugin/src/generators/component/files/stories/__componentName__/index.stories.tsx.template
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { Meta } from '@storybook/react';
 import { <%= componentName %> } from '<%= npmScope %>/<%= name %>';
 export { Default } from './Default.stories';

--- a/packages/nx-plugin/src/generators/component/generator.ts
+++ b/packages/nx-plugin/src/generators/component/generator.ts
@@ -1,9 +1,4 @@
-import {
-  formatFiles,
-  generateFiles,
-  Tree,
-  workspaceRoot,
-} from '@nx/devkit';
+import { formatFiles, generateFiles, Tree, workspaceRoot } from '@nx/devkit';
 import * as path from 'path';
 import { ComponentGeneratorSchema } from './schema';
 import { getPackagePaths, getProject, npmScope } from '../../utils';
@@ -15,14 +10,20 @@ export default async function (tree: Tree, options: ComponentGeneratorSchema) {
   const { root: projectRoot } = project;
   const paths = getPackagePaths(workspaceRoot, projectRoot);
 
-  generateFiles(tree, path.join(__dirname, 'files'), projectRoot, {...options, npmScope});
+  generateFiles(tree, path.join(__dirname, 'files'), projectRoot, {
+    ...options,
+    npmScope,
+  });
 
   let main = tree.read(paths.main)?.toString();
   if (!main) {
     throw new Error('No index.ts main entrypoint');
   }
 
-  main = `export * from './components/${componentName}';` + '\n' + main;
+  main =
+    `export { ${componentName} } from './components/${componentName}';` +
+    '\n' +
+    main;
   tree.write(paths.main, main);
   await formatFiles(tree);
 }


### PR DESCRIPTION
## Previous Behavior

When following the [contributing guidelines](https://github.com/microsoft/fluentui-contrib/blob/main/CONTRIBUTING.md#creating-a-new-package) a freshly scaffolded package would not pass the build.

![before](https://github.com/microsoft/fluentui-contrib/assets/93940821/35c216f8-b832-44b9-971c-ab514e9aeb4a)

## Current Behavior

Generator templates have been updated so a freshly minted package passes the build.

![after](https://github.com/microsoft/fluentui-contrib/assets/93940821/efba1c86-7853-4059-ad25-78bb8939cccf)
