### PR TITLE
chore: update eslint to disallow globals

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -6,7 +6,7 @@
     "no-restricted-globals": [
       "error",
       "window",
-      "document"
+      "document",
       "customElements",
       "devicePixelRatio",
       "location",

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -2,6 +2,42 @@
   "root": true,
   "ignorePatterns": ["**/*"],
   "plugins": ["@nx", "import", "@rnx-kit"],
+  "rules": {
+    "no-restricted-globals": [
+      "error",
+      {
+        "name": "window",
+        "message": "Get a reference to `window` from `useFluent()`."
+      },
+      {
+        "name": "document",
+        "message": "Get a reference to `document` from `useFluent()`."
+      },
+      "customElements",
+      "devicePixelRatio",
+      "location",
+      "navigator",
+      "performance",
+
+      "cancelAnimationFrame",
+      "cancelIdleCallback",
+      "clearImmediate",
+      "clearInterval",
+      "clearTimeout",
+      "fetch",
+      "getComputedStyle",
+      "matchMedia",
+      "requestAnimationFrame",
+      "requestIdleCallback",
+      "setImmediate",
+      "setInterval",
+      "setTimeout",
+
+      "IntersectionObserver",
+      "MutationObserver",
+      "ResizeObserver"
+    ]
+  },
   "overrides": [
     {
       "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
@@ -66,7 +102,9 @@
       "env": {
         "jest": true
       },
-      "rules": {}
+      "rules": {
+        "no-restricted-globals": "off"
+      }
     },
     {
       "files": "*.json",

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -98,7 +98,14 @@
       "rules": {}
     },
     {
-      "files": ["*.spec.ts", "*.spec.tsx", "*.spec.js", "*.spec.jsx"],
+      "files": [
+        "*.spec.ts",
+        "*.spec.tsx",
+        "*.spec.js",
+        "*.spec.jsx",
+        "*test.ts",
+        "*.test.tsx"
+      ],
       "env": {
         "jest": true
       },

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -5,14 +5,8 @@
   "rules": {
     "no-restricted-globals": [
       "error",
-      {
-        "name": "window",
-        "message": "Get a reference to `window` from `useFluent()`."
-      },
-      {
-        "name": "document",
-        "message": "Get a reference to `document` from `useFluent()`."
-      },
+      "window",
+      "document"
       "customElements",
       "devicePixelRatio",
       "location",

--- a/change/@fluentui-contrib-houdini-utils-cd0078ba-b3bb-463a-b1b3-41674707f809.json
+++ b/change/@fluentui-contrib-houdini-utils-cd0078ba-b3bb-463a-b1b3-41674707f809.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: temporarily disable no-restricted-globals for houdini-utils",
+  "packageName": "@fluentui-contrib/houdini-utils",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/houdini-utils/src/paint/fallback/animate.ts
+++ b/packages/houdini-utils/src/paint/fallback/animate.ts
@@ -29,10 +29,14 @@ const tick: TickFn = (
   onUpdate,
   isStopped
 ) => {
+  // TODO: fix global
+  // eslint-disable-next-line no-restricted-globals
   let start = performance.now();
   const currentValues = new Map<string, string>();
   let currentIteration = 1;
 
+  // TODO: fix global
+  // eslint-disable-next-line no-restricted-globals
   const raf = (time: number = performance.now()) => {
     const currentDuration = time - start;
     currentValues.clear();
@@ -115,11 +119,17 @@ const tick: TickFn = (
       )
     ) {
       currentIteration++;
+      // TODO: fix global
+      // eslint-disable-next-line no-restricted-globals
       start = performance.now();
+      // TODO: fix global
+      // eslint-disable-next-line no-restricted-globals
       requestAnimationFrame(raf);
     } else if (currentDuration >= overallDuration) {
       onComplete(currentValues);
     } else {
+      // TODO: fix global
+      // eslint-disable-next-line no-restricted-globals
       requestAnimationFrame(raf);
     }
 

--- a/packages/houdini-utils/src/paint/fallback/animate.ts
+++ b/packages/houdini-utils/src/paint/fallback/animate.ts
@@ -29,13 +29,13 @@ const tick: TickFn = (
   onUpdate,
   isStopped
 ) => {
-  // TODO: fix global
+  // TODO: fix global. See: https://github.com/microsoft/fluentui-contrib/issues/183
   // eslint-disable-next-line no-restricted-globals
   let start = performance.now();
   const currentValues = new Map<string, string>();
   let currentIteration = 1;
 
-  // TODO: fix global
+  // TODO: fix global. See: https://github.com/microsoft/fluentui-contrib/issues/183
   // eslint-disable-next-line no-restricted-globals
   const raf = (time: number = performance.now()) => {
     const currentDuration = time - start;
@@ -119,16 +119,16 @@ const tick: TickFn = (
       )
     ) {
       currentIteration++;
-      // TODO: fix global
+      // TODO: fix global. See: https://github.com/microsoft/fluentui-contrib/issues/183
       // eslint-disable-next-line no-restricted-globals
       start = performance.now();
-      // TODO: fix global
+      // TODO: fix global. See: https://github.com/microsoft/fluentui-contrib/issues/183
       // eslint-disable-next-line no-restricted-globals
       requestAnimationFrame(raf);
     } else if (currentDuration >= overallDuration) {
       onComplete(currentValues);
     } else {
-      // TODO: fix global
+      // TODO: fix global. See: https://github.com/microsoft/fluentui-contrib/issues/183
       // eslint-disable-next-line no-restricted-globals
       requestAnimationFrame(raf);
     }

--- a/packages/houdini-utils/src/paint/fallback/anims/play.ts
+++ b/packages/houdini-utils/src/paint/fallback/anims/play.ts
@@ -16,11 +16,11 @@ export const playAnim = (
   animationParams: FallbackAnimationParams
 ) => {
   const props = new Map<string, string>();
-  // TODO: fix global
+  // TODO: fix global. See: https://github.com/microsoft/fluentui-contrib/issues/183
   // eslint-disable-next-line no-restricted-globals
   const styles = getComputedStyle(state.target);
   const rect = { width: 0, height: 0 };
-  // TODO: fix global
+  // TODO: fix global. See: https://github.com/microsoft/fluentui-contrib/issues/183
   // eslint-disable-next-line no-restricted-globals
   const resizeObserver = new ResizeObserver((entries) => {
     for (const entry of entries) {

--- a/packages/houdini-utils/src/paint/fallback/anims/play.ts
+++ b/packages/houdini-utils/src/paint/fallback/anims/play.ts
@@ -16,8 +16,12 @@ export const playAnim = (
   animationParams: FallbackAnimationParams
 ) => {
   const props = new Map<string, string>();
+  // TODO: fix global
+  // eslint-disable-next-line no-restricted-globals
   const styles = getComputedStyle(state.target);
   const rect = { width: 0, height: 0 };
+  // TODO: fix global
+  // eslint-disable-next-line no-restricted-globals
   const resizeObserver = new ResizeObserver((entries) => {
     for (const entry of entries) {
       if (entry.target === state.target) {

--- a/packages/houdini-utils/src/paint/fallback/fallbackPaintAnimation.ts
+++ b/packages/houdini-utils/src/paint/fallback/fallbackPaintAnimation.ts
@@ -44,7 +44,7 @@ export const fallbackPaintAnimation = (
   // Create a wrapper for us to store these elements in so we avoid
   // thrashing the DOM with appends.
   if (!state.wrapper) {
-    // TODO: fix global
+    // TODO: fix global. See: https://github.com/microsoft/fluentui-contrib/issues/183
     // eslint-disable-next-line no-restricted-globals
     state.wrapper = appendWrapper(document.body);
   }

--- a/packages/houdini-utils/src/paint/fallback/fallbackPaintAnimation.ts
+++ b/packages/houdini-utils/src/paint/fallback/fallbackPaintAnimation.ts
@@ -44,6 +44,8 @@ export const fallbackPaintAnimation = (
   // Create a wrapper for us to store these elements in so we avoid
   // thrashing the DOM with appends.
   if (!state.wrapper) {
+    // TODO: fix global
+    // eslint-disable-next-line no-restricted-globals
     state.wrapper = appendWrapper(document.body);
   }
 

--- a/packages/houdini-utils/src/paint/fallback/keyframe.ts
+++ b/packages/houdini-utils/src/paint/fallback/keyframe.ts
@@ -31,6 +31,8 @@ export const createKeyframeAnimation: CreateKeyframeAnimationFn = ({
 
   const anims = [] as FallbackAnimation[];
   let overallDuration = 0;
+  // TODO: fix global
+  // eslint-disable-next-line no-restricted-globals
   const styles = getComputedStyle(target);
   for (
     let animationIndex = 0;

--- a/packages/houdini-utils/src/paint/fallback/keyframe.ts
+++ b/packages/houdini-utils/src/paint/fallback/keyframe.ts
@@ -31,7 +31,7 @@ export const createKeyframeAnimation: CreateKeyframeAnimationFn = ({
 
   const anims = [] as FallbackAnimation[];
   let overallDuration = 0;
-  // TODO: fix global
+  // TODO: fix global. See: https://github.com/microsoft/fluentui-contrib/issues/183
   // eslint-disable-next-line no-restricted-globals
   const styles = getComputedStyle(target);
   for (

--- a/packages/houdini-utils/src/paint/fallback/util/canvas.ts
+++ b/packages/houdini-utils/src/paint/fallback/util/canvas.ts
@@ -1,7 +1,7 @@
 export const createMozContext = (
   id: string
 ): CanvasRenderingContext2D | null => {
-  // TODO: fix global
+  // TODO: fix global. See: https://github.com/microsoft/fluentui-contrib/issues/183
   // eslint-disable-next-line no-restricted-globals
   const canvas = document.createElement('canvas');
   canvas.id = id;
@@ -31,7 +31,7 @@ export const createWebkitContext = (
   width: number,
   height: number
 ): CanvasRenderingContext2D | null => {
-  // TODO: fix global
+  // TODO: fix global. See: https://github.com/microsoft/fluentui-contrib/issues/183
   // eslint-disable-next-line no-restricted-globals
   const ctx = document.getCSSCanvasContext?.('2d', id, width, height) ?? null;
   if (!ctx) {

--- a/packages/houdini-utils/src/paint/fallback/util/canvas.ts
+++ b/packages/houdini-utils/src/paint/fallback/util/canvas.ts
@@ -1,6 +1,8 @@
 export const createMozContext = (
   id: string
 ): CanvasRenderingContext2D | null => {
+  // TODO: fix global
+  // eslint-disable-next-line no-restricted-globals
   const canvas = document.createElement('canvas');
   canvas.id = id;
   const ctx = canvas.getContext('2d');
@@ -29,6 +31,8 @@ export const createWebkitContext = (
   width: number,
   height: number
 ): CanvasRenderingContext2D | null => {
+  // TODO: fix global
+  // eslint-disable-next-line no-restricted-globals
   const ctx = document.getCSSCanvasContext?.('2d', id, width, height) ?? null;
   if (!ctx) {
     return null;

--- a/packages/houdini-utils/src/paint/fallback/util/wrapper.ts
+++ b/packages/houdini-utils/src/paint/fallback/util/wrapper.ts
@@ -1,7 +1,11 @@
 const createWrapper = (id: string): HTMLElement => {
+  // TODO: fix global
+  // eslint-disable-next-line no-restricted-globals
   let wrapper = document.getElementById(id);
 
   if (!wrapper) {
+    // TODO: fix global
+    // eslint-disable-next-line no-restricted-globals
     wrapper = document.createElement('div');
     wrapper.id = id;
     // Safari requires the canvas to have be visible in the

--- a/packages/houdini-utils/src/paint/fallback/util/wrapper.ts
+++ b/packages/houdini-utils/src/paint/fallback/util/wrapper.ts
@@ -1,10 +1,10 @@
 const createWrapper = (id: string): HTMLElement => {
-  // TODO: fix global
+  // TODO: fix global. See: https://github.com/microsoft/fluentui-contrib/issues/183
   // eslint-disable-next-line no-restricted-globals
   let wrapper = document.getElementById(id);
 
   if (!wrapper) {
-    // TODO: fix global
+    // TODO: fix global. See: https://github.com/microsoft/fluentui-contrib/issues/183
     // eslint-disable-next-line no-restricted-globals
     wrapper = document.createElement('div');
     wrapper.id = id;

--- a/packages/houdini-utils/src/util/featureDetect.ts
+++ b/packages/houdini-utils/src/util/featureDetect.ts
@@ -30,6 +30,8 @@ export type AsyncFeatureDetectFn = () => Promise<boolean>;
  * @returns `true` if the browser supports the necessary APIs, `false` otherwise.
  */
 export const hasMozElement: FeatureDetectFn = () => {
+  // This will hold regardless of the specific `document` object
+  // eslint-disable-next-line no-restricted-globals
   return typeof document?.mozSetImageElement === 'function';
 };
 
@@ -38,6 +40,8 @@ export const hasMozElement: FeatureDetectFn = () => {
  * @returns `true` if the browser supports the necessary APIs, `false` otherwise.
  */
 export const hasWebkitCanvas: FeatureDetectFn = () => {
+  // This will hold regardless of the specific `document` object
+  // eslint-disable-next-line no-restricted-globals
   return typeof document?.getCSSCanvasContext === 'function';
 };
 
@@ -48,7 +52,11 @@ export const hasWebkitCanvas: FeatureDetectFn = () => {
  */
 export const hasHoudini: FeatureDetectFn = () => {
   return (
+    // This will hold regardless of the specific `window` object
+    // eslint-disable-next-line no-restricted-globals
     typeof window !== 'undefined' &&
+    // This will hold regardless of the specific `window` object
+    // eslint-disable-next-line no-restricted-globals
     window.CSS &&
     'paintWorklet' in CSS &&
     'registerProperty' in CSS

--- a/packages/houdini-utils/stories/Utils/index.stories.tsx
+++ b/packages/houdini-utils/stories/Utils/index.stories.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { Meta } from '@storybook/react';
 
 export { Default } from './Default.stories';

--- a/packages/react-themeless-provider/stories/ThemelessFluentProvider/Default.stories.tsx
+++ b/packages/react-themeless-provider/stories/ThemelessFluentProvider/Default.stories.tsx
@@ -7,6 +7,7 @@ import {
   shorthands,
   webLightTheme,
   FluentProvider,
+  useFluent,
 } from '@fluentui/react-components';
 import type { PartialTheme } from '@fluentui/react-components';
 import {
@@ -57,14 +58,19 @@ const Container: React.FC = () => {
 };
 
 const useTheme = (theme: PartialTheme, inject = true) => {
+  const { targetDocument: doc } = useFluent();
+
   React.useEffect(() => {
     const sheet = createCSSStyleSheetFromTheme(':root', theme);
-    if (inject) {
-      document.adoptedStyleSheets = [...document.adoptedStyleSheets, sheet];
+    if (inject && doc) {
+      doc.adoptedStyleSheets = [...doc.adoptedStyleSheets, sheet];
     }
 
     return () => {
-      document.adoptedStyleSheets = document.adoptedStyleSheets.filter(
+      if (!doc) {
+        return;
+      }
+      doc.adoptedStyleSheets = doc.adoptedStyleSheets.filter(
         (adoptedSheet) => adoptedSheet !== sheet
       );
     };

--- a/packages/react-tree-grid/stories/EmailInbox.stories.tsx
+++ b/packages/react-tree-grid/stories/EmailInbox.stories.tsx
@@ -7,7 +7,6 @@ import {
   useTreeGridRowContext,
 } from '@fluentui-contrib/react-tree-grid';
 import {
-  Body1,
   Link,
   Slot,
   useTableRowStyles_unstable,

--- a/packages/react-tree-grid/stories/Meet.stories.tsx
+++ b/packages/react-tree-grid/stories/Meet.stories.tsx
@@ -22,7 +22,7 @@ import {
   Image,
   mergeClasses,
 } from '@fluentui/react-components';
-import { EventHandler, useId } from '@fluentui/react-utilities';
+import { EventHandler } from '@fluentui/react-utilities';
 import {
   CaretRightFilled,
   CaretDownFilled,

--- a/packages/react-tree-grid/stories/Virtualization.stories.tsx
+++ b/packages/react-tree-grid/stories/Virtualization.stories.tsx
@@ -18,6 +18,7 @@ import {
   ForwardRefComponent,
   makeStyles,
   shorthands,
+  useFluent,
 } from '@fluentui/react-components';
 import { isHTMLElement } from '@fluentui/react-utilities';
 
@@ -173,6 +174,9 @@ const useVirtualizationContext = () => {
 };
 
 export const Virtualization = () => {
+  const { targetDocument: doc } = useFluent();
+  const win = doc?.defaultView;
+
   const [openItems, setOpenItems] = React.useState(
     () => new Map<PropertyKey, number>()
   );
@@ -217,10 +221,10 @@ export const Virtualization = () => {
           return;
         }
         const index = openItems.get(parentId);
-        if (index !== undefined) {
+        if (index !== undefined && win && doc) {
           listRef.current?.scrollToItem(index, 'smart');
-          requestAnimationFrame(() => {
-            document
+          win.requestAnimationFrame(() => {
+            doc
               .querySelector<HTMLElement>(`[data-item-id="${parentId}"]`)
               ?.focus();
           });


### PR DESCRIPTION
Accessing global objects can cause problems in multi-window applications because we may be accessing a global object in the wrong `window` context. 

This change enables the `eslint` `no-restricted-globals` rule to disallow global access.

For more details see the corresponding PR in Fluent UI: https://github.com/microsoft/fluentui/pull/30967

This change does not address problems in `houdini-utils` specifically as those will be addressed separately.