### PR TITLE
feat(react-data-grid-react-window*): add scrolling indicators

### DIFF
--- a/change/@fluentui-contrib-react-data-grid-react-window-9616c1ea-7098-4f93-bf9e-898a71ff92d1.json
+++ b/change/@fluentui-contrib-react-data-grid-react-window-9616c1ea-7098-4f93-bf9e-898a71ff92d1.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat(react-data-grid-react-window*): add scrolling indicators",
+  "packageName": "@fluentui-contrib/react-data-grid-react-window",
+  "email": "sghorashi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-contrib-react-data-grid-react-window-grid-256637a5-2062-4d52-b56c-da5093435110.json
+++ b/change/@fluentui-contrib-react-data-grid-react-window-grid-256637a5-2062-4d52-b56c-da5093435110.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat(react-data-grid-react-window*): add scrolling indicators",
+  "packageName": "@fluentui-contrib/react-data-grid-react-window-grid",
+  "email": "sghorashi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-data-grid-react-window-grid/src/components/DataGridBody/DataGridBody.types.ts
+++ b/packages/react-data-grid-react-window-grid/src/components/DataGridBody/DataGridBody.types.ts
@@ -26,7 +26,11 @@ export type CellRenderer<TItem = unknown> = (
   /**
    * The index of each column
    */
-  columnIndex: number
+  columnIndex: number,
+  /**
+   * Indicates whether the grid is currently being scrolled.
+   */
+  isScrolling?: boolean | undefined
 ) => React.ReactNode;
 /**
  * DataGridBody Props

--- a/packages/react-data-grid-react-window-grid/src/components/DataGridBody/useDataGridBody.tsx
+++ b/packages/react-data-grid-react-window-grid/src/components/DataGridBody/useDataGridBody.tsx
@@ -56,7 +56,7 @@ export const useDataGridBody_unstable = (
 
   const virtualizedCell: DataGridBodyState['virtualizedCell'] =
     React.useCallback(
-      ({ columnIndex, rowIndex, data, style }) => {
+      ({ columnIndex, rowIndex, data, style, isScrolling }) => {
         const row: TableRowData<unknown> = data[rowIndex];
         const columnDef = columns[columnIndex];
         return (
@@ -69,7 +69,14 @@ export const useDataGridBody_unstable = (
                   value={columnDef?.columnId}
                   key={columnDef?.columnId}
                 >
-                  {children(row, columnDef, style, rowIndex, columnIndex)}
+                  {children(
+                    row,
+                    columnDef,
+                    style,
+                    rowIndex,
+                    columnIndex,
+                    isScrolling
+                  )}
                 </ColumnIdContextProvider>
               </TableRowIdContextProvider>
             </RowIndexContextProvider>

--- a/packages/react-data-grid-react-window-grid/stories/DataGrid/DataGridScrollingIndicators.stories.tsx
+++ b/packages/react-data-grid-react-window-grid/stories/DataGrid/DataGridScrollingIndicators.stories.tsx
@@ -1,0 +1,187 @@
+import * as React from 'react';
+import {
+  DataGrid,
+  DataGridBody,
+  DataGridCell,
+  CellRenderer,
+  DataGridHeaderRow,
+  DataGridHeaderCell,
+} from '@fluentui-contrib/react-data-grid-react-window-grid';
+import { Meta } from '@storybook/react';
+import { CalendarClock16Regular } from '@fluentui/react-icons';
+import {
+  makeStyles,
+  DataGridHeader,
+  TableCellLayout,
+  TableColumnDefinition,
+  createTableColumn,
+  Button,
+  Skeleton,
+  SkeletonItem,
+} from '@fluentui/react-components';
+import { VariableSizeGrid, VariableSizeList } from 'react-window';
+
+export default {
+  component: DataGrid,
+  title: 'DataGrid',
+} as Meta;
+
+/**
+ * A type guard for column id. It has a format with a prefix `column` and a number.
+ */
+type ColumnIdPrefix = `column${number}`;
+
+type TableUIData = Record<ColumnIdPrefix, string>;
+
+const useStyles = makeStyles({
+  tableHeader: {
+    position: 'relative',
+    width: '1000px',
+  },
+  headerCell: {
+    whiteSpace: 'nowrap',
+    boxSizing: 'border-box',
+  },
+});
+
+const ROW_HEIGHT = 44;
+
+function getColumnDefinitions(
+  columns: string[]
+): TableColumnDefinition<TableUIData>[] {
+  const columnDefinitions: TableColumnDefinition<TableUIData>[] = [];
+  columns.forEach((column, index) => {
+    const columnDef = createTableColumn({
+      columnId: `column${index}`,
+      compare(a, b) {
+        return a[`column${index}`].localeCompare(b[`column${index}`]);
+      },
+      renderHeaderCell: () => {
+        return (
+          <TableCellLayout media={<CalendarClock16Regular />}>
+            {column}
+          </TableCellLayout>
+        );
+      },
+      renderCell: (item: TableUIData) => {
+        return (
+          <TableCellLayout truncate title={item[`column${index}`]}>
+            {item[`column${index}`]}
+          </TableCellLayout>
+        );
+      },
+    });
+    columnDefinitions.push(columnDef);
+  });
+  return columnDefinitions;
+}
+
+const generateTableArrays = (rowCount: number, columnCount: number) => {
+  const result: TableUIData[] = [];
+  for (let i = 0; i < rowCount; i += 1) {
+    const row: TableUIData = {};
+    for (let j = 0; j < columnCount; j++) {
+      row[`column${j}`] = `r${i} c${j}`;
+    }
+    result.push(row);
+  }
+  return result;
+};
+
+/**
+ * Props for the react-window grid component to enable scrolling indicators.
+ */
+const gridProps = { useIsScrolling: true };
+
+const CellShimmer = React.memo(function CellShimmer() {
+  return (
+    <Skeleton style={{ width: 80 }}>
+      <SkeletonItem
+        shape="rectangle"
+        animation="pulse"
+        appearance="translucent"
+      />
+    </Skeleton>
+  );
+});
+
+const cellRenderer: CellRenderer<TableUIData> = (
+  { item },
+  column,
+  style,
+  _,
+  __,
+  isScrolling
+) => {
+  return (
+    <DataGridCell style={{ ...style, boxSizing: 'border-box' }}>
+      {isScrolling ? <CellShimmer /> : column.renderCell(item)}
+    </DataGridCell>
+  );
+};
+
+export const DataGridScrollingIndicators: React.FunctionComponent = () => {
+  const columns = getColumnDefinitions(
+    [...new Array(50)].map((v, index) => `Column ${index}`)
+  );
+  const items = generateTableArrays(1000, 50);
+  const styles = useStyles();
+  const bodyRef = React.useRef<VariableSizeGrid>(null);
+  const headerRef = React.useRef<VariableSizeList>(null);
+  const [width, setWidth] = React.useState(200);
+  const columnWidth = React.useCallback(
+    (index: number) => (index === 0 ? 200 : width),
+    [width]
+  );
+  return (
+    <>
+      <Button
+        onClick={() => {
+          setWidth(100);
+          bodyRef.current?.resetAfterColumnIndex(0);
+          headerRef.current?.resetAfterIndex(0);
+        }}
+      >
+        Change column width
+      </Button>
+      <DataGrid
+        noNativeElements
+        sortable
+        items={items}
+        columns={columns}
+        size={'medium'}
+        bodyRef={bodyRef}
+        headerRef={headerRef}
+      >
+        <DataGridHeader className={styles.tableHeader}>
+          <DataGridHeaderRow<TableUIData>
+            itemSize={columnWidth}
+            height={42}
+            width={1000}
+          >
+            {({ renderHeaderCell }, style) => {
+              return (
+                <DataGridHeaderCell
+                  className={styles.headerCell}
+                  as="div"
+                  style={style}
+                >
+                  {renderHeaderCell()}
+                </DataGridHeaderCell>
+              );
+            }}
+          </DataGridHeaderRow>
+        </DataGridHeader>
+        <DataGridBody<TableUIData>
+          rowHeight={() => ROW_HEIGHT}
+          height={500}
+          width={1000}
+          columnWidth={columnWidth}
+          gridProps={gridProps}
+        >
+          {cellRenderer}
+        </DataGridBody>
+      </DataGrid>
+    </>
+  );
+};

