### PR TITLE
Chore--jsx-automatic-runtime

### DIFF
--- a/change/@fluentui-contrib-react-chat-b152fb14-23ba-41ac-96f1-a4a17243fa6f.json
+++ b/change/@fluentui-contrib-react-chat-b152fb14-23ba-41ac-96f1-a4a17243fa6f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: adopts jsx runtime instead of createElement method",
+  "packageName": "@fluentui-contrib/react-chat",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-contrib-react-themeless-provider-6e8b41c9-8ad8-4d57-983c-63c47cf6d808.json
+++ b/change/@fluentui-contrib-react-themeless-provider-6e8b41c9-8ad8-4d57-983c-63c47cf6d808.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: adopts jsx runtime instead of createElement method",
+  "packageName": "@fluentui-contrib/react-themeless-provider",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-contrib-react-tree-grid-6bd53614-87e5-444f-b75a-cb39d6a4f3d9.json
+++ b/change/@fluentui-contrib-react-tree-grid-6bd53614-87e5-444f-b75a-cb39d6a4f3d9.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: adopts jsx runtime instead of createElement method",
+  "packageName": "@fluentui-contrib/react-tree-grid",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-chat/.babelrc
+++ b/packages/react-chat/.babelrc
@@ -1,3 +1,12 @@
 {
-  "extends": "../../babel.config.json"
+  "extends": "../../babel.config.json",
+  "plugins": [
+    [
+      "@babel/plugin-transform-react-jsx",
+      {
+        "runtime": "automatic",
+        "importSource": "@fluentui/react-jsx-runtime"
+      }
+    ]
+  ]
 }

--- a/packages/react-chat/src/components/Chat/renderChat.tsx
+++ b/packages/react-chat/src/components/Chat/renderChat.tsx
@@ -1,9 +1,3 @@
-/** @jsxRuntime classic */
-/** @jsx createElement */
-
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-import { createElement } from '@fluentui/react-jsx-runtime';
-
 import { assertSlots } from '@fluentui/react-components';
 import type { ChatState, ChatSlots } from './Chat.types';
 

--- a/packages/react-chat/src/components/ChatMessage/renderChatMessage.tsx
+++ b/packages/react-chat/src/components/ChatMessage/renderChatMessage.tsx
@@ -1,9 +1,3 @@
-/** @jsxRuntime classic */
-/** @jsx createElement */
-
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-import { createElement } from '@fluentui/react-jsx-runtime';
-
 import { assertSlots } from '@fluentui/react-components';
 import type { ChatMessageState, ChatMessageSlots } from './ChatMessage.types';
 

