### PR TITLE
ci: remove use of PAT on release pipeline

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -39,6 +39,9 @@ extends:
                   targetPath: $(System.DefaultWorkingDirectory)/packages
                   artifactName: output
             steps:
+              - checkout: self
+                persistCredentials: true
+
               # For multiline scripts, we want the whole task to fail if any line of the script fails.
               # ADO doesn't have bash configured this way by default. To fix we override the SHELLOPTS built-in variable.
               # https://www.gnu.org/software/bash/manual/html_node/The-Set-Builtin.html
@@ -60,12 +63,9 @@ extends:
               - script: |
                   git config user.name "Fluent UI Build"
                   git config user.email "fluentui-internal@service.microsoft.com"
-                  git remote set-url origin https://$(githubUser):$(githubPAT)@github.com/microsoft/fluentui-contrib.git
                 displayName: Authenticate git for pushes
 
               - script: |
                   yarn beachball publish -b origin/main --access public -y -n $(npmToken)
                   git reset --hard origin/main
-                env:
-                  GITHUB_PAT: $(githubPAT)
                 displayName: Publish to NPM & bump versions


### PR DESCRIPTION
Leverages ADO github app connection instead using PAT for pushing back on release trigger
