### PR TITLE
docs: Use `group` focusMode for cells

### DIFF
--- a/packages/react-data-grid-react-window/stories/DataGrid/VirtualizedDataGrid.stories.tsx
+++ b/packages/react-data-grid-react-window/stories/DataGrid/VirtualizedDataGrid.stories.tsx
@@ -194,7 +194,9 @@ const columns: TableColumnDefinition<Item>[] = [
 
 const renderRow: RowRenderer<Item> = ({ item, rowId }, style) => (
   <DataGridRow<Item> key={rowId} style={style}>
-    {({ renderCell }) => <DataGridCell focusMode="group">{renderCell(item)}</DataGridCell>}
+    {({ renderCell }) => (
+      <DataGridCell focusMode="group">{renderCell(item)}</DataGridCell>
+    )}
   </DataGridRow>
 );
 

--- a/packages/react-data-grid-react-window/stories/DataGrid/VirtualizedDataGrid.stories.tsx
+++ b/packages/react-data-grid-react-window/stories/DataGrid/VirtualizedDataGrid.stories.tsx
@@ -194,7 +194,7 @@ const columns: TableColumnDefinition<Item>[] = [
 
 const renderRow: RowRenderer<Item> = ({ item, rowId }, style) => (
   <DataGridRow<Item> key={rowId} style={style}>
-    {({ renderCell }) => <DataGridCell>{renderCell(item)}</DataGridCell>}
+    {({ renderCell }) => <DataGridCell focusMode="group">{renderCell(item)}</DataGridCell>}
   </DataGridRow>
 );
 


### PR DESCRIPTION
Updates the virtualized data grid example to use `focusMode="group"` for cells since there can be nested buttons inside.