--- a/packages/react-chat/src/components/ChatMyMessage/renderChatMyMessage.tsx
+++ b/packages/react-chat/src/components/ChatMyMessage/renderChatMyMessage.tsx
@@ -1,9 +1,3 @@
-/** @jsxRuntime classic */
-/** @jsx createElement */
-
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-import { createElement } from '@fluentui/react-jsx-runtime';
-
 import { assertSlots } from '@fluentui/react-components';
 
 import type {

--- a/packages/react-chat/tsconfig.lib.json
+++ b/packages/react-chat/tsconfig.lib.json
@@ -2,7 +2,9 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "../../dist/out-tsc",
-    "declaration": true
+    "declaration": true,
+    "jsx": "react-jsx",
+    "jsxImportSource": "@fluentui/react-jsx-runtime"
   },
   "include": ["src/**/*.ts"],
   "exclude": [

--- a/packages/react-themeless-provider/.babelrc
+++ b/packages/react-themeless-provider/.babelrc
@@ -1,3 +1,12 @@
 {
-  "extends": "../../babel.config.json"
+  "extends": "../../babel.config.json",
+  "plugins": [
+    [
+      "@babel/plugin-transform-react-jsx",
+      {
+        "runtime": "automatic",
+        "importSource": "@fluentui/react-jsx-runtime"
+      }
+    ]
+  ]
 }

--- a/packages/react-themeless-provider/src/components/ThemelessFluentProvider/renderThemelessFluentProvider.tsx
+++ b/packages/react-themeless-provider/src/components/ThemelessFluentProvider/renderThemelessFluentProvider.tsx
@@ -1,8 +1,3 @@
-/** @jsxRuntime classic */
-/** @jsx createElement */
-
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-import { createElement, Fragment } from '@fluentui/react-jsx-runtime';
 import { assertSlots } from '@fluentui/react-components';
 import { TextDirectionProvider } from '@griffel/react';
 import {

--- a/packages/react-themeless-provider/tsconfig.lib.json
+++ b/packages/react-themeless-provider/tsconfig.lib.json
@@ -2,7 +2,9 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "../../dist/out-tsc",
-    "declaration": true
+    "declaration": true,
+    "jsx": "react-jsx",
+    "jsxImportSource": "@fluentui/react-jsx-runtime"
   },
   "include": ["src/**/*.ts"],
   "exclude": [

--- a/packages/react-tree-grid/.babelrc
+++ b/packages/react-tree-grid/.babelrc
@@ -1,3 +1,12 @@
 {
-  "extends": "../../babel.config.json"
+  "extends": "../../babel.config.json",
+  "plugins": [
+    [
+      "@babel/plugin-transform-react-jsx",
+      {
+        "runtime": "automatic",
+        "importSource": "@fluentui/react-jsx-runtime"
+      }
+    ]
+  ]
 }

--- a/packages/react-tree-grid/src/components/TreeGrid/TreeGrid.tsx
+++ b/packages/react-tree-grid/src/components/TreeGrid/TreeGrid.tsx
@@ -1,9 +1,3 @@
-/** @jsxRuntime classic */
-/** @jsx createElement */
-
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-import { createElement } from '@fluentui/react-jsx-runtime';
-
 import * as React from 'react';
 import {
   getIntrinsicElementProps,

--- a/packages/react-tree-grid/src/components/TreeGridCell/TreeGridCell.tsx
+++ b/packages/react-tree-grid/src/components/TreeGridCell/TreeGridCell.tsx
@@ -1,8 +1,3 @@
-/** @jsxRuntime classic */
-/** @jsx createElement */
-
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-import { createElement } from '@fluentui/react-jsx-runtime';
 import * as React from 'react';
 import {
   ForwardRefComponent,

--- a/packages/react-tree-grid/src/components/TreeGridInteraction/TreeGridInteraction.tsx
+++ b/packages/react-tree-grid/src/components/TreeGridInteraction/TreeGridInteraction.tsx
@@ -1,8 +1,3 @@
-/** @jsxRuntime classic */
-/** @jsx createElement */
-
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-import { createElement } from '@fluentui/react-jsx-runtime';
 import * as React from 'react';
 import {
   ForwardRefComponent,

--- a/packages/react-tree-grid/src/components/TreeGridRow/TreeGridRow.tsx
+++ b/packages/react-tree-grid/src/components/TreeGridRow/TreeGridRow.tsx
@@ -1,9 +1,3 @@
-/** @jsxRuntime classic */
-/** @jsx createElement */
-/** @jsxFrag Fragment */
-
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-import { createElement, Fragment } from '@fluentui/react-jsx-runtime';
 import * as React from 'react';
 import {
   getIntrinsicElementProps,

--- a/packages/react-tree-grid/tsconfig.lib.json
+++ b/packages/react-tree-grid/tsconfig.lib.json
@@ -2,7 +2,9 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "../../dist/out-tsc",
-    "declaration": true
+    "declaration": true,
+    "jsx": "react-jsx",
+    "jsxImportSource": "@fluentui/react-jsx-runtime"
   },
   "include": ["src/**/*.ts"],
   "exclude": [


### PR DESCRIPTION
Addresses usages of the classic jsx runtime in favor of the automatic

https://github.com/microsoft/fluentui-contrib/pull/208/files#diff-434aa1b7faa5f2ca928cac2330327f41693b5199517c0325ccf4b9b39d803952L1-L5

## Changes

1. adds `@babel/plugin-transform-react-jsx` per package to opt-in to automatic jsx
2. updates `tsconfig.lib.json` per package to opt-in to automatic jsx 
3. updates each render file to stop using `createElement`