### PR TITLE
fix(react-keytips): fix tree issue with not removing the nodes

### DIFF
--- a/change/@fluentui-contrib-react-keytips-0d1d16b6-84a2-42c8-88eb-2076c577056f.json
+++ b/change/@fluentui-contrib-react-keytips-0d1d16b6-84a2-42c8-88eb-2076c577056f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: fix the issue with showing duplicates in Overflow",
+  "packageName": "@fluentui-contrib/react-keytips",
+  "email": "vgenaev@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-keytips/src/components/Keytips/useKeytips.tsx
+++ b/packages/react-keytips/src/components/Keytips/useKeytips.tsx
@@ -123,13 +123,17 @@ export const useKeytips_unstable = (props: KeytipsProps): KeytipsState => {
         keytip,
       });
 
-      if (state.inKeytipMode && tree.isCurrentKeytipParent(keytip)) {
+      if (tree.isCurrentKeytipParent(keytip)) {
         showKeytips(tree.getChildren());
       }
     };
 
     const handleKeytipRemoved = (keytip: KeytipWithId) => {
       tree.removeNode(keytip.uniqueId);
+      // nodemway mave an alias registered, if it's shortcut
+      if (keytip.isShortcut) {
+        tree.removeNode(`${keytip.uniqueId}-alias`);
+      }
 
       dispatch({ type: ACTIONS.REMOVE_KEYTIP, id: keytip.uniqueId });
     };
@@ -147,7 +151,7 @@ export const useKeytips_unstable = (props: KeytipsProps): KeytipsState => {
     return () => {
       reset();
     };
-  }, [state.inKeytipMode]);
+  }, []);
 
   React.useEffect(() => {
     const controller = new AbortController();

--- a/packages/react-keytips/src/hooks/useKeytipRef.ts
+++ b/packages/react-keytips/src/hooks/useKeytipRef.ts
@@ -50,6 +50,7 @@ export const useKeytipRef = <
     dispatch(EVENTS.KEYTIP_ADDED, ktp);
 
     return () => {
+      [];
       dispatch(EVENTS.KEYTIP_REMOVED, ktp);
     };
   }, [node]);

--- a/packages/react-keytips/src/hooks/useKeytipRef.ts
+++ b/packages/react-keytips/src/hooks/useKeytipRef.ts
@@ -50,7 +50,6 @@ export const useKeytipRef = <
     dispatch(EVENTS.KEYTIP_ADDED, ktp);
 
     return () => {
-      [];
       dispatch(EVENTS.KEYTIP_REMOVED, ktp);
     };
   }, [node]);

--- a/packages/react-keytips/stories/OverflowMenu.stories.tsx
+++ b/packages/react-keytips/stories/OverflowMenu.stories.tsx
@@ -108,7 +108,7 @@ const OverflowMenuItemWrapper = React.forwardRef<
   }
 
   return (
-    <MenuItem id={keytipProps.id} ref={mergedRefs} persistOnClick>
+    <MenuItem id={keytipProps.id} ref={mergedRefs}>
       Item {keytipProps.id}
     </MenuItem>
   );


### PR DESCRIPTION
`useKeytips` hook was not removing alias node, plus it had duplicates and it showed them  in some cases (see Overflow example below).

**Before:** 

https://github.com/user-attachments/assets/2b48e1c1-5dd8-48c1-b17b-a90c7931554e

**After:** 

https://github.com/user-attachments/assets/a94c20c3-ec1b-4c07-9e70-e1f307f03372

