### PR TITLE
fix(react-keytips): do not show overflowing keytips

### DIFF
--- a/change/@fluentui-contrib-react-keytips-d123b6a8-376c-449e-a0b1-9698b5da6667.json
+++ b/change/@fluentui-contrib-react-keytips-d123b6a8-376c-449e-a0b1-9698b5da6667.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: do not show overflowing keytips",
+  "packageName": "@fluentui-contrib/react-keytips",
+  "email": "vgenaev@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-keytips/src/utilities/isTargetVisible.ts
+++ b/packages/react-keytips/src/utilities/isTargetVisible.ts
@@ -6,7 +6,12 @@ export const isTargetVisible = (
 ): boolean => {
   if (!target || !win) return false;
   if (isDisabled(target)) return false;
+  if (
+    target?.hasAttribute('data-overflowing') ||
+    target?.parentElement?.hasAttribute('data-overflowing')
+  )
+    return false;
 
   const style = win.getComputedStyle(target);
-  return style.display !== 'none' && style.visibility !== 'hidden';
+  return style.display !== 'none' || style.visibility !== 'hidden';
 };

--- a/packages/react-keytips/stories/Overflow/OverflowMenu.tsx
+++ b/packages/react-keytips/stories/Overflow/OverflowMenu.tsx
@@ -26,7 +26,6 @@ const OverflowMenuItemWrapper = React.forwardRef<
   }>
 >(({ keytipProps, overflowSequence, id, children, ...props }, ref) => {
   const isVisible = useIsOverflowItemVisible(id);
-  false;
 
   const keytipRef = useKeytipRef<HTMLDivElement>({
     ...keytipProps,

--- a/packages/react-keytips/stories/Shortcuts.stories.tsx
+++ b/packages/react-keytips/stories/Shortcuts.stories.tsx
@@ -91,7 +91,6 @@ const OverflowMenuItemWrapper = React.forwardRef<
   { keytipProps: KeytipProps & { id: string } }
 >(({ keytipProps }, ref) => {
   const isVisible = useIsOverflowItemVisible(keytipProps.id);
-  false;
 
   const keytipRef = useKeytipRef<HTMLDivElement>({
     ...keytipProps,


### PR DESCRIPTION
**Before:**

![Screenshot 2025-01-17 at 19 50 04](https://github.com/user-attachments/assets/4ec28ddb-5c25-47e0-ac28-e76038ceb8f3)

**After:**

![Screenshot 2025-01-17 at 19 51 04](https://github.com/user-attachments/assets/0347a6af-12e5-487b-a8b8-8b3d2bdef349)

In the Overflow example, the overflowed element stays in the DOM after it’s overflowed. Just checking the visibility or display styles isn’t enough. For example, with a Keytip attached to a SplitButton, the styles were applied to the root div of the SplitButton, not the specific side button where the Keytip was attached. To make this more reliable, we could add a check for the data-overflowing attribute.