### PR TITLE
fix: Add null guard for depth check

### DIFF
--- a/change/@fluentui-contrib-stylelint-plugin-79aafcea-5765-4f2c-af35-91dba0eb16de.json
+++ b/change/@fluentui-contrib-stylelint-plugin-79aafcea-5765-4f2c-af35-91dba0eb16de.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Add null guard for depth check",
+  "packageName": "@fluentui-contrib/stylelint-plugin",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/stylelint-plugin/src/rules/combinator-depth/combinator-depth.test.ts
+++ b/packages/stylelint-plugin/src/rules/combinator-depth/combinator-depth.test.ts
@@ -111,6 +111,27 @@ describe('combinator-depth', () => {
     expect(results[0].warnings[0].text).toContain(`maximum allowed depth of 0`);
   });
 
+  it.each(['.foo', '[data-foo]', '[data-foo="bar"]', '.foo[data-foo="bar"]'])(
+    'should not fail for singe level combinator %s',
+    async (selector) => {
+      const { errored, results } = await stylelint.lint({
+        code: `${selector} { color: red; }`,
+        config: {
+          pluginFunctions: {
+            [rule.ruleName]: rule,
+          },
+          rules: {
+            [rule.ruleName]: [0],
+          },
+        },
+      });
+
+      expect(errored).toBe(false);
+      expect(results.length).toBe(1);
+      expect(results[0].warnings.length).toBe(0);
+    }
+  );
+
   it.each([false, 'a', '%'])(
     'should throw an error if not configured with an %s',
     (allowedDepth) => {

--- a/packages/stylelint-plugin/src/rules/combinator-depth/combinator-depth.ts
+++ b/packages/stylelint-plugin/src/rules/combinator-depth/combinator-depth.ts
@@ -53,6 +53,7 @@ export default createRule({
       ).length;
 
       if (
+        tokenizedSelector.length > 1 &&
         tokenizedSelector[1].type === 'pseudo-class' &&
         [':hover', ':active'].includes(tokenizedSelector[1].content) &&
         combinatorCount <= allowedDepth + 1


### PR DESCRIPTION
Adds a check for the tokenizedSelector length before checking further indexes in the tokenized selector array.

Adds tests to cover the regression