### PR TITLE
Clarifies `startSequence` in `KeyTips` docs

### DIFF
--- a/change/@fluentui-contrib-react-keytips-050264dc-fc06-4619-bc99-d97fced79a69.json
+++ b/change/@fluentui-contrib-react-keytips-050264dc-fc06-4619-bc99-d97fced79a69.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "docs: clarify startSequence value",
+  "packageName": "@fluentui-contrib/react-keytips",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-keytips/README.md
+++ b/packages/react-keytips/README.md
@@ -41,7 +41,7 @@ export const App = () => {
 
   return (
     <>
-      {/* Keytips must be added once at the root level of the app */}
+      {/* Keytips must be added once under the root-most FluentProvider of the app */}
       <Keytips />
       <Button ref={keytipRefA}>Button A</Button>
       <Button ref={keytipRefB}>Button B</Button>

--- a/packages/react-keytips/src/components/Keytips/Keytips.types.ts
+++ b/packages/react-keytips/src/components/Keytips/Keytips.types.ts
@@ -27,8 +27,8 @@ export type KeytipsProps = ComponentProps<KeytipsSlots> &
     content?: string;
     /**
      * Key sequence that will start keytips mode. Should be a combination of modifier
-     * or modifiers and a key.
-     * @default 'alt+meta'.
+     * or modifiers and a key. Defaults to `alt + ctrl` on Windows and `option + cmd` on macOS.
+     * @default 'alt+meta'
      */
     startSequence?: string;
     /**

--- a/packages/react-keytips/src/docs/Spec.md
+++ b/packages/react-keytips/src/docs/Spec.md
@@ -86,7 +86,7 @@ const App = () => {
 
   return (
     <>
-      {/* Should be added once at the top level of your app */}
+      {/* Should be added once under the root-most FluentProvider of the app */}
       <Keytips />
       <Checkbox label="checkbox" ref={checkboxRef} />
     </>


### PR DESCRIPTION
I was unclear on the hotkey to display `KeyTips` so I've updated the docs to:

1. Explicitly call out the default Windows and macOS hotkeys in the props table
2. Remove a period from the default value in the props table. This made me think the key sequence was `alt + meta + .`