### PR TITLE
bugfix: allow override internal attributes through props

### DIFF
--- a/change/@fluentui-contrib-react-tree-grid-7314d4c2-4f6d-4d2d-a3b3-aefea024d9c0.json
+++ b/change/@fluentui-contrib-react-tree-grid-7314d4c2-4f6d-4d2d-a3b3-aefea024d9c0.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "bugfix: allow override internal attributes through props",
+  "packageName": "@fluentui-contrib/react-tree-grid",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-tree-grid/src/components/TreeGrid/TreeGrid.tsx
+++ b/packages/react-tree-grid/src/components/TreeGrid/TreeGrid.tsx
@@ -15,13 +15,14 @@ import { useRowNavigation } from '../../hooks/useRowNavigation';
 
 export const TreeGrid = React.forwardRef(
   (props: TreeGridProps, ref: React.ForwardedRef<HTMLDivElement>) => {
-    const navigationProps = useRowNavigation(props);
+    const { onKeyDown, ...tabsterAttributes } = useRowNavigation(props);
     const Root = slot.always(
       getIntrinsicElementProps('div', {
         ref,
         role: 'treegrid',
+        ...tabsterAttributes,
         ...props,
-        ...navigationProps,
+        onKeyDown,
         className: mergeClasses('fui-TreeGrid', props.className),
       }),
       { elementType: 'div' }

--- a/packages/react-tree-grid/src/components/TreeGridRow/TreeGridRow.tsx
+++ b/packages/react-tree-grid/src/components/TreeGridRow/TreeGridRow.tsx
@@ -86,14 +86,14 @@ export const TreeGridRow = React.forwardRef(
         role: 'row',
         tabIndex: 0,
         'aria-level': level,
+        ...tabsterAttributes,
         ...props,
         className: mergeClasses(styles, props.className),
-        ...tabsterAttributes,
         ...(Subtree && {
           onKeyDown: handleKeyDown,
           onClick: handleClick,
-          'aria-expanded': open,
-          'aria-level': level,
+          'aria-expanded': props['aria-expanded'] ?? open,
+          'aria-level': props['aria-level'] ?? level,
         }),
       }),
       { elementType: 'div' }


### PR DESCRIPTION
Fixes https://github.com/microsoft/fluentui-contrib/issues/210

1. Ensures that `props` will always overrides internal attributes (exception is event handlers, where the internal and external are merged to ensure behaviour)