### PR TITLE
docs(react-keytips): improve keytips for docsite

### DIFF
--- a/change/@fluentui-contrib-react-keytips-a837d56c-a0f7-4c82-a6e8-4acb794f4fc7.json
+++ b/change/@fluentui-contrib-react-keytips-a837d56c-a0f7-4c82-a6e8-4acb794f4fc7.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: adjust exports",
+  "packageName": "@fluentui-contrib/react-keytips",
+  "email": "vgenaev@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-keytips/src/Keytip.ts
+++ b/packages/react-keytips/src/Keytip.ts
@@ -1,0 +1,1 @@
+export * from './components/Keytip';

--- a/packages/react-keytips/src/Keytips.ts
+++ b/packages/react-keytips/src/Keytips.ts
@@ -1,0 +1,1 @@
+export * from './components/Keytips';

--- a/packages/react-keytips/src/index.ts
+++ b/packages/react-keytips/src/index.ts
@@ -1,8 +1,25 @@
 export {
   Keytip,
+  useKeytip_unstable,
+  useKeytipStyles_unstable,
+  renderKeytip_unstable,
+  keytipClassNames,
+} from './Keytip';
+
+export type {
   KeytipProps,
+  KeytipSlots,
+  KeytipState,
   ReturnKeytipEventHandler,
   ExecuteKeytipEventHandler,
-} from './components/Keytip';
-export { Keytips, KeytipsProps } from './components/Keytips';
+} from './Keytip';
+
+export {
+  Keytips,
+  renderKeytips_unstable,
+  useKeytips_unstable,
+} from './components/Keytips';
+
+export type { KeytipsProps, KeytipsSlots, KeytipsState } from './Keytips';
+
 export { useKeytipRef } from './hooks/useKeytipRef';

--- a/packages/react-keytips/stories/Default.stories.tsx
+++ b/packages/react-keytips/stories/Default.stories.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
 import {
-  Keytips,
-  KeytipsProps,
   ExecuteKeytipEventHandler,
   useKeytipRef,
 } from '@fluentui-contrib/react-keytips';
@@ -122,7 +120,7 @@ const MenuButtonComponent = () => {
   );
 };
 
-export const DefaultStory = (props: KeytipsProps) => {
+export const DefaultStory = () => {
   const classes = useStyles();
 
   const normalButton = useKeytipRef({
@@ -146,7 +144,6 @@ export const DefaultStory = (props: KeytipsProps) => {
 
   return (
     <>
-      <Keytips {...props} content="Alt Meta" />
       <div className={classes.column}>
         <div className={classes.row}>
           <Button ref={normalButton}>Button</Button>

--- a/packages/react-keytips/stories/Dynamic.stories.tsx
+++ b/packages/react-keytips/stories/Dynamic.stories.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
 import {
-  Keytips,
-  KeytipsProps,
   ExecuteKeytipEventHandler,
   useKeytipRef,
 } from '@fluentui-contrib/react-keytips';
@@ -21,7 +19,7 @@ const useStyles = makeStyles({
   },
 });
 
-export const DynamicStory = (props: KeytipsProps) => {
+export const DynamicStory = () => {
   const classes = useStyles();
 
   const [currentButton, setCurrentButton] = React.useState('Button 1');
@@ -52,7 +50,6 @@ export const DynamicStory = (props: KeytipsProps) => {
 
   return (
     <>
-      <Keytips {...props} content="Alt Control" />
       <div className={classes.column}>
         <div className={classes.row}>
           <Button

--- a/packages/react-keytips/stories/WithTabs.stories.tsx
+++ b/packages/react-keytips/stories/WithTabs.stories.tsx
@@ -1,8 +1,6 @@
 import * as React from 'react';
 import {
   ExecuteKeytipEventHandler,
-  Keytips,
-  KeytipsProps,
   useKeytipRef,
 } from '@fluentui-contrib/react-keytips';
 import {
@@ -44,7 +42,7 @@ const btnExecute: ExecuteKeytipEventHandler = (_, el) => {
   el.targetElement?.click();
 };
 
-export const WithTabsStory = (props: KeytipsProps) => {
+export const WithTabsStory = () => {
   const classes = useStyles();
 
   const [selectedValue, setSelectedValue] = React.useState<TabValue>('1');
@@ -103,7 +101,6 @@ export const WithTabsStory = (props: KeytipsProps) => {
 
   return (
     <>
-      <Keytips {...props} content="Alt Control" />
       <TabList onTabSelect={onTabSelect}>
         <Tab id="1" ref={refFirstTab} value="1">
           First Tab

--- a/packages/react-keytips/stories/index.stories.tsx
+++ b/packages/react-keytips/stories/index.stories.tsx
@@ -1,5 +1,8 @@
+import * as React from 'react';
+
 import { Meta } from '@storybook/react';
 import { Keytips } from '@fluentui-contrib/react-keytips';
+import description from '../README.md';
 export { DefaultStory as Default } from './Default.stories';
 export { WithTabsStory as WithTabs } from './WithTabs.stories';
 export { DynamicStory as Dynamic } from './Dynamic.stories';
@@ -8,6 +11,22 @@ export { OverflowStory as Overflow } from './OverflowMenu.stories';
 const meta = {
   title: 'Packages/react-keytips',
   component: Keytips,
+  decorators: [
+    (Story, { viewMode, name }) => (
+      <>
+        {viewMode === 'story' && <Keytips />}
+        {viewMode === 'docs' && name === 'Default' && <Keytips />}
+        <Story />
+      </>
+    ),
+  ],
+  parameters: {
+    docs: {
+      description: {
+        component: description,
+      },
+    },
+  },
 } satisfies Meta<typeof Keytips>;
 
 export default meta;


### PR DESCRIPTION
Currently, the Keytips implementation on our documentation site isn’t working optimally because each story contains its own instance of the Keytips component. This setup was manageable when the components were only separated in stories, but it’s not effective for the docsite. Ideally, the Keytips component should be added once at the application level. With the current configuration, we would end up registering four different handlers.

