### PR TITLE
feat(react-resize-handle): Use slider role for better screen reader support

### DIFF
--- a/change/@fluentui-contrib-react-resize-handle-8d62436f-d3a1-4246-8e9e-57eecc1d5de2.json
+++ b/change/@fluentui-contrib-react-resize-handle-8d62436f-d3a1-4246-8e9e-57eecc1d5de2.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat(react-resize-handle): Use slider role for better screen reader support",
+  "packageName": "@fluentui-contrib/react-resize-handle",
+  "email": "jirivyhnalek@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-resize-handle/src/hooks/useResizeHandle.component-browser-spec.tsx
+++ b/packages/react-resize-handle/src/hooks/useResizeHandle.component-browser-spec.tsx
@@ -5,21 +5,78 @@ import { TestArea } from './useResizeHandleExample.component-browser-spec';
 
 test.use({ viewport: { width: 500, height: 500 } });
 
+async function mountTest(mount) {
+  const component = await mount(<TestArea />);
+  const dragHandle = component.getByRole('slider');
+  const wrapper = component.getByTestId('wrapper');
+  const valueEl = component.getByTestId('value');
+
+  return { component, dragHandle, wrapper, valueEl };
+}
+
+async function validateComponent(component, value) {
+  await expect(component.wrapper).toHaveCSS('--width', `${value}px`);
+  await expect(component.valueEl).toContainText(`--width: ${value}px;`);
+  await expect(component.dragHandle).toHaveAttribute(
+    'aria-valuetext',
+    `${value}px`
+  );
+}
+
 test.describe('useResizeHandle', () => {
-  test('"onChange" is called after dragging', async ({ mount, page }) => {
-    const component = await mount(<TestArea />);
+  test('mouse can be used for dragging', async ({ mount, page }) => {
+    const component = await mountTest(mount);
 
-    const dragHandle = component.getByRole('separator');
-    const valueEl = component.getByTestId('value');
-
-    await expect(valueEl).toContainText('Default value');
-
-    // Drag the handle to the right
-    await dragHandle.hover();
+    await component.dragHandle.hover();
     await page.mouse.down();
     await page.mouse.move(100, 0);
     await page.mouse.up();
 
-    await expect(valueEl).toContainText('--width: 83px;');
+    await validateComponent(component, 83);
+  });
+
+  test('keyboard can be used for resizing', async ({ mount, page }) => {
+    const component = await mountTest(mount);
+
+    await component.dragHandle.focus();
+    await page.keyboard.press('ArrowRight');
+    await validateComponent(component, 70);
+    await page.keyboard.press('ArrowLeft');
+    await validateComponent(component, 50);
+  });
+
+  test.describe("min/max value can't be exceeded", () => {
+    test('with mouse', async ({ mount, page }) => {
+      const component = await mountTest(mount);
+      await component.dragHandle.hover();
+      await page.mouse.down();
+      await page.mouse.move(1000, 0);
+      await page.mouse.up();
+
+      await validateComponent(component, 400);
+
+      await component.dragHandle.hover();
+      await page.mouse.down();
+      await page.mouse.move(-1000, 0);
+      await page.mouse.up();
+
+      await validateComponent(component, 50);
+    });
+
+    test('with keyboard', async ({ mount, page }) => {
+      const component = await mountTest(mount);
+      await component.dragHandle.focus();
+
+      for (let i = 0; i < 30; i++) {
+        await page.keyboard.press('ArrowRight');
+      }
+
+      await validateComponent(component, 400);
+
+      for (let i = 0; i < 30; i++) {
+        await page.keyboard.press('ArrowLeft');
+      }
+      await validateComponent(component, 50);
+    });
   });
 });

--- a/packages/react-resize-handle/src/hooks/useResizeHandle.component-browser-spec.tsx
+++ b/packages/react-resize-handle/src/hooks/useResizeHandle.component-browser-spec.tsx
@@ -23,14 +23,18 @@ async function validateComponent(component, value) {
   );
 }
 
+async function dragX(component, page, amount) {
+  await component.dragHandle.hover();
+  await page.mouse.down();
+  await page.mouse.move(amount, 0);
+  await page.mouse.up();
+}
+
 test.describe('useResizeHandle', () => {
   test('mouse can be used for dragging', async ({ mount, page }) => {
     const component = await mountTest(mount);
 
-    await component.dragHandle.hover();
-    await page.mouse.down();
-    await page.mouse.move(100, 0);
-    await page.mouse.up();
+    dragX(component, page, 100);
 
     await validateComponent(component, 83);
   });
@@ -48,18 +52,11 @@ test.describe('useResizeHandle', () => {
   test.describe("min/max value can't be exceeded", () => {
     test('with mouse', async ({ mount, page }) => {
       const component = await mountTest(mount);
-      await component.dragHandle.hover();
-      await page.mouse.down();
-      await page.mouse.move(1000, 0);
-      await page.mouse.up();
 
+      dragX(component, page, 1000);
       await validateComponent(component, 400);
 
-      await component.dragHandle.hover();
-      await page.mouse.down();
-      await page.mouse.move(-1000, 0);
-      await page.mouse.up();
-
+      dragX(component, page, -1000);
       await validateComponent(component, 50);
     });
 

--- a/packages/react-resize-handle/src/hooks/useResizeHandle.component-browser-spec.tsx
+++ b/packages/react-resize-handle/src/hooks/useResizeHandle.component-browser-spec.tsx
@@ -53,10 +53,10 @@ test.describe('useResizeHandle', () => {
     test('with mouse', async ({ mount, page }) => {
       const component = await mountTest(mount);
 
-      dragX(component, page, 1000);
+      dragX(component, page, 500);
       await validateComponent(component, 400);
 
-      dragX(component, page, -1000);
+      dragX(component, page, -500);
       await validateComponent(component, 50);
     });
 

--- a/packages/react-resize-handle/src/hooks/useResizeHandle.ts
+++ b/packages/react-resize-handle/src/hooks/useResizeHandle.ts
@@ -92,14 +92,14 @@ export const useResizeHandle = (params: UseResizeHandleParams) => {
       : getA11ValueText(currentValue.current);
 
     const handleAttributes = {
-      role: 'separator',
+      role: 'slider',
       'aria-valuemin': minValue,
       ...(maxValue < Number.MAX_SAFE_INTEGER && { 'aria-valuemax': maxValue }),
       ...(a11yValue && { 'aria-valuetext': a11yValue }),
       'aria-orientation':
         growDirection === 'end' || growDirection === 'start'
-          ? 'vertical'
-          : 'horizontal',
+          ? 'horizontal'
+          : 'vertical',
     };
 
     Object.entries(handleAttributes).forEach(([key, value]) => {

--- a/packages/react-resize-handle/src/hooks/useResizeHandleExample.component-browser-spec.tsx
+++ b/packages/react-resize-handle/src/hooks/useResizeHandleExample.component-browser-spec.tsx
@@ -21,6 +21,7 @@ export function TestArea() {
     <div style={{ display: 'flex', flexDirection: 'column', gap: '12px' }}>
       <div
         ref={handle.wrapperRef}
+        data-testid="wrapper"
         style={{
           '--width': '50px',
           display: 'grid',
@@ -38,6 +39,7 @@ export function TestArea() {
           }}
         />
         <div
+          tabIndex={0}
           ref={handle.handleRef}
           role="separator"
           style={{


### PR DESCRIPTION
After doing research about the support of `separator` and `slider` roles across different screen readers and platforms it became obvious that the slider role has much better narration and keyboard support.

While `separator` fits the use case the best on paper, in real-world it's support leaves much to be desired.

To summarize the issues with `separator`:
 - aria-label not supported on VoiceOver on Mac for `separator`
 - VO keys not working for `separator`
 - current value (aria-valuetext) not being narrated in Jaws
 - no mode auto switching in NVDA and Jaws, hindering the experience.

All of these issues are avoided by using `slider`.

"Horizontal" and "vertical" orientation needs to be flipped for "slider".