### PR TITLE
fix(react-keytips): allow multiple modifiers

### DIFF
--- a/change/@fluentui-contrib-react-keytips-eee8961e-66d4-46b7-98a1-4e0f0c7b66bc.json
+++ b/change/@fluentui-contrib-react-keytips-eee8961e-66d4-46b7-98a1-4e0f0c7b66bc.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: useHotkeys hook to accept several modifiers",
+  "packageName": "@fluentui-contrib/react-keytips",
+  "email": "vgenaev@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-keytips/README.md
+++ b/packages/react-keytips/README.md
@@ -23,8 +23,6 @@ hook to attach a Keytip to a specific target element.
 Users can toggle Keytip mode using the `startSequence` (Option+Command on macOS, Alt+Windows (Meta) on Windows, by default).
 To navigate back to the previous level of Keytips, the `returnSequence` (Esc by default) is used.
 
-````tsx
-
 ## Usage
 
 ```tsx
@@ -51,6 +49,6 @@ export const App = () => {
     </>
   );
 };
-````
+```
 
 Follow up on the [Storybook](https://microsoft.github.io/fluentui-contrib/react-keytips) for examples on how to use the components provided by this package.

--- a/packages/react-keytips/README.md
+++ b/packages/react-keytips/README.md
@@ -12,6 +12,19 @@ or
 yarn add @fluentui-contrib/react-keytips
 ```
 
+A Keytip is a small popup displayed near a UI component, indicating a key sequence that can be used to navigate to or trigger that component. Unlike keyboard shortcuts,
+Keytips guide users through a sequence of keys to traverse hierarchical levels of the UI.
+
+From a technical perspective, a Keytip is a wrapper around the Tooltip component.
+
+To enable Keytips, include the Keytips component at the root level of your application. Use the `useKeytipRef`
+hook to attach a Keytip to a specific target element.
+
+Users can toggle Keytip mode using the `startSequence` (Option+Command on macOS, Alt+Windows (Meta) on Windows, by default).
+To navigate back to the previous level of Keytips, the `returnSequence` (Esc by default) is used.
+
+````tsx
+
 ## Usage
 
 ```tsx
@@ -38,6 +51,6 @@ export const App = () => {
     </>
   );
 };
-```
+````
 
 Follow up on the [Storybook](https://microsoft.github.io/fluentui-contrib/react-keytips) for examples on how to use the components provided by this package.

--- a/packages/react-keytips/README.md
+++ b/packages/react-keytips/README.md
@@ -3,6 +3,12 @@
 ## Installation
 
 ```bash
