### PR TITLE
fix(react-keytips): make keytips available for screen readers before …

### DIFF
--- a/change/@fluentui-contrib-react-keytips-b1b6223b-88d1-4525-8ef9-36742752adbe.json
+++ b/change/@fluentui-contrib-react-keytips-b1b6223b-88d1-4525-8ef9-36742752adbe.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: keep aria-keyshortcuts and make it available before entering keytip mode",
+  "packageName": "@fluentui-contrib/react-keytips",
+  "email": "vgenaev@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-keytips/src/components/Keytip/useKeytip.tsx
+++ b/packages/react-keytips/src/components/Keytip/useKeytip.tsx
@@ -81,15 +81,6 @@ export const useKeytip_unstable = (props: KeytipProps): KeytipState => {
   const target = props.positioning?.target as HTMLElement;
 
   if (target && targetDocument) {
-    target.setAttribute('aria-describedby', `${KTP_ROOT_ID} ${id}`);
-    const root = targetDocument.getElementById(KTP_ROOT_ID);
-    if (root) {
-      const startSequence = root.getAttribute('data-start-shortcut');
-      target.setAttribute(
-        'aria-keyshortcuts',
-        `${[startSequence, ...keySequences].join('+')}`
-      );
-    }
     state.shouldRenderKeytip = true;
   }
 

--- a/packages/react-keytips/src/components/Keytips/Keytips.test.tsx
+++ b/packages/react-keytips/src/components/Keytips/Keytips.test.tsx
@@ -36,13 +36,7 @@ describe('Keytips', () => {
       );
     };
 
-    const { baseElement } = render(<Component />);
-
-    expect(screen.getByText('b1')).toBeTruthy();
-    expect(screen.getByText('b2')).toBeTruthy();
-    const portal = baseElement.querySelector('[data-portal-node]');
-
-    expect(portal?.children).toHaveLength(3);
+    render(<Component />);
 
     expect(screen.queryAllByRole('tooltip')).toHaveLength(0);
 

--- a/packages/react-keytips/src/components/Keytips/Keytips.types.ts
+++ b/packages/react-keytips/src/components/Keytips/Keytips.types.ts
@@ -69,6 +69,5 @@ export type KeytipsProps = ComponentProps<KeytipsSlots> &
  */
 export type KeytipsState = ComponentState<KeytipsSlots> &
   Pick<KeytipsProps, 'mountNode' | 'content'> & {
-    visibleKeytips: React.ReactElement[];
     keytips: React.ReactElement[];
   };

--- a/packages/react-keytips/src/components/Keytips/renderKeytips.tsx
+++ b/packages/react-keytips/src/components/Keytips/renderKeytips.tsx
@@ -34,10 +34,7 @@ export const renderKeytips_unstable = (state: KeytipsState) => {
       >
         {state.content}
       </span>
-      {state.keytips}
-      {state.visibleKeytips.length > 0 && (
-        <state.root>{state.visibleKeytips}</state.root>
-      )}
+      {state.keytips.length > 0 && <state.root>{state.keytips}</state.root>}
     </Portal>
   );
 };

--- a/packages/react-keytips/src/components/Keytips/useKeytips.tsx
+++ b/packages/react-keytips/src/components/Keytips/useKeytips.tsx
@@ -7,12 +7,7 @@ import {
 } from '@fluentui/react-components';
 import type { KeytipsProps, KeytipsState } from './Keytips.types';
 import { useHotkeys, parseHotkey } from '../../hooks/useHotkeys';
-import {
-  EXIT_KEYS,
-  EVENTS,
-  VISUALLY_HIDDEN_STYLES,
-  ACTIONS,
-} from '../../constants';
+import { EXIT_KEYS, EVENTS, ACTIONS } from '../../constants';
 import type { KeytipWithId } from '../Keytip';
 import { Keytip } from '../Keytip';
 import { useEventService } from '../../hooks/useEventService';
@@ -297,22 +292,11 @@ export const useKeytips_unstable = (props: KeytipsProps): KeytipsState => {
     handleKeytipExecution,
   ]);
 
-  const visibleKeytips = Object.entries(state.keytips)
+  const keytips = Object.entries(state.keytips)
     .filter(([, { visible, visibleInternal }]) => visible || visibleInternal)
     .map(([keytipId, keytipProps]) => (
       <Keytip key={keytipId} {...keytipProps} />
     ));
