### PR TITLE
fix: Chat should be able to override tabster attributes

### DIFF
--- a/change/@fluentui-contrib-react-chat-92014f96-b0d6-45d4-a231-f0c2843bcc96.json
+++ b/change/@fluentui-contrib-react-chat-92014f96-b0d6-45d4-a231-f0c2843bcc96.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Chat should be able to override tabster attributes",
+  "packageName": "@fluentui-contrib/react-chat",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-chat/src/components/Chat/Chat.test.tsx
+++ b/packages/react-chat/src/components/Chat/Chat.test.tsx
@@ -6,4 +6,11 @@ describe('Chat', () => {
   it('should render', () => {
     render(<Chat />);
   });
+
+  it('should be able to override tabster', () => {
+    const { container } = render(<Chat data-tabster="foo" />);
+    expect(container.firstElementChild?.getAttribute('data-tabster')).toBe(
+      'foo'
+    );
+  });
 });

--- a/packages/react-chat/src/components/Chat/useChat.ts
+++ b/packages/react-chat/src/components/Chat/useChat.ts
@@ -25,8 +25,8 @@ export const useChat_unstable = (
     root: slot.always(
       getIntrinsicElementProps('div', {
         ref,
-        ...props,
         ...arrowAttrs,
+        ...props,
       }),
       { elementType: 'div' }
     ),


### PR DESCRIPTION
Allows tabster attributes to be overriden and adds a test to prevent regression