### PR TITLE
feat(react-resize-handle): Allow relative panel adjustments

### DIFF
--- a/packages/react-resize-handle/src/hooks/useMouseHandler.ts
+++ b/packages/react-resize-handle/src/hooks/useMouseHandler.ts
@@ -7,16 +7,15 @@ import {
 } from '@fluentui/react-utilities';
 import * as React from 'react';
 import { GrowDirection } from '../types';
-import { elementDimension } from '../utils';
 
 export type UseMouseHandlerParams = {
   onDown?: (event: NativeTouchOrMouseEvent) => void;
   onMove?: (event: NativeTouchOrMouseEvent) => void;
-  elementRef: React.RefObject<HTMLElement>;
   growDirection: GrowDirection;
   onValueChange: (value: number) => void;
   onDragEnd?: (e: NativeTouchOrMouseEvent) => void;
   onDragStart?: (e: NativeTouchOrMouseEvent) => void;
+  currentValue: React.RefObject<number>;
 };
 
 export function useMouseHandler(params: UseMouseHandlerParams) {
@@ -24,11 +23,9 @@ export function useMouseHandler(params: UseMouseHandlerParams) {
   const targetWindow = targetDocument?.defaultView;
 
   const dragStartOriginCoords = React.useRef({ clientX: 0, clientY: 0 });
-  const { growDirection, onValueChange, elementRef } = params;
+  const { growDirection, onValueChange, currentValue } = params;
 
-  const initialElementSize = React.useRef(
-    elementDimension(elementRef.current, growDirection)
-  );
+  const startValue = React.useRef(0);
 
   const recalculatePosition = useEventCallback(
     (event: NativeTouchOrMouseEvent) => {
@@ -38,7 +35,7 @@ export function useMouseHandler(params: UseMouseHandlerParams) {
         clientY - dragStartOriginCoords.current.clientY,
       ];
 
-      let newValue = initialElementSize.current;
+      let newValue = startValue.current || 0;
 
       switch (growDirection) {
         case 'end':
@@ -56,15 +53,6 @@ export function useMouseHandler(params: UseMouseHandlerParams) {
       }
 
       onValueChange(Math.round(newValue));
-
-      // If, after resize, the element size is different than the value we set, that we have reached the boundary
-      // and the element size is controlled by something else (minmax, clamp, max, min css functions etc.)
-      // In this case, we need to update the value to the actual element size so that the css var and a11y props
-      // reflect the reality.
-      const elSize = elementDimension(elementRef.current, growDirection);
-      if (elSize !== newValue) {
-        onValueChange(elSize);
-      }
     }
   );
 
@@ -88,10 +76,9 @@ export function useMouseHandler(params: UseMouseHandlerParams) {
 
   const onPointerDown = useEventCallback((event: NativeTouchOrMouseEvent) => {
     dragStartOriginCoords.current = getEventClientCoords(event);
-    initialElementSize.current = elementDimension(
-      elementRef.current,
-      growDirection
-    );
+    // As we start dragging, save the current value otherwise the value increases,
+    // the delta compounds and the element grows/shrinks too fast.
+    startValue.current = currentValue.current || 0;
 
     if (event.defaultPrevented) {
       return;

--- a/packages/react-resize-handle/stories/Default.stories.tsx
+++ b/packages/react-resize-handle/stories/Default.stories.tsx
@@ -9,7 +9,6 @@ import {
 } from '@fluentui/react-components';
 import { Handle } from './Handle';
 
-const NAV_INITIAL_WIDTH = 80;
 const NAV_SIZE_CSS_VAR = '--nav-size';
 const SIDE_SIZE_CSS_VAR = '--side-size';
 const FOOTER_SIZE_CSS_VAR = '--footer-size';
@@ -19,7 +18,7 @@ const usePageStyles = makeResetStyles({
 });
 
 const useMainWrapperStyles = makeResetStyles({
-  [NAV_SIZE_CSS_VAR]: `${NAV_INITIAL_WIDTH}px`,
+  [NAV_SIZE_CSS_VAR]: `20%`,
   [SIDE_SIZE_CSS_VAR]: '120px',
   [FOOTER_SIZE_CSS_VAR]: '10%',
   display: 'grid',
@@ -28,7 +27,7 @@ const useMainWrapperStyles = makeResetStyles({
   gap: '16px',
   gridTemplate: `"nav sub-nav main side" minmax(0, 1fr)
   "nav sub-nav main-footer side" clamp(5%, var(${FOOTER_SIZE_CSS_VAR}), 30%)
-  / clamp(60px, var(${NAV_SIZE_CSS_VAR}), 40%)  150px 1fr var(${SIDE_SIZE_CSS_VAR})`,
+  / clamp(60px, calc(20% + var(${NAV_SIZE_CSS_VAR})), 40%)  150px 1fr var(${SIDE_SIZE_CSS_VAR})`,
 });
 
 const useStyles = makeStyles({
@@ -67,8 +66,6 @@ const Component = (props: ComponentProps) => {
   const boxStyles = useMainBoxStyles();
   const styles = useStyles();
 
-  const [maxValue, setMaxValue] = React.useState(400);
-
   const {
     handleRef: navHandleRef,
     wrapperRef: navWrapperRef,
@@ -77,8 +74,7 @@ const Component = (props: ComponentProps) => {
   } = useResizeHandle({
     variableName: NAV_SIZE_CSS_VAR,
     growDirection: 'end',
-    minValue: 60,
-    maxValue: maxValue,
+    relative: true,
     onChange: (value: number) => {
       props.onChange(value);
     },
@@ -117,7 +113,7 @@ const Component = (props: ComponentProps) => {
   );
 
   const resetToInitial = () => {
-    setLeftColumnSize(NAV_INITIAL_WIDTH);
+    setLeftColumnSize(0);
   };
 
   return (
@@ -127,7 +123,6 @@ const Component = (props: ComponentProps) => {
           className={mergeClasses(boxStyles, styles.areaNav)}
           ref={navElementRef}
         >
-          <button onClick={() => setMaxValue(200)}>Set max 200</button>
           <Handle
             position="end"
             ref={navHandleRef}


### PR DESCRIPTION
This PR adds possibility to use relative sizes in combination with resizable panels. Only the difference from the default dimension is measured, which, when plugged in the `calc` function, results in only relative adjustments. This still fixes 2 issues:

- issues where the panel is first rendered with 0 width, as that will immediately measure it and set as fixed
- Issue where the layout would become irresponsive as a result of plugging this in, as all of the sizes would be in px.