-
-  const hiddenKeytips = Object.values(state.keytips).map(
-    ({ keySequences, uniqueId }) => {
-      const id = sequencesToID(keySequences);
-      return (
-        <span key={uniqueId} id={id} style={VISUALLY_HIDDEN_STYLES}>
-          {keySequences.join(', ')}
-        </span>
-      );
-    }
-  );
 
   return {
     components: {
@@ -320,8 +304,7 @@ export const useKeytips_unstable = (props: KeytipsProps): KeytipsState => {
     },
     content,
     mountNode: props.mountNode,
-    keytips: hiddenKeytips,
-    visibleKeytips,
+    keytips,
     root: slot.always(
       getIntrinsicElementProps('div', {
         ...props,

--- a/packages/react-keytips/src/docs/Spec.md
+++ b/packages/react-keytips/src/docs/Spec.md
@@ -114,7 +114,7 @@ The keytip is positioned below and centered to the target element by default.
 
 | Prop Name            | Type                                   | Default                                         | Description                                                                                                                                                           |
 | -------------------- | -------------------------------------- | ----------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `content`            | `string`                               | `Alt Meta` on Windows, `Alt Control` on MacOS   | String to put inside the `Portal`to be used for the aria-describedby for the component with the keytip. Should be one of the starting sequences.                      |
+| `content`            | `string`                               | `Alt Meta` on Windows, `Alt Control` on MacOS   | String to put inside the `Portal` to be used for the `aria-keyshortcuts` for the component with the keytip. Should be one of the starting sequences.                  |
 | `mountNode`          |                                        |                                                 | Where the Portal children are mounted on DOM.                                                                                                                         |
 | `startSequence`      | `string`                               | `'alt+meta` on Windows, `'alt+control` on MacOS | Key sequence that will start keytips mode.                                                                                                                            |
 | `returnSequence`     | `string`                               | `'escape'`                                      | Key sequences that execute the return functionality in keytips.                                                                                                       |
@@ -233,9 +233,8 @@ const thirdButton = useKeytipRef({
 In terms of accessibility, `Keytip` component is very similar to `Tooltip` - it's a small popup that displays information related to an element, with difference, that `Keytip` can't be displayed by mouse hover over target element. Multiple keytips can be visible at the same time.
 
 - Each `Keytip` is assigned the role `"tooltip"`.
-- The `Keytip` target element references the corresponding keytip element using the `"aria-describedby"` attribute, providing a clear association between the target and the keytip (tooltip).
+- The `Keytip` target element references the corresponding keytip element using the `"aria-keyshortcuts"` attribute, providing a clear association between the target and the keytip (tooltip).
 - `Keytips` component has `content` prop, which is responsible for adding the `"aria-describedby"` for default start key sequence.
 - `Keytip` is not focusable.
-- `Keytip` adds `"aria-keyshortcuts"` attribute to the target element, which contains the key sequence that will trigger the keytip.
 - Unlike Tooltip, pressing `Escape` does not always hide the `Keytip`. By default, `Keytip` is configured to use `Escape` as a return sequence. Therefore, if there are ancestor keytips, pressing it will not hide the current `Keytip` but will instead display the ancestor keytips.
 - Focus stays on the trigger element while `Keytip` is displayed.

--- a/packages/react-keytips/src/hooks/useKeytipRef.ts
+++ b/packages/react-keytips/src/hooks/useKeytipRef.ts
@@ -1,6 +1,7 @@
 import * as React from 'react';
+import { useFluent } from '@fluentui/react-components';
 import { useEventService } from './useEventService';
-import { EVENTS } from '../constants';
+import { EVENTS, KTP_ROOT_ID } from '../constants';
 import { usePrevious } from '@fluentui/react-utilities';
 import type { KeytipProps } from '../components/Keytip';
 import { sequencesToID } from '../utilities/index';
@@ -15,6 +16,7 @@ export const useKeytipRef = <
   content,
   ...keytip
 }: KeytipProps): React.Dispatch<React.SetStateAction<T | null>> => {
+  const { targetDocument } = useFluent();
   const [node, setNode] = React.useState<T | null>(null);
   const { dispatch } = useEventService();
   const uniqueId = React.useId();
@@ -57,6 +59,15 @@ export const useKeytipRef = <
   React.useEffect(() => {
     // if content is empty string do not add the keytip
     if (isPrimitiveContent && content.length === 0) return;
+
+    if (node) {
+      const root = targetDocument?.getElementById(KTP_ROOT_ID);
+      const startSequence = root?.getAttribute('data-start-shortcut');
+      node.setAttribute(
+        'aria-keyshortcuts',
+        `${[startSequence, ...keySequences].join('+')}`
+      );
+    }
 
     dispatch(EVENTS.KEYTIP_ADDED, ktp);
     return () => {

--- a/packages/react-keytips/stories/Default.stories.tsx
+++ b/packages/react-keytips/stories/Default.stories.tsx
@@ -40,7 +40,7 @@ const useStyles = makeStyles({
 
 const onExecute: ExecuteKeytipEventHandler = (_, { targetElement }) => {
   if (targetElement) {
-    console.info(targetElement.getAttribute('aria-describedby'));
+    console.info(targetElement.getAttribute('aria-keyshortcuts'));
     targetElement.focus();
     targetElement.click();
   }


### PR DESCRIPTION
Removed `aria-describedby`, now it relays on `aria-keyshortcuts` only. Made them available for screen readers before entering the keytip mode.