### PR TITLE
feat(tools): add yarn.lock verification to repo integrity script

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -19,6 +19,7 @@ packages/react-interactive-tab @microsoft/cxe-prg @dmytrokirpa
 # <%= NX-CODEOWNER-PLACEHOLDER %>
 
 #### Build/Infra
+/tools/ @microsoft/fluentui-react-build
 /.github/ @microsoft/fluentui-react-build
 /tsconfig.base.json @microsoft/fluentui-react-build
 /yarn.lock @microsoft/fluentui-react-build

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "lint": "nx affected --target=lint",
     "test": "nx affected --target=test",
     "type-check": "nx affected --target=type-check",
+    "preinstall": "node ./tools/scripts/preinstall.mjs",
     "postinstall": "patch-package",
     "dedupe": "npx yarn-deduplicate --strategy fewer"
   },

--- a/tools/scripts/preinstall.mjs
+++ b/tools/scripts/preinstall.mjs
@@ -1,0 +1,5 @@
+main();
+
+function main() {
+  // TODO add code if needed
+}

--- a/tools/scripts/verify-repo-integrity.mjs
+++ b/tools/scripts/verify-repo-integrity.mjs
@@ -22,7 +22,7 @@ function main() {
 
 /**
  *
- * @param {Array<VerifyResult>} results
+ * @param {VerifyResult[]} results
  */
 function processVerifications(...results) {
   results.forEach((result) => {
@@ -50,14 +50,14 @@ function verifyPackageJson() {
 
   if (json.private !== true) {
     return {
-      message: 'The package.json must have a private field set to true',
+      message: `The package.json must have a "private" field set to true`,
       type: 'error',
     };
   }
 
   if (json.version !== '0.0.0') {
     return {
-      message: 'The package.json must have a version field set to 0.0.0',
+      message: `The package.json must have a "version" field set to 0.0.0`,
       type: 'error',
     };
   }
@@ -85,7 +85,7 @@ function verifyYarnLock() {
 
   if (rootYarnLockPath !== nonRootYarnLock) {
     const message = [
-      `Invalid yarn.lock file "${nonRootYarnLock}", yarn.lock file can exists only at monorepo root`,
+      `Invalid yarn.lock file "${nonRootYarnLock}", yarn.lock file can exist only at the monorepo root`,
       chalk.italic(
         `\tNOTE: Make sure your run "yarn install" from monorepo root`
       ),
@@ -95,7 +95,7 @@ function verifyYarnLock() {
   }
 
   return {
-    message: 'yarn.lock file exists only in monorepo root.',
+    message: 'yarn.lock file exists only at the monorepo root.',
     type: 'success',
   };
 }

--- a/tools/scripts/verify-repo-integrity.mjs
+++ b/tools/scripts/verify-repo-integrity.mjs
@@ -2,28 +2,46 @@
 
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
-import { readFileSync } from 'node:fs';
+import { readFileSync, readdirSync, statSync } from 'node:fs';
 
 import chalk from 'chalk';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
+const workspaceRoot = join(__dirname, '../../');
 
 main();
 
+/**
+ * @typedef {{message: string; type: 'error' | 'success';}} VerifyResult
+ */
+
 function main() {
-  /**
-   * @type {string[]}
-   */
-  const log = [];
+  processVerifications(verifyYarnLock(), verifyPackageJson());
+}
 
-  log.push(verifyPackageJson());
-
-  log.forEach((message) => {
-    console.log(`- ✅ ${chalk.bold.green(message)}`);
+/**
+ *
+ * @param {Array<VerifyResult>} results
+ */
+function processVerifications(...results) {
+  results.forEach((result) => {
+    if (result.type === 'success') {
+      console.log(`- ✅ ${chalk.bold.green(result.message)}`);
+    }
+    if (result.type === 'error') {
+      console.log(`- 🚨 ${chalk.bold.red(result.message)}`);
+      process.exit(1);
+    }
   });
 }
 
+// ==== Verification ====
+
+/**
+ *
+ * @returns {VerifyResult}
+ */
 function verifyPackageJson() {
   /** @type {import('nx/src/utils/package-json').PackageJson} */
   const json = JSON.parse(
@@ -31,12 +49,88 @@ function verifyPackageJson() {
   );
 
   if (json.private !== true) {
-    throw new Error('The package.json must have a private field set to true');
+    return {
+      message: 'The package.json must have a private field set to true',
+      type: 'error',
+    };
   }
 
   if (json.version !== '0.0.0') {
-    throw new Error('The package.json must have a version field set to 0.0.0');
+    return {
+      message: 'The package.json must have a version field set to 0.0.0',
+      type: 'error',
+    };
   }
 
-  return 'The package.json is valid.';
+  return { message: 'The package.json is valid.', type: 'success' };
+}
+
+/**
+ *
+ * @returns {VerifyResult}
+ */
+function verifyYarnLock() {
+  const rootYarnLockPath = join(__dirname, '../../yarn.lock');
+
+  const nonRootYarnLock = findFileInDirectory(workspaceRoot, 'yarn.lock', [
+    'node_modules',
+    'dist',
+    '.nx',
+    '.yarn',
+    '.git',
+    '.github',
+    '.verdaccio',
+    '.vscode',
+  ]);
+
+  if (rootYarnLockPath !== nonRootYarnLock) {
+    const message = [
+      `Invalid yarn.lock file "${nonRootYarnLock}", yarn.lock file can exists only at monorepo root`,
+      chalk.italic(
+        `\tNOTE: Make sure your run "yarn install" from monorepo root`
+      ),
+    ].join('\n');
+
+    return { message, type: 'error' };
+  }
+
+  return {
+    message: 'yarn.lock file exists only in monorepo root.',
+    type: 'success',
+  };
+}
+
+// ==== Utils ====
+
+/**
+ *
+ * @param {string} directory
+ * @param {string} fileName
+ * @param {string[]} exclude
+ * @returns {string | null}
+ */
+function findFileInDirectory(directory, fileName, exclude) {
+  const files = readdirSync(directory);
+
+  for (const file of files) {
+    if (exclude.includes(file)) {
+      continue;
+    }
+
+    const filePath = join(directory, file);
+    const stats = statSync(filePath);
+
+    if (stats.isFile() && file === fileName) {
+      return filePath;
+    }
+
+    if (stats.isDirectory()) {
+      const foundFilePath = findFileInDirectory(filePath, fileName, exclude);
+      if (foundFilePath) {
+        return foundFilePath;
+      }
+    }
+  }
+
+  return null;
 }


### PR DESCRIPTION
this repo is an integrated nx repo (https://nx.dev/concepts/integrated-vs-package-based), thus there is no need for hoisting and other workspace package manager related jazz.

In the recent past few contributors added yarn.lock by accident as we didnt have any validation/automation for that.


This PR adds new verification to our verify repo integrity script to mitigate invalid yarn.lock additions.

**Demo:** 

all good:

<img width="470" alt="image" src="https://github.com/user-attachments/assets/3020233f-8a8d-43da-8742-2e87b20d8be4">


failing:

<img width="1353" alt="image" src="https://github.com/user-attachments/assets/0364bd2e-3bde-47b6-a84b-1fe3a57ba5ff">


### Related issues:

- https://github.com/microsoft/fluentui-contrib/pull/224
- https://github.com/microsoft/fluentui-contrib/pull/202/files/01a351e64b5e1c551818d718a9c749cde8fb6a39#diff-44c004bf424fe7b2b154315253e520db3c5126aa009bfe6f02a3996db1c1f10d

