### PR TITLE
refactor(react-interactive-tab): export all types and hooks from barrel file

### DIFF
--- a/change/@fluentui-contrib-react-interactive-tab-8aa8ba4d-13ec-4ea7-b62f-55b5e8d76951.json
+++ b/change/@fluentui-contrib-react-interactive-tab-8aa8ba4d-13ec-4ea7-b62f-55b5e8d76951.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "refactor: export all types and hooks from barrel file",
+  "packageName": "@fluentui-contrib/react-interactive-tab",
+  "email": "soniaboller@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-interactive-tab/src/index.ts
+++ b/packages/react-interactive-tab/src/index.ts
@@ -1,2 +1,13 @@
-export { InteractiveTab } from './components/InteractiveTab';
-export {};
+export type {
+  InteractiveTabProps,
+  InteractiveTabSlots,
+  InteractiveTabState,
+  InteractiveTabInternalSlots,
+} from './components/InteractiveTab';
+export {
+  InteractiveTab,
+  interactiveTabClassNames,
+  renderInteractiveTab_unstable,
+  useInteractiveTabStyles_unstable,
+  useInteractiveTab_unstable,
+} from './components/InteractiveTab';

--- a/packages/react-interactive-tab/src/index.ts
+++ b/packages/react-interactive-tab/src/index.ts
@@ -2,7 +2,6 @@ export type {
   InteractiveTabProps,
   InteractiveTabSlots,
   InteractiveTabState,
-  InteractiveTabInternalSlots,
 } from './components/InteractiveTab';
 export {
   InteractiveTab,


### PR DESCRIPTION
barrel file for InteractiveTab should export all types and hooks, in addition to the component