--- a/packages/react-data-grid-react-window-grid/stories/DataGrid/index.stories.tsx
+++ b/packages/react-data-grid-react-window-grid/stories/DataGrid/index.stories.tsx
@@ -1,6 +1,7 @@
 import { Meta } from '@storybook/react';
 import { DataGrid } from '@fluentui-contrib/react-data-grid-react-window-grid';
 export { VirtualizedDataGrid } from './VirtualizedDataGrid.stories';
+export { DataGridScrollingIndicators } from './DataGridScrollingIndicators.stories';
 
 const meta: Meta<typeof DataGrid> = {
   component: DataGrid,

--- a/packages/react-data-grid-react-window/src/components/DataGridBody/DataGridBody.types.ts
+++ b/packages/react-data-grid-react-window/src/components/DataGridBody/DataGridBody.types.ts
@@ -15,7 +15,11 @@ export type RowRenderer<TItem = unknown> = (
   /**
    * The index of each row
    */
-  index: number
+  index: number,
+  /**
+   * Indicates whether the grid is currently being scrolled.
+   */
+  isScrolling?: boolean | undefined
 ) => React.ReactNode;
 
 /**

--- a/packages/react-data-grid-react-window/src/components/DataGridBody/useDataGridBody.tsx
+++ b/packages/react-data-grid-react-window/src/components/DataGridBody/useDataGridBody.tsx
@@ -41,12 +41,12 @@ export const useDataGridBody_unstable = (
   );
 
   const virtualizedRow: DataGridBodyState['virtualizedRow'] = React.useCallback(
-    ({ data, index, style }) => {
+    ({ data, index, style, isScrolling }) => {
       const row: TableRowData<unknown> = data[index];
       return (
         <TableRowIndexContextProvider value={ariaRowIndexStart + index}>
           <TableRowIdContextProvider value={row.rowId}>
-            {children(row, style, index)}
+            {children(row, style, index, isScrolling)}
           </TableRowIdContextProvider>
         </TableRowIndexContextProvider>
       );

--- a/packages/react-data-grid-react-window/stories/DataGrid/DataGridScrollingIndicators.stories.tsx
+++ b/packages/react-data-grid-react-window/stories/DataGrid/DataGridScrollingIndicators.stories.tsx
@@ -1,0 +1,268 @@
+import * as React from 'react';
+import {
+  FolderRegular,
+  EditRegular,
+  OpenRegular,
+  DocumentRegular,
+  PeopleRegular,
+  DocumentPdfRegular,
+  VideoRegular,
+  MoreHorizontalRegular,
+} from '@fluentui/react-icons';
+import {
+  TableColumnDefinition,
+  createTableColumn,
+  TableCellLayout,
+  PresenceBadgeStatus,
+  Avatar,
+  useScrollbarWidth,
+  useFluent,
+  TableCellActions,
+  Menu,
+  MenuTrigger,
+  MenuItem,
+  MenuList,
+  MenuPopover,
+  Button,
+  Skeleton,
+  SkeletonItem,
+} from '@fluentui/react-components';
+import {
+  DataGridBody,
+  DataGrid,
+  DataGridRow,
+  DataGridHeader,
+  DataGridCell,
+  DataGridHeaderCell,
+  RowRenderer,
+} from '@fluentui-contrib/react-data-grid-react-window';
+
+type FileCell = {
+  label: string;
+  icon: JSX.Element;
+};
+
+type LastUpdatedCell = {
+  label: string;
+  timestamp: number;
+};
+
+type LastUpdateCell = {
+  label: string;
+  icon: JSX.Element;
+};
+
+type AuthorCell = {
+  label: string;
+  status: PresenceBadgeStatus;
+};
+
+type Item = {
+  index: number;
+  file: FileCell;
+  author: AuthorCell;
+  lastUpdated: LastUpdatedCell;
+  lastUpdate: LastUpdateCell;
+};
+
+const baseItems = [
+  {
+    file: { label: 'Meeting notes', icon: <DocumentRegular /> },
+    author: { label: 'Max Mustermann', status: 'available' },
+    lastUpdated: { label: '7h ago', timestamp: 1 },
+    lastUpdate: {
+      label: 'You edited this',
+      icon: <EditRegular />,
+    },
+  },
+  {
+    file: { label: 'Thursday presentation', icon: <FolderRegular /> },
+    author: { label: 'Erika Mustermann', status: 'busy' },
+    lastUpdated: { label: 'Yesterday at 1:45 PM', timestamp: 2 },
+    lastUpdate: {
+      label: 'You recently opened this',
+      icon: <OpenRegular />,
+    },
+  },
+  {
+    file: { label: 'Training recording', icon: <VideoRegular /> },
+    author: { label: 'John Doe', status: 'away' },
+    lastUpdated: { label: 'Yesterday at 1:45 PM', timestamp: 2 },
+    lastUpdate: {
+      label: 'You recently opened this',
+      icon: <OpenRegular />,
+    },
+  },
+  {
+    file: { label: 'Purchase order', icon: <DocumentPdfRegular /> },
+    author: { label: 'Jane Doe', status: 'offline' },
+    lastUpdated: { label: 'Tue at 9:30 AM', timestamp: 3 },
+    lastUpdate: {
+      label: 'You shared this in a Teams chat',
+      icon: <PeopleRegular />,
+    },
+  },
+];
+
+const items = new Array(1500)
+  .fill(0)
+  .map((_, i) => ({ ...baseItems[i % baseItems.length], index: i }));
+
+const columns: TableColumnDefinition<Item>[] = [
+  createTableColumn<Item>({
+    columnId: 'file',
+    compare: (a, b) => {
+      return a.file.label.localeCompare(b.file.label);
+    },
+    renderHeaderCell: () => {
+      return 'File';
+    },
+    renderCell: (item) => {
+      return (
+        <TableCellLayout media={item.file.icon}>
+          <strong>[{item.index}] </strong>
+          {item.file.label}
+          <TableCellActions>
+            <Menu>
+              <MenuTrigger>
+                <Button
+                  appearance="subtle"
+                  aria-label="more"
+                  icon={<MoreHorizontalRegular />}
+                />
+              </MenuTrigger>
+
+              <MenuPopover>
+                <MenuList>
+                  <MenuItem>Item</MenuItem>
+                  <MenuItem>Item</MenuItem>
+                  <MenuItem>Item</MenuItem>
+                </MenuList>
+              </MenuPopover>
+            </Menu>
+          </TableCellActions>
+        </TableCellLayout>
+      );
+    },
+  }),
+  createTableColumn<Item>({
+    columnId: 'author',
+    compare: (a, b) => {
+      return a.author.label.localeCompare(b.author.label);
+    },
+    renderHeaderCell: () => {
+      return 'Author';
+    },
+    renderCell: (item) => {
+      return (
+        <TableCellLayout
+          media={<Avatar badge={{ status: item.author.status }} />}
+        >
+          {item.author.label}
+        </TableCellLayout>
+      );
+    },
+  }),
+  createTableColumn<Item>({
+    columnId: 'lastUpdated',
+    compare: (a, b) => {
+      return a.lastUpdated.timestamp - b.lastUpdated.timestamp;
+    },
+    renderHeaderCell: () => {
+      return 'Last updated';
+    },
+
+    renderCell: (item) => {
+      return item.lastUpdated.label;
+    },
+  }),
+  createTableColumn<Item>({
+    columnId: 'lastUpdate',
+    compare: (a, b) => {
+      return a.lastUpdate.label.localeCompare(b.lastUpdate.label);
+    },
+    renderHeaderCell: () => {
+      return 'Last update';
+    },
+    renderCell: (item) => {
+      return (
+        <TableCellLayout media={item.lastUpdate.icon}>
+          {item.lastUpdate.label}
+        </TableCellLayout>
+      );
+    },
+  }),
+];
+
+/**
+ * Props for the react-window list component to enable scrolling indicators.
+ */
+const listProps = { useIsScrolling: true };
+
+const CellShimmer = React.memo(function CellShimmer() {
+  return (
+    <Skeleton style={{ width: '100%' }}>
+      <SkeletonItem
+        shape="rectangle"
+        animation="pulse"
+        appearance="translucent"
+      />
+    </Skeleton>
+  );
+});
+
+const renderRow: RowRenderer<Item> = (
+  { item, rowId },
+  style,
+  _,
+  isScrolling
+) => (
+  <DataGridRow<Item> key={rowId} style={style}>
+    {({ renderCell }) => (
+      <DataGridCell focusMode="group">
+        {isScrolling ? <CellShimmer /> : renderCell(item)}
+      </DataGridCell>
+    )}
+  </DataGridRow>
+);
+
+export const DataGridScrollingIndicators = () => {
+  const { targetDocument } = useFluent();
+  const scrollbarWidth = useScrollbarWidth({ targetDocument });
+
+  return (
+    <DataGrid
+      items={items}
+      columns={columns}
+      focusMode="cell"
+      sortable
+      selectionMode="multiselect"
+    >
+      <DataGridHeader style={{ paddingRight: scrollbarWidth }}>
+        <DataGridRow>
+          {({ renderHeaderCell }) => (
+            <DataGridHeaderCell>{renderHeaderCell()}</DataGridHeaderCell>
+          )}
+        </DataGridRow>
+      </DataGridHeader>
+      <DataGridBody<Item> itemSize={50} height={400} listProps={listProps}>
+        {renderRow}
+      </DataGridBody>
+    </DataGrid>
+  );
+};
+
+DataGridScrollingIndicators.parameters = {
+  docs: {
+    description: {
+      story: [
+        'As VirtualizedDataGrid relies on [FixedSizeList](https://react-window.vercel.app/#/examples/list/fixed-size),',
+        "you may want to pass some props directly to it. If your component's items are expensive to render,",
+        'you can boost performance by rendering a placeholder while the user is scrolling.',
+        'To do this, add the `useIsScrolling` property to your List or Grid.',
+        'Now an additional parameter, `isScrolling`, will be passed to your render method.',
+        'In this example, we render a shimmer effect while the user is scrolling.',
+      ].join('\n'),
+    },
+  },
+};

--- a/packages/react-data-grid-react-window/stories/DataGrid/index.stories.tsx
+++ b/packages/react-data-grid-react-window/stories/DataGrid/index.stories.tsx
@@ -2,6 +2,7 @@ import { Meta } from '@storybook/react';
 import { DataGrid } from '@fluentui-contrib/react-data-grid-react-window';
 export { VirtualizedDataGrid } from './VirtualizedDataGrid.stories';
 export { ReactWindowOverrides } from './ReactWindowOverrides.stories';
+export { DataGridScrollingIndicators } from './DataGridScrollingIndicators.stories';
 
 const meta: Meta<typeof DataGrid> = {
   component: DataGrid,


### PR DESCRIPTION
If your component's items are expensive to render, you can boost performance by rendering a placeholder while the user is scrolling. To do this, add the `useIsScrolling` property to your List or Grid. Now an additional parameter, `isScrolling`, will be passed to your render method.

Original doc from `react-window` https://react-window.vercel.app/#/examples/list/scrolling-indicators).vercel.app/#/examples/list/scrolling-indicators