### PR TITLE
feat: Extensions to makeStrictStyles

### DIFF
--- a/packages/teams-components/src/components/Button/Button.tsx
+++ b/packages/teams-components/src/components/Button/Button.tsx
@@ -5,10 +5,21 @@ import {
   renderButton_unstable,
   type ButtonProps as ButtonPropsBase,
   Tooltip,
+  GriffelStyle,
 } from '@fluentui/react-components';
 import { validateIconButton, validateMenuButton } from './validateProps';
-import { type StrictCssClass, validateStrictClasses } from '../../strictStyles';
+import {
+  type StrictCssClass,
+  validateStrictClasses,
+  type DefaultStrictStyles,
+} from '../../strictStyles';
 import { type StrictSlot } from '../../strictSlot';
+
+export type ButtonStrictOverrides = Pick<
+  GriffelStyle,
+  'maxWidth' | 'minWidth'
+> &
+  DefaultStrictStyles;
 
 export interface ButtonProps
   extends Pick<
@@ -22,7 +33,7 @@ export interface ButtonProps
     | 'disabledFocusable'
   > {
   appearance?: 'transparent' | 'primary';
-  className?: StrictCssClass;
+  className?: StrictCssClass<ButtonStrictOverrides>;
   icon?: StrictSlot;
   onClick?: React.MouseEventHandler<HTMLButtonElement>;
   title?: StrictSlot;

--- a/packages/teams-components/src/strictStyles/index.ts
+++ b/packages/teams-components/src/strictStyles/index.ts
@@ -1,4 +1,4 @@
 export { makeStrictStyles } from './makeStrictStyles';
 export { mergeStrictClasses } from './mergeStrictClasses';
 export { validateStrictClasses } from './validateStrictClasses';
-export type { StrictCssClass } from './types';
+export type { StrictCssClass, DefaultStrictStyles } from './types';

--- a/packages/teams-components/src/strictStyles/types.ts
+++ b/packages/teams-components/src/strictStyles/types.ts
@@ -1,18 +1,20 @@
+import * as React from 'react';
 import type { STRICT_SYMBOL } from './STRICT_SYMBOL';
 import type { GriffelStyle } from '@fluentui/react-components';
 
-export interface StrictCssClass {
+export interface StrictCssClass<TExtension = DefaultStrictStyles> {
   /**
    * @returns CSS class string
    */
   toString: () => string;
   DO_NOT_USE_OR_YOU_WILL_BE_FIRED: typeof STRICT_SYMBOL;
+  /**
+   * This field is only used to allow style extensions for components
+   */
+  overrideFilter?: TExtension;
 }
 
-/**
- * Allow list for CSS properties - add to this cautiously
- */
-export type StrictStyles = Pick<
+export type DefaultStrictStyles = Pick<
   GriffelStyle,
   | 'marginInline'
   | 'marginBlock'
@@ -25,9 +27,30 @@ export type StrictStyles = Pick<
   | 'alignSelf'
 >;
 
-export type MakeStrictStyles = <Slots extends string>(
-  styles: Record<Slots, StrictStyles>
-) => () => Record<Slots, StrictCssClass>;
+/**
+ * Allow list for CSS properties - add to this cautiously
+ */
+export type StrictStyles<TExtension = DefaultStrictStyles> =
+  DefaultStrictStyles & TExtension;
+
+type BaseComponenType = React.JSXElementConstructor<{
+  className?: StrictCssClass;
+}>;
+
+type ExtractStrictStyleOverrides<TComponent extends BaseComponenType> =
+  NonNullable<
+    NonNullable<React.ComponentProps<TComponent>['className']>['overrideFilter']
+  >;
+
+export type MakeStrictStyles = <
+  TComponent extends BaseComponenType,
+  Slots extends string = string
+>(
+  styles: Record<Slots, StrictStyles<ExtractStrictStyleOverrides<TComponent>>>
+) => () => Record<
+  Slots,
+  StrictCssClass<ExtractStrictStyleOverrides<TComponent>>
+>;
 
 export type MergeStrictClasses = (
   ...strictClasses: StrictCssClass[]

--- a/packages/teams-components/src/strictStyles/validateStrictClasses.ts
+++ b/packages/teams-components/src/strictStyles/validateStrictClasses.ts
@@ -1,8 +1,8 @@
 import { STRICT_SYMBOL } from './STRICT_SYMBOL';
 import type { StrictCssClass } from './types';
 
-export const validateStrictClasses = (
-  className?: StrictCssClass | false | undefined
+export const validateStrictClasses = <TExtension>(
+  className?: StrictCssClass<TExtension> | false | undefined
 ) => {
   if (!className) {
     return;


### PR DESCRIPTION
Updates strict styles API to support component level extensions by leveraging generics throughout all the types. Example of usage

```tsx
const useStrictStyles = makeStrictStyles<typeof Button>({
  strict: {
    alignSelf: 'center',
    // 👇 `maxWidth` only exists when Button style extensions are used
    maxWidth: '100%',
  },
});

// 👇 This is equally valid usage for the `Button` component without enabling component styling extensions
const useStrictStyles = makeStrictStyles({
  strict: {
    alignSelf: 'center',
  },
});

<Button className={strictStyles.strict}>Button</Button>
```