### PR TITLE
feat(variant-theme): keep custom colors

### DIFF
--- a/change/@fluentui-contrib-variant-theme-30b11b3b-d257-4605-a5e0-3b645353268b.json
+++ b/change/@fluentui-contrib-variant-theme-30b11b3b-d257-4605-a5e0-3b645353268b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "keep custom colors",
+  "packageName": "@fluentui-contrib/variant-theme",
+  "email": "rongqizhou@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/variant-theme/src/ThemeGenerator.ts
+++ b/packages/variant-theme/src/ThemeGenerator.ts
@@ -214,7 +214,11 @@ function getStrongVariant(
   // Todo: dark mode support
   setNeutralWithBrand(theme, brand);
 
-  const alphas: Record<AlphaColors, string> = contrast(hex_to_sRGB(newBrandColor), hex_to_sRGB(black)) > contrast(hex_to_sRGB(newBrandColor), hex_to_sRGB(white)) ? whiteAlpha : blackAlpha;
+  const alphas: Record<AlphaColors, string> =
+    contrast(hex_to_sRGB(newBrandColor), hex_to_sRGB(black)) >
+    contrast(hex_to_sRGB(newBrandColor), hex_to_sRGB(white))
+      ? whiteAlpha
+      : blackAlpha;
   setColorsOnBrand(theme, brand, newBrandColor, alphas, isInverted);
 }
 

--- a/packages/variant-theme/src/ThemeGenerator.ts
+++ b/packages/variant-theme/src/ThemeGenerator.ts
@@ -209,15 +209,13 @@ function getStrongVariant(
   brand: BrandVariants,
   isInverted?: boolean
 ) {
+  const newBrandColor = theme.colorNeutralBackground1;
+
   // Todo: dark mode support
   setNeutralWithBrand(theme, brand);
-  const colorOnBrand: string = determineColorOnBrand(
-    theme.colorNeutralBackground1
-  );
-  const alphas: Record<AlphaColors, string> =
-    colorOnBrand === black ? blackAlpha : whiteAlpha;
 
-  setColorsOnBrand(theme, brand, colorOnBrand, alphas, isInverted);
+  const alphas: Record<AlphaColors, string> = contrast(hex_to_sRGB(newBrandColor), hex_to_sRGB(black)) > contrast(hex_to_sRGB(newBrandColor), hex_to_sRGB(white)) ? whiteAlpha : blackAlpha;
+  setColorsOnBrand(theme, brand, newBrandColor, alphas, isInverted);
 }
 
 function setNeutralWithBrand(theme: Theme, brand: BrandVariants) {


### PR DESCRIPTION
Since color is user's choice, so we will keep the color, and do not flip it when it has contrast issue.

before:
![image](https://github.com/user-attachments/assets/b38d936d-77bb-4431-9632-3171d9969b9d)

after:
![image](https://github.com/user-attachments/assets/6832dd6e-a4c8-43ee-9994-bd254af4f29a)
