### PR TITLE
feat(react-draggable-dialog): prepare for first release

### DIFF
--- a/change/@fluentui-contrib-react-draggable-dialog-a0f3a781-ab7a-42d4-ae63-695043256bbc.json
+++ b/change/@fluentui-contrib-react-draggable-dialog-a0f3a781-ab7a-42d4-ae63-695043256bbc.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "release: first minor version",
+  "packageName": "@fluentui-contrib/react-draggable-dialog",
+  "email": "marcosvmmoura@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-draggable-dialog/package.json
+++ b/packages/react-draggable-dialog/package.json
@@ -12,5 +12,11 @@
     "@types/react-dom": ">=16.8.0 <19.0.0",
     "react": ">=16.8.0 <19.0.0",
     "react-dom": ">=16.8.0 <19.0.0"
+  },
+  "beachball": {
+    "disallowedChangeTypes": [
+      "major",
+      "prerelease"
+    ]
   }
 }

--- a/packages/react-draggable-dialog/package.json
+++ b/packages/react-draggable-dialog/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@fluentui-contrib/react-draggable-dialog",
   "version": "0.0.1",
-  "private": true,
   "dependencies": {
     "@dnd-kit/core": "^6.1.0",
     "@dnd-kit/utilities": "^3.2.2",


### PR DESCRIPTION
Remove the private flag from package to enable the release of the Draggable Dialog