### PR TITLE
chore: replace deprecated @nx/linter with @nx/eslint

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@nx/eslint-plugin": "19.8.14",
     "@nx/jest": "19.8.14",
     "@nx/js": "19.8.14",
-    "@nx/linter": "19.8.14",
+    "@nx/eslint": "19.8.14",
     "@nx/playwright": "19.8.14",
     "@nx/plugin": "19.8.14",
     "@nx/react": "19.8.14",

--- a/packages/nx-plugin/project.json
+++ b/packages/nx-plugin/project.json
@@ -37,7 +37,7 @@
       }
     },
     "lint": {
-      "executor": "@nx/linter:eslint",
+      "executor": "@nx/eslint:lint",
       "outputs": ["{options.outputFile}"],
       "options": {
         "lintFilePatterns": [

--- a/packages/pierce-dom/project.json
+++ b/packages/pierce-dom/project.json
@@ -12,7 +12,7 @@
       "dependsOn": ["build"]
     },
     "lint": {
-      "executor": "@nx/linter:eslint",
+      "executor": "@nx/eslint:lint",
       "outputs": ["{options.outputFile}"],
       "options": {
         "lintFilePatterns": [

--- a/packages/react-chat/project.json
+++ b/packages/react-chat/project.json
@@ -12,7 +12,7 @@
       "dependsOn": ["build"]
     },
     "lint": {
-      "executor": "@nx/linter:eslint",
+      "executor": "@nx/eslint:lint",
       "outputs": ["{options.outputFile}"],
       "options": {
         "lintFilePatterns": [

--- a/packages/react-data-grid-react-window-grid/project.json
+++ b/packages/react-data-grid-react-window-grid/project.json
@@ -12,7 +12,7 @@
       "dependsOn": ["build"]
     },
     "lint": {
-      "executor": "@nx/linter:eslint",
+      "executor": "@nx/eslint:lint",
       "outputs": ["{options.outputFile}"],
       "options": {
         "lintFilePatterns": [

--- a/packages/react-data-grid-react-window/project.json
+++ b/packages/react-data-grid-react-window/project.json
@@ -12,7 +12,7 @@
       "dependsOn": ["build"]
     },
     "lint": {
-      "executor": "@nx/linter:eslint",
+      "executor": "@nx/eslint:lint",
       "outputs": ["{options.outputFile}"],
       "options": {
         "lintFilePatterns": [

--- a/packages/react-draggable-dialog/project.json
+++ b/packages/react-draggable-dialog/project.json
@@ -12,7 +12,7 @@
       "dependsOn": ["build"]
     },
     "lint": {
-      "executor": "@nx/linter:eslint",
+      "executor": "@nx/eslint:lint",
       "outputs": ["{options.outputFile}"],
       "options": {
         "lintFilePatterns": [

--- a/packages/react-headless-provider/project.json
+++ b/packages/react-headless-provider/project.json
@@ -12,7 +12,7 @@
       "dependsOn": ["build"]
     },
     "lint": {
-      "executor": "@nx/linter:eslint",
+      "executor": "@nx/eslint:lint",
       "outputs": ["{options.outputFile}"],
       "options": {
         "lintFilePatterns": [

--- a/packages/react-resize-handle/project.json
+++ b/packages/react-resize-handle/project.json
@@ -13,7 +13,7 @@
       "dependsOn": ["build"]
     },
     "lint": {
-      "executor": "@nx/linter:eslint",
+      "executor": "@nx/eslint:lint",
       "outputs": ["{options.outputFile}"],
       "options": {
         "lintFilePatterns": [

--- a/packages/react-shadow/project.json
+++ b/packages/react-shadow/project.json
@@ -12,7 +12,7 @@
       "dependsOn": ["build"]
     },
     "lint": {
-      "executor": "@nx/linter:eslint",
+      "executor": "@nx/eslint:lint",
       "outputs": ["{options.outputFile}"],
       "options": {
         "lintFilePatterns": [

--- a/packages/react-tree-grid/project.json
+++ b/packages/react-tree-grid/project.json
@@ -12,7 +12,7 @@
       "dependsOn": ["build"]
     },
     "lint": {
-      "executor": "@nx/linter:eslint",
+      "executor": "@nx/eslint:lint",
       "outputs": ["{options.outputFile}"],
       "options": {
         "lintFilePatterns": [

--- a/packages/stylelint-plugin/project.json
+++ b/packages/stylelint-plugin/project.json
@@ -12,7 +12,7 @@
       "dependsOn": ["build"]
     },
     "lint": {
-      "executor": "@nx/linter:eslint",
+      "executor": "@nx/eslint:lint",
       "outputs": ["{options.outputFile}"],
       "options": {
         "lintFilePatterns": [

--- a/project.json
+++ b/project.json
@@ -1,6 +1,7 @@
 {
   "name": "fluentui-contrib",
   "$schema": "node_modules/nx/schemas/project-schema.json",
+  "includedScripts": [],
   "targets": {
     "local-registry": {
       "executor": "@nx/js:verdaccio",


### PR DESCRIPTION
`@nx/linter` plugin is no longer published starting with nx v20, thus automatic migrations would not work

this PR replaces deprecated `@nx/linter` with `@nx/eslint`