### PR TITLE
chore: setup nx release with version plans

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -37,6 +37,11 @@
     },
     "e2e": {
       "cache": true
+    },
+    "nx-release-publish": {
+      "options": {
+        "packageRoot": "dist/packages/{projectName}"
+      }
     }
   },
   "namedInputs": {
@@ -52,6 +57,43 @@
       "!{projectRoot}/tsconfig.storybook.json"
     ],
     "sharedGlobals": []
+  },
+  "release": {
+    "projects": ["packages/**/*", "!tag:npm:private"],
+    "changelog": {
+      "projectChangelogs": {
+        "renderOptions": {
+          "authors": false,
+          "commitReferences": true,
+          "versionTitleDate": true
+        }
+      }
+    },
+    "version": {
+      "generatorOptions": {
+        "versionPrefix": "auto",
+        "currentVersionResolver": "disk"
+      }
+    },
+    "versionPlans": {
+      "ignorePatternsForPlanCheck": [
+        "**/*.test.tsx",
+        "**/*.test.ts",
+        "**/*.spec.tsx",
+        "**/*.spec.ts",
+        "**/*.component-browser-spec.tsx",
+        "**/*.stories.tsx",
+        "**/.eslintrc.json",
+        "**/jest.config.js",
+        "**/playwright.config.ts",
+        "**/project.json",
+        "**/*.md",
+        "**/*.babelrc",
+        "**/playwright/**",
+        "**/.storybook/**"
+      ]
+    },
+    "projectsRelationship": "independent"
   },
   "workspaceLayout": {
     "appsDir": "packages",


### PR DESCRIPTION
Adds production configuration for Nx Release Plans and publishing.

> see https://nx.dev/recipes/nx-release/file-based-versioning-version-plans#file-based-versioning-version-plans

Relates to https://github.com/microsoft/fluentui-contrib/pull/281