### PR TITLE
docs(react-tree-grid): add a11y section to documentation

### DIFF
--- a/change/@fluentui-contrib-react-tree-grid-0ace8cfd-01c0-444f-ae97-d23f97d6ad9d.json
+++ b/change/@fluentui-contrib-react-tree-grid-0ace8cfd-01c0-444f-ae97-d23f97d6ad9d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "docs(react-tree-grid): add a11y section to documentation",
+  "packageName": "@fluentui-contrib/react-tree-grid",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-tree-grid/stories/a11y.md
+++ b/packages/react-tree-grid/stories/a11y.md
@@ -1,0 +1,3 @@
+## Accessibility
+
+Here are some accessibility edge cases scenarios we identified and users should keep in mind while using the `TreeGrid` components.

--- a/packages/react-tree-grid/stories/index.stories.tsx
+++ b/packages/react-tree-grid/stories/index.stories.tsx
@@ -1,7 +1,7 @@
 import { Meta } from '@storybook/react';
 import { TreeGrid } from '@fluentui-contrib/react-tree-grid';
 import description from '../README.md';
-import a11y from './a11y.md'
+import a11y from './a11y.md';
 
 export { Default } from './Default.stories';
 export { Meet } from './Meet.stories';

--- a/packages/react-tree-grid/stories/index.stories.tsx
+++ b/packages/react-tree-grid/stories/index.stories.tsx
@@ -1,6 +1,7 @@
 import { Meta } from '@storybook/react';
 import { TreeGrid } from '@fluentui-contrib/react-tree-grid';
 import description from '../README.md';
+import a11y from './a11y.md'
 
 export { Default } from './Default.stories';
 export { Meet } from './Meet.stories';
@@ -15,7 +16,7 @@ const meta = {
   parameters: {
     docs: {
       description: {
-        component: description,
+        component: [description, a11y].join('\n'),
       },
     },
   },


### PR DESCRIPTION
Adds an `a11y` section to the documentation to ensure a11y issues will be tracked and kept in check.