### PR TITLE
chore: add react-icons to repo deps to avoid transitive dependency usage from react-components, tweak azure-theme dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@ tmp
 
 # dependencies
 node_modules
+# we use yarn
+package-lock.json
 
 # IDEs and editors
 /.idea

--- a/change/@fluentui-contrib-azure-theme-38aa95aa-6904-46a0-a2d1-262a63424cab.json
+++ b/change/@fluentui-contrib-azure-theme-38aa95aa-6904-46a0-a2d1-262a63424cab.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "feat: move react-icons to peerDependencies to mitigate dupes in applications",
+  "packageName": "@fluentui-contrib/azure-theme",
+  "email": "hochelmartin@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-contrib-azure-theme-50ec81f2-7b56-4409-ba3e-74f8e5767a9c.json
+++ b/change/@fluentui-contrib-azure-theme-50ec81f2-7b56-4409-ba3e-74f8e5767a9c.json
@@ -1,6 +1,6 @@
 {
-  "type": "minor",
-  "comment": "Added Azure Theme for V9 style object for partner teams use. Exported as AzureLightTheme and AzureDarkTheme",
+  "type": "patch",
+  "comment": "feat: add Azure Theme for V9 style object for partner teams use. Exported as AzureLightTheme and AzureDarkTheme",
   "packageName": "@fluentui-contrib/azure-theme",
   "email": "30805892+Jacqueline-ms@users.noreply.github.com",
   "dependentChangeType": "patch"

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@dnd-kit/modifiers": "^7.0.0",
     "@dnd-kit/utilities": "^3.2.2",
     "@fluentui/react-components": "^9.46.3",
+    "@fluentui/react-icons": "^2.0.249",
     "@fluentui/react-shared-contexts": "^9.7.2",
     "@griffel/shadow-dom": "~0.2.0",
     "@nx/devkit": "19.3.2",

--- a/packages/azure-theme/package.json
+++ b/packages/azure-theme/package.json
@@ -1,11 +1,17 @@
 {
   "name": "@fluentui-contrib/azure-theme",
-  "version": "0.0.1",
+  "version": "0.0.0",
   "dependencies": {
     "@swc/helpers": "~0.5.2"
   },
   "main": "./src/index.js",
   "typings": "./src/index.d.ts",
+  "beachball": {
+    "disallowedChangeTypes": [
+      "prerelease",
+      "major"
+    ]
+  },
   "peerDependencies": {
     "@fluentui/react-components": ">=9.46.3 <10.0.0",
     "@fluentui/react-icons": ">=2.0.204 <3.0.0",

--- a/packages/azure-theme/package.json
+++ b/packages/azure-theme/package.json
@@ -2,14 +2,13 @@
   "name": "@fluentui-contrib/azure-theme",
   "version": "0.0.1",
   "dependencies": {
-    "@fluentui/react-icons": ">=2.0.204 <3.0.0",
     "@swc/helpers": "~0.5.2"
   },
   "main": "./src/index.js",
   "typings": "./src/index.d.ts",
-  "private": false,
   "peerDependencies": {
     "@fluentui/react-components": ">=9.46.3 <10.0.0",
+    "@fluentui/react-icons": ">=2.0.204 <3.0.0",
     "@types/react": ">=16.8.0 <19.0.0",
     "@types/react-dom": ">=16.8.0 <19.0.0",
     "react": ">=16.8.0 <19.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1724,10 +1724,10 @@
     "@griffel/react" "^1.5.14"
     "@swc/helpers" "^0.5.1"
 
-"@fluentui/react-icons@^2.0.224":
-  version "2.0.225"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-icons/-/react-icons-2.0.225.tgz#fc0302a69db1d91cb184c0afd1a9dcb3fd9fbbc7"
-  integrity sha512-L9phN3bAMlZCa5+/ObGjIO+5GI8M50ym766sraSq92jaJwgAXrCJDLWuDGWZRGrC63DcagtR2culptj3q7gMMg==
+"@fluentui/react-icons@^2.0.224", "@fluentui/react-icons@^2.0.249":
+  version "2.0.249"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-icons/-/react-icons-2.0.249.tgz#dc6416f7a8a7d2897ac4b434aac9d442b838c03a"
+  integrity sha512-VcOCbqv3MxzMZdH6jyqpzsfyNV0cG5F4TKXnnXcJ/QVQcWsN2BU6NrCiwkZHKEjbOYbxwBTdBHq1gnR5qz4baw==
   dependencies:
     "@griffel/react" "^1.0.0"
     tslib "^2.1.0"


### PR DESCRIPTION
**Repo:**

- update gitignore https://github.com/microsoft/fluentui-contrib/pull/190#discussion_r1686713024
- add `react-icons` to repo deps to avoid transitive dep usage 

**azure-theme:**

- move react-icons to peerDependencies to avoid dupes in user land which lead to huge perf hits (https://github.com/microsoft/fluentui/issues/31714#issuecomment-2192050491)
- setup beachball to allow only change types that mirror package zero versioned semver policy
  - 0.x.x
   - `type: patch` == FIXes and FEATures 0.x.<b>X</b>
   - `type: minor` == BREAKING change  0.<b>X</b>.x

### Related issues:

- follows https://github.com/microsoft/fluentui-contrib/pull/190#discussion_r1686713024 and https://github.com/microsoft/fluentui-contrib/pull/203