+npm install @fluentui-contrib/react-keytips
+```
+
+or
+
+```bash
 yarn add @fluentui-contrib/react-keytips
 ```
 

--- a/packages/react-keytips/src/components/Keytip/Keytip.types.ts
+++ b/packages/react-keytips/src/components/Keytip/Keytip.types.ts
@@ -49,7 +49,7 @@ export type KeytipProps = ComponentProps<KeytipSlots> & {
   onReturn?: ReturnKeytipEventHandler;
   /**
    * Array of KeySequences which is the full key sequence to trigger this keytip
-   * Should not include initial 'start' key sequence
+   * Should not include initial 'start' key sequence.
    */
   keySequences: string[];
   /**
@@ -63,7 +63,7 @@ export type KeytipProps = ComponentProps<KeytipSlots> & {
   isShortcut?: boolean;
   /**
    * Whether or not this Keytip belongs to a component that has a menu. Keytip mode will stay on when a menu is opened,
-   * even if the items in that menu have no keytips. If this is
+   * even if the items in that menu have no keytips.
    */
   hasMenu?: boolean;
 };

--- a/packages/react-keytips/src/components/Keytips/Keytips.component-browser-spec.tsx
+++ b/packages/react-keytips/src/components/Keytips/Keytips.component-browser-spec.tsx
@@ -58,13 +58,13 @@ test.describe('enter and exit from keytip mode interactions', () => {
   }) => {
     const component = await mount(
       <KeytipsBasicExample
-        startSequence="alt+control"
+        startSequence="shift+control+m"
         exitSequence="alt+enter"
       />
     );
     const tooltip = page.getByRole('tooltip');
     await expect(tooltip).toBeHidden();
-    await component.press('Alt+Control');
+    await component.press('Shift+Control+M');
     await expect(tooltip).toBeVisible();
     await component.press('Alt+Enter');
     await expect(tooltip).toBeHidden();

--- a/packages/react-keytips/src/components/Keytips/Keytips.types.ts
+++ b/packages/react-keytips/src/components/Keytips/Keytips.types.ts
@@ -26,12 +26,13 @@ export type KeytipsProps = ComponentProps<KeytipsSlots> &
      */
     content?: string;
     /**
-     * Key sequence that will start keytips mode
+     * Key sequence that will start keytips mode. Should be a combination of modifier
+     * or modifiers and a key.
      * @default 'alt+meta'.
      */
     startSequence?: string;
     /**
-     * Key sequences that execute the return functionality in keytips
+     * Key sequence that execute the return functionality in keytips
      * (going back to the previous level of keytips).
      * @default 'escape'
      */

--- a/packages/react-keytips/src/docs/MIGRATION.md
+++ b/packages/react-keytips/src/docs/MIGRATION.md
@@ -11,19 +11,18 @@ This Migration guide is a work in progress and is not yet ready for use.
   - `keytipExitSequence` -> renamed to `exitSequence`, instead of `IKeytipTransitionKey[]`
     accepts a string value. Can be a single key or a combination of keys separated by "+".
   - `keytipStartSequence` -> renamed to `startSequence`, instead of `IKeytipTransitionKey[]`,
-    accepts a string value (default: "alt+meta (alt+win on Windows)"). Can be a single key or a combination of keys separated by "+".
+    accepts a string value (default: "alt+meta (Alt+Win on Windows, Option+Command on MacOS)"). Can be a single key or a combination of keys separated by "+".
   - `keytipReturnSequence` -> renamed to `returnSequence`, instead of `IKeytipTransitionKey[]`,
     accepts a string value. Can be a single key or a combination of keys separated by "+".
   - `styles` - Not supported.
   - `componentRef` -> Not supported.
 
 - `useKeytipRef`:
-  - `offset` - Changed. Instead use [positioning.offset](https://react.fluentui.dev/?path=/docs/concepts-developer-positioning-components--docs#offset-value).
+  - `offset` - Changed. Please use instead [positioning.offset](https://react.fluentui.dev/?path=/docs/concepts-developer-positioning-components--docs#offset-value).
   - `styles` - Not supported.
   - `theme` - Not supported. `Keytip` theme depends on the values passed to `css` variables.
   - `disabled` - Not supported. `Keytip` won't appear for disabled target.
-    `callOutProps` -> Not supported. Instead there are multiple props available, that has to be used individually: `positioning`, `visible`, `content`.
-  - `hasDynamicChildren` became `dynamic` prop. If `Keytip` triggers dynamic content: Menu, Modal, Tabs or any other item that
-    that has keytips, set `dynamic` to `true`.
+    `callOutProps` -> Not supported. Instead of `calloutProps`, there are multiple props available, that has to be used individually: `positioning`, `visible`, `content`.
+  - `hasDynamicChildren` became `dynamic` prop. If `Keytip` triggers dynamic content (DOM is generated on keytip activation) set `dynamic` to `true`.
   - `overflowSetSequence` - Not supported.
-  - `hasOverflowSubMenu` -> Changed. Instead use `hasMenu`.
+  - `hasOverflowSubMenu` -> renamed to `hasMenu`.

--- a/packages/react-keytips/src/docs/Spec.md
+++ b/packages/react-keytips/src/docs/Spec.md
@@ -169,7 +169,7 @@ See [MIGRATION.md](./MIGRATION.md).
 
 ## Entering and Exiting Keytips Mode
 
-- When the `startSequence` is pressed, the keytips component will enter keytips mode. By default the `startSequence` is `'alt+meta'` (option+control on macOS).
+- When the `startSequence` is pressed, the keytips component will enter keytips mode. By default the `startSequence` is `'alt+meta'` (option+control on macOS, alt+windows on Windows).
   After entering keytips mode, the root Keytips will be visible (the ones that have no parent Keytip).
 
 - When the `returnSequence` is pressed, the parent keytips of current keytip will be shown, if it's the first (root) level of keytip, then the keytips mode will be exited.

--- a/packages/react-keytips/src/hooks/useHotkeys.test.ts
+++ b/packages/react-keytips/src/hooks/useHotkeys.test.ts
@@ -9,12 +9,12 @@ describe('useHotkeys', () => {
 
     renderHook(() =>
       useHotkeys([
-        ['alt+control', handlerFirst],
+        ['shift+control+m', handlerFirst],
         ['alt+x', handlerSecond],
       ])
     );
 
-    await userEvent.keyboard('{Alt>}{Control}');
+    await userEvent.keyboard('{Shift>}{Control>}{m}');
     expect(handlerFirst).toHaveBeenCalledTimes(1);
     expect(handlerSecond).not.toHaveBeenCalled();
 
@@ -36,9 +36,9 @@ describe('useHotkeys', () => {
 
     const cb = jest.fn();
 
-    renderHook(() => useHotkeys([['alt+control', cb, { delay: 1000 }]]));
+    renderHook(() => useHotkeys([['alt+meta', cb, { delay: 1000 }]]));
 
-    await user.keyboard('{Alt>}{Control>}');
+    await user.keyboard('{Alt>}{Meta>}');
 
     expect(cb).toHaveBeenCalledTimes(0);
 


### PR DESCRIPTION
fixed the issue with modifiers and adding control as a modifier. Updated README. 