### PR TITLE
chore(ci): update github pages upload action

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -43,12 +43,12 @@ jobs:
       - run: yarn nx run-many --target=build-storybook
 
       - name: Setup Pages
-        uses: actions/configure-pages@v3
+        uses: actions/configure-pages@v5
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
         with:
           # Upload entire repository
           path: './dist/storybook'
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
Failed job: https://github.com/microsoft/fluentui-contrib/actions/runs/13457302489 

`actions/upload-artifact: v3` is [no longer accessible for usage](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/). 

Upload to the latest [upload-page-artifact](https://github.com/actions/upload-pages-artifact) should solve it: https://github.com/actions/upload-pages-artifact/blob/main/action.yml#L80