### PR TITLE
feat(react-draggable-dialog): add ref forwarding for DraggableDialogSurface

### DIFF
--- a/change/@fluentui-contrib-react-draggable-dialog-9a965112-4f42-4d8b-834e-08364ccdaab5.json
+++ b/change/@fluentui-contrib-react-draggable-dialog-9a965112-4f42-4d8b-834e-08364ccdaab5.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add ref forwarding for DraggableDialogSurface",
+  "packageName": "@fluentui-contrib/react-draggable-dialog",
+  "email": "tor.lye@tietoevry.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-draggable-dialog/src/components/DraggableDialogSurface/DraggableDialogSurface.tsx
+++ b/packages/react-draggable-dialog/src/components/DraggableDialogSurface/DraggableDialogSurface.tsx
@@ -1,5 +1,9 @@
 import * as React from 'react';
-import { DialogSurface, ForwardRefComponent, mergeClasses } from '@fluentui/react-components';
+import {
+  DialogSurface,
+  ForwardRefComponent,
+  mergeClasses,
+} from '@fluentui/react-components';
 
 import { DraggableDialogSurfaceProps } from './DraggableDialogSurface.types';
 import { useStyles } from './DraggableDialogSurface.styles';
@@ -9,24 +13,25 @@ import { useDraggableDialogSurface } from './useDraggableDialogSurface';
  * DraggableDialogSurface is a wrapper around the DialogSurface component that,
  * when composed with DraggableDialog, can be dragged.
  */
-export const DraggableDialogSurface: ForwardRefComponent<DraggableDialogSurfaceProps> = React.forwardRef((props, _ref) => {
-  const { children, className } = props;
-  const styles = useStyles();
-  const { ref, style, mountNode } = useDraggableDialogSurface(props, _ref);
+export const DraggableDialogSurface: ForwardRefComponent<DraggableDialogSurfaceProps> =
+  React.forwardRef((props, _ref) => {
+    const { children, className } = props;
+    const styles = useStyles();
+    const { ref, style, mountNode } = useDraggableDialogSurface(props, _ref);
 
-  return (
-    <DialogSurface
-      ref={ref}
-      style={style}
-      className={mergeClasses(
-        'fui-DraggableDialogSurface',
-        styles.root,
-        className
-      )}
-      mountNode={mountNode}
-      {...props}
-    >
-      {children}
-    </DialogSurface>
-  );
-});
+    return (
+      <DialogSurface
+        ref={ref}
+        style={style}
+        className={mergeClasses(
+          'fui-DraggableDialogSurface',
+          styles.root,
+          className
+        )}
+        mountNode={mountNode}
+        {...props}
+      >
+        {children}
+      </DialogSurface>
+    );
+  });

--- a/packages/react-draggable-dialog/src/components/DraggableDialogSurface/DraggableDialogSurface.tsx
+++ b/packages/react-draggable-dialog/src/components/DraggableDialogSurface/DraggableDialogSurface.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { DialogSurface, mergeClasses } from '@fluentui/react-components';
+import { DialogSurface, ForwardRefComponent, mergeClasses } from '@fluentui/react-components';
 
 import { DraggableDialogSurfaceProps } from './DraggableDialogSurface.types';
 import { useStyles } from './DraggableDialogSurface.styles';
@@ -9,13 +9,10 @@ import { useDraggableDialogSurface } from './useDraggableDialogSurface';
  * DraggableDialogSurface is a wrapper around the DialogSurface component that,
  * when composed with DraggableDialog, can be dragged.
  */
