### PR TITLE
ci: simplify pipelines and setup jest to follow fluent core setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,6 @@ on:
 
 env:
   NX_PARALLEL: 2 # ubuntu-latest = 2-core CPU / 7 GB of RAM
-  NX_PREFER_TS_NODE: true
   NX_VERBOSE_LOGGING: true
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
           fetch-depth: 0
 
       - name: Derive appropriate SHAs for base and head for `nx affected` commands
-        uses: nrwl/nx-set-shas@v2
+        uses: nrwl/nx-set-shas@v4
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
       - run: yarn nx affected --target=type-check
       - run: yarn nx affected --target=lint
       - run: yarn nx affected --target=test
-      - run: yarn nx affected --target=component-test
+      - run: yarn nx affected --target=component-test --skipInstall
       - run: yarn nx format:check --base origin/main
 
       - name: 'Check for unstaged changes'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,9 +5,18 @@ on:
       - main
   pull_request:
 
+env:
+  NX_PARALLEL: 2 # ubuntu-latest = 2-core CPU / 7 GB of RAM
+  NX_PREFER_TS_NODE: true
+  NX_VERBOSE_LOGGING: true
+
 jobs:
   main:
     runs-on: ubuntu-latest
+    permissions:
+      contents: 'read'
+      actions: 'read'
+
     steps:
       - uses: actions/checkout@v4
         with:
@@ -31,34 +40,16 @@ jobs:
       - name: Install Playwright Browsers
         run: npx playwright install --with-deps
 
-      - run: yarn nx affected --target=verify-integrity --parallel --max-parallel=3
-      - run: yarn nx affected --target=type-check --parallel --max-parallel=3
-      - run: yarn nx affected --target=build --parallel --max-parallel=3
-      - run: yarn nx affected --target=build-storybook --parallel --max-parallel=3
-      - run: yarn nx affected --target=test --parallel --max-parallel=2
-      - run: yarn nx affected --target=component-test --skipInstall --parallel --max-parallel=2
-      - run: yarn nx affected --target=lint --parallel --max-parallel=3
+      - run: yarn nx affected --target=verify-integrity
+      - run: yarn nx affected --target=build
+      - run: yarn nx affected --target=build-storybook
+      - run: yarn nx affected --target=type-check
+      - run: yarn nx affected --target=lint
+      - run: yarn nx affected --target=test
+      - run: yarn nx affected --target=component-test
       - run: yarn nx format:check --base origin/main
 
       - name: 'Check for unstaged changes'
         run: |
           git status --porcelain
           git diff-index --quiet HEAD -- || exit 1
-
-  docs:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Derive appropriate SHAs for base and head for `nx affected` commands
-        uses: nrwl/nx-set-shas@v2
-
-      - uses: actions/setup-node@v4
-        with:
-          cache: 'yarn'
-          node-version: '20'
-
-      - run: yarn install --frozen-lockfile
-      - run: yarn nx affected --target=build-storybook --parallel --max-parallel=3

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,7 +13,6 @@ permissions:
 
 env:
   NX_PARALLEL: 2 # ubuntu-latest = 2-core CPU / 7 GB of RAM
-  NX_PREFER_TS_NODE: true
   NX_VERBOSE_LOGGING: true
 
 # Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,6 +11,11 @@ permissions:
   pages: write
   id-token: write
 
+env:
+  NX_PARALLEL: 2 # ubuntu-latest = 2-core CPU / 7 GB of RAM
+  NX_PREFER_TS_NODE: true
+  NX_VERBOSE_LOGGING: true
+
 # Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
 # However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
 concurrency:
@@ -36,7 +41,7 @@ jobs:
           node-version: '20'
 
       - run: yarn install --frozen-lockfile
-      - run: yarn nx run-many --target=build-storybook --parallel --max-parallel=3
+      - run: yarn nx run-many --target=build-storybook
 
       - name: Setup Pages
         uses: actions/configure-pages@v3

--- a/jest.preset.js
+++ b/jest.preset.js
@@ -7,4 +7,13 @@ module.exports = {
     // @see https://github.com/nrwl/nx/blob/master/packages/jest/preset/jest-preset.ts#L8-L13
     '^.+\\.(ts|js|html)$': ['@swc/jest'],
   },
+  maxWorkers: isCI() ? 1 : '50%',
 };
+
+function isCI() {
+  return (
+    (process.env.CI && process.env.CI !== 'false') ||
+    process.env.TF_BUILD === 'true' ||
+    process.env.GITHUB_ACTIONS === 'true'
+  );
+}


### PR DESCRIPTION
- removes redundant `docs` job from PR pipeline
- migratest to latest https://github.com/nrwl/nx-set-shas
- uses env variables to set NX common CLI args
- uses same jest setup as in core https://github.com/microsoft/fluentui/pull/32096 ( although there seems to be no perf gains because GHA runs on weak machine )