### PR TITLE
lint: setup nx dependency-checks rule

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -113,7 +113,26 @@
     {
       "files": "*.json",
       "parser": "jsonc-eslint-parser",
-      "rules": {}
+      "rules": {
+        "@nx/dependency-checks": [
+          "error",
+          {
+            "includeTransitiveDependencies": false,
+            "ignoredDependencies": [
+              "@types/react",
+              "@types/react-dom",
+              "@swc/helpers"
+            ],
+            "ignoredFiles": [
+              "{projectRoot}/playwright.config.ts",
+              "{projectRoot}/playwright/**",
+              "{projectRoot}/.storybook/**",
+              "{projectRoot}/stories/**",
+              "{projectRoot}/**/*.component-browser-spec.tsx"
+            ]
+          }
+        ]
+      }
     }
   ]
 }

--- a/packages/nx-plugin/.eslintrc.json
+++ b/packages/nx-plugin/.eslintrc.json
@@ -8,6 +8,7 @@
         "project": ["packages/nx-plugin/tsconfig.*?.json"]
       },
       "rules": {
+        "import/no-extraneous-dependencies": "off",
         "@typescript-eslint/await-thenable": "error",
         "@typescript-eslint/no-misused-promises": "error",
         "@typescript-eslint/no-floating-promises": "error"

--- a/packages/nx-plugin/package.json
+++ b/packages/nx-plugin/package.json
@@ -10,6 +10,11 @@
     "semver": "^7.5.2",
     "@nx/storybook": "^19.3.2",
     "@nx/js": "^19.3.2",
-    "@nx/playwright": "^19.3.2"
+    "@nx/playwright": "^19.3.2",
+    "tslib": "^2.3.0"
+  },
+  "peerDependencies": {
+    "@playwright/experimental-ct-react": "^1.49.1",
+    "nx": ">= 19 <= 21"
   }
 }

--- a/packages/nx-plugin/project.json
+++ b/packages/nx-plugin/project.json
@@ -44,7 +44,8 @@
           "packages/nx-plugin/**/*.ts",
           "packages/nx-plugin/package.json",
           "packages/nx-plugin/generators.json",
-          "packages/nx-plugin/executors.json"
+          "packages/nx-plugin/executors.json",
+          "packages/nx-plugin/package.json"
         ]
       }
     },

--- a/packages/nx-plugin/src/utils.ts
+++ b/packages/nx-plugin/src/utils.ts
@@ -35,5 +35,4 @@ export const npmScope = '@fluentui-contrib';
 // nx @private API's re-exports for internal usage
 // =================================================
 
-// eslint-disable-next-line import/no-extraneous-dependencies
 export { type PackageJson } from 'nx/src/utils/package-json';


### PR DESCRIPTION
Introduce https://nx.dev/nx-api/eslint-plugin/documents/dependency-checks which will become primary source of truth of depedencies specifications within fluent packages, which will be crucial for Nx Release migration.

This PR enables the rule on internal nx-plugin for better testing.

Relates to https://github.com/microsoft/fluentui-contrib/pull/281