-export const DraggableDialogSurface: React.FC<DraggableDialogSurfaceProps> = ({
-  children,
-  className,
-  ...props
-}) => {
+export const DraggableDialogSurface: ForwardRefComponent<DraggableDialogSurfaceProps> = React.forwardRef((props, _ref) => {
+  const { children, className } = props;
   const styles = useStyles();
-  const { ref, style, mountNode } = useDraggableDialogSurface(props);
+  const { ref, style, mountNode } = useDraggableDialogSurface(props, _ref);
 
   return (
     <DialogSurface
@@ -32,4 +29,4 @@ export const DraggableDialogSurface: React.FC<DraggableDialogSurfaceProps> = ({
       {children}
     </DialogSurface>
   );
-};
+});

--- a/packages/react-draggable-dialog/src/components/DraggableDialogSurface/DraggableDialogSurface.tsx
+++ b/packages/react-draggable-dialog/src/components/DraggableDialogSurface/DraggableDialogSurface.tsx
@@ -14,10 +14,10 @@ import { useDraggableDialogSurface } from './useDraggableDialogSurface';
  * when composed with DraggableDialog, can be dragged.
  */
 export const DraggableDialogSurface: ForwardRefComponent<DraggableDialogSurfaceProps> =
-  React.forwardRef((props, _ref) => {
+  React.forwardRef((props, forwardedRef) => {
     const { children, className } = props;
     const styles = useStyles();
-    const { ref, style, mountNode } = useDraggableDialogSurface(props, _ref);
+    const { ref, style, mountNode } = useDraggableDialogSurface(props, forwardedRef);
 
     return (
       <DialogSurface

--- a/packages/react-draggable-dialog/src/components/DraggableDialogSurface/DraggableDialogSurface.tsx
+++ b/packages/react-draggable-dialog/src/components/DraggableDialogSurface/DraggableDialogSurface.tsx
@@ -17,7 +17,10 @@ export const DraggableDialogSurface: ForwardRefComponent<DraggableDialogSurfaceP
   React.forwardRef((props, forwardedRef) => {
     const { children, className } = props;
     const styles = useStyles();
-    const { ref, style, mountNode } = useDraggableDialogSurface(props, forwardedRef);
+    const { ref, style, mountNode } = useDraggableDialogSurface(
+      props,
+      forwardedRef
+    );
 
     return (
       <DialogSurface

--- a/packages/react-draggable-dialog/src/components/DraggableDialogSurface/useDraggableDialogSurface.ts
+++ b/packages/react-draggable-dialog/src/components/DraggableDialogSurface/useDraggableDialogSurface.ts
@@ -14,7 +14,8 @@ import {
  * Returns the state needed to make a draggable dialog surface.
  */
 export const useDraggableDialogSurface = (
-  props: DraggableDialogSurfaceProps, _ref: React.ForwardedRef<HTMLDivElement>
+  props: DraggableDialogSurfaceProps,
+  _ref: React.ForwardedRef<HTMLDivElement>
 ): DraggableDialogSurfaceState => {
   const { targetDocument } = useFluent();
   const {

--- a/packages/react-draggable-dialog/src/components/DraggableDialogSurface/useDraggableDialogSurface.ts
+++ b/packages/react-draggable-dialog/src/components/DraggableDialogSurface/useDraggableDialogSurface.ts
@@ -15,7 +15,7 @@ import {
  */
 export const useDraggableDialogSurface = (
   props: DraggableDialogSurfaceProps,
-  _ref: React.ForwardedRef<HTMLDivElement>
+  forwardedRef: React.ForwardedRef<HTMLDivElement>
 ): DraggableDialogSurfaceState => {
   const { targetDocument } = useFluent();
   const {
@@ -148,7 +148,7 @@ export const useDraggableDialogSurface = (
   assertDialogParent(hasDraggableParent, 'DraggableDialogSurface');
 
   return {
-    ref: useMergedRefs(setNodeRef as React.Ref<HTMLDivElement>, ref, _ref),
+    ref: useMergedRefs(setNodeRef as React.Ref<HTMLDivElement>, ref, forwardedRef),
     mountNode,
     style,
   };

--- a/packages/react-draggable-dialog/src/components/DraggableDialogSurface/useDraggableDialogSurface.ts
+++ b/packages/react-draggable-dialog/src/components/DraggableDialogSurface/useDraggableDialogSurface.ts
@@ -14,7 +14,7 @@ import {
  * Returns the state needed to make a draggable dialog surface.
  */
 export const useDraggableDialogSurface = (
-  props: DraggableDialogSurfaceProps
+  props: DraggableDialogSurfaceProps, _ref: React.ForwardedRef<HTMLDivElement>
 ): DraggableDialogSurfaceState => {
   const { targetDocument } = useFluent();
   const {
@@ -147,7 +147,7 @@ export const useDraggableDialogSurface = (
   assertDialogParent(hasDraggableParent, 'DraggableDialogSurface');
 
   return {
-    ref: useMergedRefs(setNodeRef as React.Ref<HTMLDivElement>, ref),
+    ref: useMergedRefs(setNodeRef as React.Ref<HTMLDivElement>, ref, _ref),
     mountNode,
     style,
   };

--- a/packages/react-draggable-dialog/src/components/DraggableDialogSurface/useDraggableDialogSurface.ts
+++ b/packages/react-draggable-dialog/src/components/DraggableDialogSurface/useDraggableDialogSurface.ts
@@ -148,7 +148,11 @@ export const useDraggableDialogSurface = (
   assertDialogParent(hasDraggableParent, 'DraggableDialogSurface');
 
   return {
-    ref: useMergedRefs(setNodeRef as React.Ref<HTMLDivElement>, ref, forwardedRef),
+    ref: useMergedRefs(
+      setNodeRef as React.Ref<HTMLDivElement>,
+      ref,
+      forwardedRef
+    ),
     mountNode,
     style,
   };


### PR DESCRIPTION
In the newest released version of Fluent UI 9, the DialogSurface component must support ref forwarding. If DialogSurface is wrapped inside another component, then that component must support ref forwarding. See e.g. https://github.com/microsoft/fluentui/issues/31630

That is the case in this module, react-draggable-dialog. DraggableDialogSurface is a wrapper around DialogSurface. If using this module with the newest Fluent UI 9 build, it throws the following error: 
```
Error: @fluentui/react-motion: Invalid child element.
Motion factories require a single child element to be passed. That element element should support ref forwarding i.e. it should be either an intrinsic element (e.g. div) or a component that uses React.forwardRef().
```

This pull request adds the necessary forwarded ref for the DraggableDialogSurface component.