### PR TITLE
bugfix(react-tree-grid): merges tabster attributes instead of replacing with props

### DIFF
--- a/change/@fluentui-contrib-react-tree-grid-c4eb3274-5637-442a-850a-f7c704e25d82.json
+++ b/change/@fluentui-contrib-react-tree-grid-c4eb3274-5637-442a-850a-f7c704e25d82.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "react-tree-grid/bugfix: merges tabster attributes instead of replacing with props",
+  "packageName": "@fluentui-contrib/react-tree-grid",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-tree-grid/src/components/TreeGrid/TreeGrid.tsx
+++ b/packages/react-tree-grid/src/components/TreeGrid/TreeGrid.tsx
@@ -12,6 +12,10 @@ import {
 } from '@fluentui/react-components';
 import { TreeGridProps } from './TreeGrid.types';
 import { useRowNavigation } from '../../hooks/useRowNavigation';
+import {
+  TabsterDOMAttribute,
+  useMergedTabsterAttributes_unstable,
+} from '@fluentui/react-tabster';
 
 export const TreeGrid = React.forwardRef(
   (props: TreeGridProps, ref: React.ForwardedRef<HTMLDivElement>) => {
@@ -20,8 +24,11 @@ export const TreeGrid = React.forwardRef(
       getIntrinsicElementProps('div', {
         ref,
         role: 'treegrid',
-        ...tabsterAttributes,
         ...props,
+        ...useMergedTabsterAttributes_unstable(
+          tabsterAttributes,
+          props as TabsterDOMAttribute
+        ),
         onKeyDown,
         className: mergeClasses('fui-TreeGrid', props.className),
       }),

--- a/packages/react-tree-grid/src/components/TreeGridInteraction/TreeGridInteraction.tsx
+++ b/packages/react-tree-grid/src/components/TreeGridInteraction/TreeGridInteraction.tsx
@@ -10,20 +10,27 @@ import {
   useFocusableGroup,
 } from '@fluentui/react-components';
 import type { TreeGridInteractionProps } from './TreeGridInteraction.types';
+import {
+  TabsterDOMAttribute,
+  useMergedTabsterAttributes_unstable,
+} from '@fluentui/react-tabster';
 
 export const TreeGridInteraction: ForwardRefComponent<TreeGridInteractionProps> =
   React.forwardRef((props, ref) => {
-    const focusableGroupAttribute = useFocusableGroup({
-      tabBehavior: 'limited-trap-focus',
-    });
+    const tabsterAttributes = useMergedTabsterAttributes_unstable(
+      useFocusableGroup({
+        tabBehavior: 'limited-trap-focus',
+      }),
+      props as unknown as TabsterDOMAttribute
+    );
 
     const Root = slot.always(
       {
         tabIndex: 0,
         role: 'group',
-        ...focusableGroupAttribute,
         ref,
         ...props,
+        ...tabsterAttributes,
       },
       { elementType: 'div' }
     );

--- a/packages/react-tree-grid/src/components/TreeGridRow/TreeGridRow.tsx
+++ b/packages/react-tree-grid/src/components/TreeGridRow/TreeGridRow.tsx
@@ -15,7 +15,10 @@ import {
 } from '@fluentui/react-components';
 import { useTreeGridRowStyles } from './useTreeGridRowStyles.styles';
 import { TreeGridRowProps } from './TreeGridRow.types';
-import { useMergedTabsterAttributes_unstable } from '@fluentui/react-tabster';
+import {
+  TabsterDOMAttribute,
+  useMergedTabsterAttributes_unstable,
+} from '@fluentui/react-tabster';
 import { isHTMLElement } from '@fluentui/react-utilities';
 import { ArrowLeft, ArrowRight, Enter } from '@fluentui/keyboard-keys';
 import {
@@ -38,7 +41,8 @@ export const TreeGridRow = React.forwardRef(
       useFocusableGroup({
         tabBehavior: 'limited-trap-focus',
         ignoreDefaultKeydown: { Enter: true },
-      })
+      }),
+      props as TabsterDOMAttribute
     );
     const handleKeyDown = useEventCallback(
       (event: React.KeyboardEvent<HTMLDivElement>) => {
@@ -86,8 +90,8 @@ export const TreeGridRow = React.forwardRef(
         role: 'row',
         tabIndex: 0,
         'aria-level': level,
-        ...tabsterAttributes,
         ...props,
+        ...tabsterAttributes,
         className: mergeClasses(styles, props.className),
         ...(Subtree && {
           onKeyDown: handleKeyDown,


### PR DESCRIPTION
Fixes bug introduced by https://github.com/microsoft/fluentui-contrib/pull/211

In https://github.com/microsoft/fluentui-contrib/pull/211 we started overriding internal tabster attributes by the ones provided by `props`. This may cause behavioral issue due to `props` removing internal necessary tabster attributes.

This PR fixes this by using `useMergedTabsterAttributes` to merge internal attributes with `props` one instead of replacing