### PR TITLE
feat(variant-theme): prepare initial release

### DIFF
--- a/change/@fluentui-contrib-variant-theme-5f415918-9549-4242-a32a-3fc71e85c865.json
+++ b/change/@fluentui-contrib-variant-theme-5f415918-9549-4242-a32a-3fc71e85c865.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "feat: release package",
+  "packageName": "@fluentui-contrib/variant-theme",
+  "email": "hochelmartin@gmail.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
generate change file in order to trigger first release

- command used: `yarn change --force -p @fluentui-contrib/variant-theme`
- change type: `patch` . why? we are using zero based semver `0.m.p` / p=patch (features/fixes) m=minor (breaking change)
