### PR TITLE
fix(nx-plugin): remove unwanted @nx/js release boilerplate from library generator output

### DIFF
--- a/packages/nx-plugin/src/generators/library/generator.spec.ts
+++ b/packages/nx-plugin/src/generators/library/generator.spec.ts
@@ -5,6 +5,8 @@ import {
   readJson,
   workspaceRoot,
   joinPathFragments,
+  readNxJson,
+  updateNxJson,
 } from '@nx/devkit';
 
 import generator from './generator';
@@ -22,6 +24,9 @@ describe('create-package generator', () => {
   beforeEach(() => {
     tree = createTreeWithEmptyWorkspace();
     setupWorkspaceDependencies(tree);
+    updateNxJson(tree, {
+      release: { projects: ['packages/**/*', '!tag:npm:private'] },
+    });
     createCodeowners(tree);
   });
 
@@ -175,6 +180,25 @@ describe('create-package generator', () => {
       expect(readJson(tree, '/package.json').devDependencies).not.toEqual(
         expect.objectContaining({ 'ts-jest': expect.any(String) })
       );
+    });
+
+    it(`should not update /project.json with release metadata`, async () => {
+      await generator(tree, options);
+
+      const project = readProjectConfiguration(tree, 'test');
+
+      expect(project.release).toEqual(undefined);
+      expect(project.targets?.['nx-release-publish']).toEqual(undefined);
+    });
+
+    it(`should not force update nx.json#release`, async () => {
+      await generator(tree, options);
+
+      const nxJson = readNxJson(tree);
+
+      expect(nxJson.release).toEqual({
+        projects: ['packages/**/*', '!tag:npm:private'],
+      });
     });
   });
 });

--- a/packages/nx-plugin/src/generators/library/generator.ts
+++ b/packages/nx-plugin/src/generators/library/generator.ts
@@ -7,6 +7,10 @@ import {
   generateFiles,
   readProjectConfiguration,
   readJson,
+  joinPathFragments,
+  ProjectConfiguration,
+  readNxJson,
+  updateNxJson,
 } from '@nx/devkit';
 import * as path from 'path';
 import { libraryGenerator } from '@nx/js';
@@ -17,9 +21,7 @@ import { addCodeowner } from '../add-codeowners';
 export default async function (tree: Tree, options: LibraryGeneratorSchema) {
   const { name, owner } = options;
 
-  await invokeNxGenerators(tree, options);
-
-  const newProject = readProjectConfiguration(tree, name);
+  const { projectConfig: newProject } = await invokeNxGenerators(tree, options);
 
   const { root: projectRoot } = newProject;
   const paths = getPackagePaths(workspaceRoot, projectRoot);
@@ -90,6 +92,7 @@ function getReactComponentsVersion(tree: Tree) {
 
 async function invokeNxGenerators(tree: Tree, options: LibraryGeneratorSchema) {
   const { name } = options;
+  const currentNxJson = readNxJson(tree);
 
   await libraryGenerator(tree, {
     name,
@@ -102,7 +105,42 @@ async function invokeNxGenerators(tree: Tree, options: LibraryGeneratorSchema) {
     importPath: `${npmScope}/${name}`,
   });
 
+  const projectConfig = readProjectConfiguration(tree, name);
+
+  // remove nx release implicit config @see https://github.com/nrwl/nx/blob/master/packages/js/src/generators/library/library.ts#L341-L356
+  if (projectConfig.release) {
+    delete projectConfig.release;
+  }
+  if (projectConfig.targets?.['nx-release-publish']) {
+    delete projectConfig.targets?.['nx-release-publish'];
+  }
+  updateProjectConfiguration(tree, name, { ...projectConfig });
+
   // remove nx/jest generator defaults that we don't need
+  updateJson(
+    tree,
+    joinPathFragments(projectConfig.root, 'project.json'),
+    (json: ProjectConfiguration) => {
+      if (json.release) {
+        delete json.release;
+      }
+      if (json.targets?.['nx-release-publish']) {
+        delete json.targets?.['nx-release-publish'];
+      }
+
+      return json;
+    }
+  );
+
+  // remove unwanted release.version.preVersionCommand override @see https://github.com/nrwl/nx/blob/master/packages/js/src/generators/library/library.ts#L1252
+  const nxJson = readNxJson(tree);
+  if (currentNxJson?.release?.version) {
+    nxJson.release.version = currentNxJson.release.version;
+  } else {
+    delete nxJson?.release?.version;
+  }
+  updateNxJson(tree, nxJson);
+
   updateJson(tree, '/package.json', (json: PackageJson) => {
     if (json.devDependencies) {
       // @see https://github.com/nrwl/nx/blob/master/packages/jest/src/generators/configuration/lib/ensure-dependencies.ts#L26
@@ -113,5 +151,5 @@ async function invokeNxGenerators(tree: Tree, options: LibraryGeneratorSchema) {
     return json;
   });
 
-  return tree;
+  return { tree, projectConfig };
 }

--- a/packages/nx-plugin/src/generators/library/generator.ts
+++ b/packages/nx-plugin/src/generators/library/generator.ts
@@ -133,8 +133,8 @@ async function invokeNxGenerators(tree: Tree, options: LibraryGeneratorSchema) {
   );
 
   // remove unwanted release.version.preVersionCommand override @see https://github.com/nrwl/nx/blob/master/packages/js/src/generators/library/library.ts#L1252
-  const nxJson = readNxJson(tree);
-  if (currentNxJson?.release?.version) {
+  const nxJson = readNxJson(tree) ?? {};
+  if (currentNxJson?.release?.version && nxJson?.release?.version) {
     nxJson.release.version = currentNxJson.release.version;
   } else {
     delete nxJson?.release?.version;

--- a/packages/react-interactive-tab/project.json
+++ b/packages/react-interactive-tab/project.json
@@ -3,23 +3,10 @@
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "packages/react-interactive-tab/src",
   "projectType": "library",
-  "release": {
-    "version": {
-      "generatorOptions": {
-        "packageRoot": "dist/{projectRoot}",
-        "currentVersionResolver": "git-tag"
-      }
-    }
-  },
   "tags": [],
   "targets": {
     "build": {
       "executor": "@fluentui-contrib/nx-plugin:build"
-    },
-    "nx-release-publish": {
-      "options": {
-        "packageRoot": "dist/{projectRoot}"
-      }
     },
     "lint": {
       "executor": "@nx/eslint:lint",

--- a/packages/react-keytips/project.json
+++ b/packages/react-keytips/project.json
@@ -3,23 +3,10 @@
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "packages/react-keytips/src",
   "projectType": "library",
-  "release": {
-    "version": {
-      "generatorOptions": {
-        "packageRoot": "dist/{projectRoot}",
-        "currentVersionResolver": "git-tag"
-      }
-    }
-  },
   "tags": [],
   "targets": {
     "build": {
       "executor": "@fluentui-contrib/nx-plugin:build"
-    },
-    "nx-release-publish": {
-      "options": {
-        "packageRoot": "dist/{projectRoot}"
-      }
     },
     "lint": {
       "executor": "@nx/eslint:lint",


### PR DESCRIPTION
Since Nx Release was implemented within nx core `@nx/js:library` generator started to add nx release related setup that is not aligned with our specific needs.

**This PR:**
- normalizes existing project configs
- mitigates aforementioned issue in our library generator 