### PR TITLE
fix(react-gamepad-navigation): upgrade @fluentui/react-tabster to match new package API

### DIFF
--- a/change/@fluentui-contrib-react-gamepad-navigation-442d36f4-404e-4645-ba49-ae8cb73092b5.json
+++ b/change/@fluentui-contrib-react-gamepad-navigation-442d36f4-404e-4645-ba49-ae8cb73092b5.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "remove mouseevent type augmentation",
+  "packageName": "@fluentui-contrib/react-gamepad-navigation",
+  "email": "hectorjimenez@outlook.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-contrib-react-gamepad-navigation-fb61cc85-ebf8-43aa-98ab-898fe7395629.json
+++ b/change/@fluentui-contrib-react-gamepad-navigation-fb61cc85-ebf8-43aa-98ab-898fe7395629.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "upgrade react-tabster dependency",
+  "comment": "upgrade react-tabster imports",
   "packageName": "@fluentui-contrib/react-gamepad-navigation",
   "email": "6352233+hectorjjb@users.noreply.github.com",
   "dependentChangeType": "patch"

--- a/change/@fluentui-contrib-react-gamepad-navigation-fb61cc85-ebf8-43aa-98ab-898fe7395629.json
+++ b/change/@fluentui-contrib-react-gamepad-navigation-fb61cc85-ebf8-43aa-98ab-898fe7395629.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "upgrade react-tabster dependency",
+  "packageName": "@fluentui-contrib/react-gamepad-navigation",
+  "email": "6352233+hectorjjb@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-contrib-react-tree-grid-855ad395-ed73-43f5-8da7-0fd2ac574a6f.json
+++ b/change/@fluentui-contrib-react-tree-grid-855ad395-ed73-43f5-8da7-0fd2ac574a6f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "upgrading react-tabster dependency",
+  "packageName": "@fluentui-contrib/react-tree-grid",
+  "email": "hectorjimenez@outlook.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-contrib-react-tree-grid-a39b385d-84a0-45a8-8db6-c700bbb9aaf0.json
+++ b/change/@fluentui-contrib-react-tree-grid-a39b385d-84a0-45a8-8db6-c700bbb9aaf0.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "matching dep version",
+  "packageName": "@fluentui-contrib/react-tree-grid",
+  "email": "6352233+hectorjjb@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-contrib-react-tree-grid-a39b385d-84a0-45a8-8db6-c700bbb9aaf0.json
+++ b/change/@fluentui-contrib-react-tree-grid-a39b385d-84a0-45a8-8db6-c700bbb9aaf0.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "matching dep version",
-  "packageName": "@fluentui-contrib/react-tree-grid",
-  "email": "6352233+hectorjjb@users.noreply.github.com",
-  "dependentChangeType": "patch"
-}

--- a/packages/react-gamepad-navigation/README.md
+++ b/packages/react-gamepad-navigation/README.md
@@ -81,7 +81,7 @@ import { useGamepadNavigationGroup } from '@fluentui-contrib/react-gamepad-navig
 ```tsx
 export const SampleApp = () => {
   // attributes for both: Gamepad and Arrow key navigation
-  const gamepadNavDOMAttributes = useGamepadNavigationGroup();
+  const { gamepadNavDOMAttributes } = useGamepadNavigationGroup();
 
   return <div {...gamepadNavDOMAttributes}></div>;
 };

--- a/packages/react-gamepad-navigation/package.json
+++ b/packages/react-gamepad-navigation/package.json
@@ -2,7 +2,7 @@
   "name": "@fluentui-contrib/react-gamepad-navigation",
   "version": "0.1.0",
   "dependencies": {
-    "@fluentui/react-tabster": "~9.14.0"
+    "@fluentui/react-tabster": "~9.23.2"
   },
   "main": "./src/index.js",
   "typings": "./src/index.d.ts",

--- a/packages/react-gamepad-navigation/package.json
+++ b/packages/react-gamepad-navigation/package.json
@@ -2,12 +2,12 @@
   "name": "@fluentui-contrib/react-gamepad-navigation",
   "version": "0.1.0",
   "dependencies": {
-    "@fluentui/react-tabster": "~9.23.2"
+    "@fluentui/react-tabster": "~9.14.0"
   },
   "main": "./src/index.js",
   "typings": "./src/index.d.ts",
   "peerDependencies": {
-    "@fluentui/react-components": ">=9.56.8 <10.0.0",
+    "@fluentui/react-components": ">=9.54.13 <10.0.0",
     "@types/react": ">=16.8.0 <19.0.0",
     "@types/react-dom": ">=16.8.0 <19.0.0",
     "react": ">=16.8.0 <19.0.0",

--- a/packages/react-gamepad-navigation/package.json
+++ b/packages/react-gamepad-navigation/package.json
@@ -2,7 +2,7 @@
   "name": "@fluentui-contrib/react-gamepad-navigation",
   "version": "0.1.0",
   "dependencies": {
-    "@fluentui/react-tabster": "~9.23.2"
+    "@fluentui/react-tabster": ">=9.17.2 < 10.0.0"
   },
   "main": "./src/index.js",
   "typings": "./src/index.d.ts",

--- a/packages/react-gamepad-navigation/package.json
+++ b/packages/react-gamepad-navigation/package.json
@@ -2,12 +2,12 @@
   "name": "@fluentui-contrib/react-gamepad-navigation",
   "version": "0.1.0",
   "dependencies": {
-    "@fluentui/react-tabster": "~9.14.0"
+    "@fluentui/react-tabster": "~9.23.2"
   },
   "main": "./src/index.js",
   "typings": "./src/index.d.ts",
   "peerDependencies": {
-    "@fluentui/react-components": ">=9.54.13 <10.0.0",
+    "@fluentui/react-components": ">=9.56.8 <10.0.0",
     "@types/react": ">=16.8.0 <19.0.0",
     "@types/react-dom": ">=16.8.0 <19.0.0",
     "react": ">=16.8.0 <19.0.0",

--- a/packages/react-gamepad-navigation/package.json
+++ b/packages/react-gamepad-navigation/package.json
@@ -7,7 +7,7 @@
   "main": "./src/index.js",
   "typings": "./src/index.d.ts",
   "peerDependencies": {
-    "@fluentui/react-components": ">=9.54.13 <10.0.0",
+    "@fluentui/react-components": ">=9.56.8 <10.0.0",
     "@types/react": ">=16.8.0 <19.0.0",
     "@types/react-dom": ">=16.8.0 <19.0.0",
     "react": ">=16.8.0 <19.0.0",

--- a/packages/react-gamepad-navigation/src/core/GamepadEvents.ts
+++ b/packages/react-gamepad-navigation/src/core/GamepadEvents.ts
@@ -15,30 +15,17 @@ import { KeyboardKey, MoverKey } from '../types/Keys';
     Synthetic Events
 */
 const syntheticKey = Symbol('synthetic');
-declare global {
-  // eslint-disable-next-line @typescript-eslint/no-namespace
-  namespace React {
-    interface KeyboardEvent {
-      readonly [syntheticKey]?: boolean;
-    }
-    interface MouseEvent {
-      readonly [syntheticKey]?: boolean;
-    }
-  }
-  interface KeyboardEvent {
-    readonly [syntheticKey]?: boolean;
-  }
-  interface MouseEvent {
-    readonly [syntheticKey]?: boolean;
-  }
-}
+
+export type MouseSyntheticEvent = MouseEvent & {
+  [syntheticKey]?: boolean;
+};
 
 export const isSyntheticMouseEvent = (
-  evt: React.MouseEvent<unknown, MouseEvent> | MouseEvent
+  evt: MouseEvent | React.MouseEvent<unknown, MouseEvent>
 ): boolean => {
   return evt instanceof MouseEvent
-    ? !!evt?.[syntheticKey]
-    : !!evt.nativeEvent?.[syntheticKey];
+    ? !!(evt as MouseSyntheticEvent)?.[syntheticKey]
+    : !!(evt.nativeEvent as MouseSyntheticEvent)?.[syntheticKey];
 };
 
 export const emitSyntheticKeyboardEvent = (
@@ -135,7 +122,7 @@ export const emitSyntheticGroupperMoveFocusEvent = (
   } else {
     // Note: GroupperMoveFocusActions.Escape has no difference to KeyboardKey.Escape
     if (isSelectElement(activeElement)) {
-      handleSelectOnEscape(targetDocument);
+      handleSelectOnEscape(activeElement, targetDocument);
     } else if (isComboboxElement(activeElement)) {
       emitSyntheticMouseEvent('click', true, targetDocument);
     } else {

--- a/packages/react-gamepad-navigation/src/core/GamepadUtils.ts
+++ b/packages/react-gamepad-navigation/src/core/GamepadUtils.ts
@@ -26,32 +26,35 @@ export const isRadioElement = (element: Element | null | undefined) => {
   return element?.getAttribute('type') === 'radio';
 };
 
-export const isSelectElement = (element: Element | null | undefined) => {
+export const isSelectElement = (
+  element: Element | null | undefined
+): element is HTMLSelectElement => {
   return element?.tagName === 'SELECT';
 };
 
-export const hidePickerOnSeLectElement = (selectElement: HTMLSelectElement) => {
-  selectElement.blur();
-  selectElement.focus();
-  selectElement.removeAttribute(selectOptionsVisibleAttribute);
+export const hidePickerOnSelectElement = (htmlSelect: HTMLSelectElement) => {
+  htmlSelect.blur();
+  htmlSelect.focus();
+  htmlSelect.removeAttribute(selectOptionsVisibleAttribute);
 };
 
-export const handleSelectOnEnter = (activeElement: Element | null) => {
-  const htmlSelect = activeElement as HTMLSelectElement;
+export const handleSelectOnEnter = (htmlSelect: HTMLSelectElement) => {
   const openOptions = htmlSelect.hasAttribute(selectOptionsVisibleAttribute);
   if (openOptions) {
-    hidePickerOnSeLectElement(htmlSelect);
+    hidePickerOnSelectElement(htmlSelect);
   } else {
     htmlSelect.showPicker();
     htmlSelect.setAttribute(selectOptionsVisibleAttribute, '');
   }
 };
 
-export const handleSelectOnEscape = (targetDocument: Document) => {
-  const htmlSelect = targetDocument.activeElement as HTMLSelectElement;
+export const handleSelectOnEscape = (
+  htmlSelect: HTMLSelectElement,
+  targetDocument: Document
+) => {
   const openOptions = htmlSelect.hasAttribute(selectOptionsVisibleAttribute);
   if (openOptions) {
-    hidePickerOnSeLectElement(htmlSelect);
+    hidePickerOnSelectElement(htmlSelect);
   } else {
     emitSyntheticKeyboardEvent(
       'keydown',

--- a/packages/react-gamepad-navigation/src/core/InputManager.ts
+++ b/packages/react-gamepad-navigation/src/core/InputManager.ts
@@ -138,7 +138,7 @@ export const onButtonPress = (
     return;
   }
 
-  let focusDirection = FocusDirection.None;
+  let focusDirection: FocusDirection = FocusDirection.None;
   let focusAction: KeyboardKey | undefined;
   switch (button) {
     case GamepadButton.A:

--- a/packages/react-gamepad-navigation/src/hooks/useGamepadNavigationGroup.ts
+++ b/packages/react-gamepad-navigation/src/hooks/useGamepadNavigationGroup.ts
@@ -53,8 +53,7 @@ export const useGamepadNavigationGroup = (
   } = options;
   const { findFirstFocusable } = useFocusFinders();
   const { targetDocument } = useFluent();
-  const gpnProps = {
-    targetDocument,
+  const gpnOptions = {
     defaultInputMode,
     pollingEnabled,
   };
@@ -81,7 +80,7 @@ export const useGamepadNavigationGroup = (
     groupperDOMAttribute,
     moverDOMAttribute
   );
-  const removeGamepadNavEventListeners = useGamepadNavigation(gpnProps);
+  const removeGamepadNavEventListeners = useGamepadNavigation(gpnOptions);
 
   return {
     gamepadNavDOMAttributes,

--- a/packages/react-gamepad-navigation/src/index.ts
+++ b/packages/react-gamepad-navigation/src/index.ts
@@ -1,4 +1,3 @@
 export { useGamepadNavigationGroup } from './hooks/useGamepadNavigationGroup';
 export type { UseGamepadNavigationGroupOptions } from './hooks/useGamepadNavigationGroup';
 export type { GamepadNavigationOptions } from './hooks/useGamepadNavigation';
-export type { TabsterDOMAttribute } from '@fluentui/react-tabster';

--- a/packages/react-gamepad-navigation/src/types/DirectionalSource.ts
+++ b/packages/react-gamepad-navigation/src/types/DirectionalSource.ts
@@ -1,5 +1,8 @@
-export enum DirectionalSource {
-  Dpad = 'Dpad',
-  LeftStick = 'LeftStick',
-  ArrowKey = 'ArrowKey',
-}
+export const DirectionalSource = {
+  Dpad: 'Dpad',
+  LeftStick: 'LeftStick',
+  ArrowKey: 'ArrowKey',
+} as const;
+
+export type DirectionalSource =
+  (typeof DirectionalSource)[keyof typeof DirectionalSource];

--- a/packages/react-gamepad-navigation/src/types/FocusDirection.ts
+++ b/packages/react-gamepad-navigation/src/types/FocusDirection.ts
@@ -1,9 +1,12 @@
 import { MoverKeys } from './Keys';
 
-export enum FocusDirection {
-  None = 0,
-  Up = MoverKeys.ArrowUp,
-  Down = MoverKeys.ArrowDown,
-  Left = MoverKeys.ArrowLeft,
-  Right = MoverKeys.ArrowRight,
-}
+export const FocusDirection = {
+  None: 0,
+  Up: MoverKeys.ArrowUp,
+  Down: MoverKeys.ArrowDown,
+  Left: MoverKeys.ArrowLeft,
+  Right: MoverKeys.ArrowRight,
+} as const;
+
+export type FocusDirection =
+  (typeof FocusDirection)[keyof typeof FocusDirection];

--- a/packages/react-gamepad-navigation/src/types/InputMode.ts
+++ b/packages/react-gamepad-navigation/src/types/InputMode.ts
@@ -1,20 +1,22 @@
-export enum InputMode {
+export const InputMode = {
   /** @member {string} */
   /** The last input was from user touch */
-  Touch = 'Touch',
+  Touch: 'Touch',
 
   /** @member {string} */
   /** The last input was from mouse click */
-  Mouse = 'Mouse',
+  Mouse: 'Mouse',
 
   /** @member {string} */
   /** the last input was from a gamepad */
-  Gamepad = 'Gamepad',
+  Gamepad: 'Gamepad',
 
   /** @member {string} */
   /** the last input was from a keyboard press */
-  Keyboard = 'Keyboard',
-}
+  Keyboard: 'Keyboard',
+} as const;
+
+export type InputMode = (typeof InputMode)[keyof typeof InputMode];
 
 /**
  * Returns whether the given input mode is focus-driven, i.e. gamepad/keyboard.

--- a/packages/react-gamepad-navigation/src/types/Keys.ts
+++ b/packages/react-gamepad-navigation/src/types/Keys.ts
@@ -1,27 +1,31 @@
-import { TabsterTypes } from '@fluentui/react-tabster';
+import { MoverKeys as TabsterMoverKeys } from '@fluentui/react-tabster';
 
 /*
     Gamepad Buttons, State, & Actions
 */
 
-export enum GamepadButton {
-  A = 'A',
-  B = 'B',
-  X = 'X',
-  Y = 'Y',
-  LB = 'LB',
-  RB = 'RB',
-  DpadUp = 'DpadUp',
-  DpadDown = 'DpadDown',
-  DpadLeft = 'DpadLeft',
-  DpadRight = 'DpadRight',
-}
+export const GamepadButton = {
+  A: 'A',
+  B: 'B',
+  X: 'X',
+  Y: 'Y',
+  LB: 'LB',
+  RB: 'RB',
+  DpadUp: 'DpadUp',
+  DpadDown: 'DpadDown',
+  DpadLeft: 'DpadLeft',
+  DpadRight: 'DpadRight',
+} as const;
 
-export enum KeyPressState {
-  Down = 1,
-  Up = 0,
-  Reset = -1,
-}
+export type GamepadButton = (typeof GamepadButton)[keyof typeof GamepadButton];
+
+export const KeyPressState = {
+  Down: 1,
+  Up: 0,
+  Reset: -1,
+} as const;
+
+export type KeyPressState = (typeof KeyPressState)[keyof typeof KeyPressState];
 
 export type GamepadState = {
   [key in GamepadButton]: KeyPressState;
@@ -29,25 +33,29 @@ export type GamepadState = {
   timestamp: number;
 };
 
-export enum GamepadAction {
-  Down = 'gamepadDown',
-  Up = 'gamepadUp',
-}
+export const GamepadAction = {
+  Down: 'gamepadDown',
+  Up: 'gamepadUp',
+} as const;
+
+export type GamepadAction = (typeof GamepadAction)[keyof typeof GamepadAction];
 
 /*
     Keyboard Keys
 */
 
-export enum KeyboardKey {
-  Enter = 'Enter',
-  ArrowUp = 'ArrowUp',
-  ArrowDown = 'ArrowDown',
-  ArrowLeft = 'ArrowLeft',
-  ArrowRight = 'ArrowRight',
-  Escape = 'Escape',
-  None = 'None',
-}
+export const KeyboardKey = {
+  Enter: 'Enter',
+  ArrowUp: 'ArrowUp',
+  ArrowDown: 'ArrowDown',
+  ArrowLeft: 'ArrowLeft',
+  ArrowRight: 'ArrowRight',
+  Escape: 'Escape',
+  None: 'None',
+} as const;
 
-export type MoverKey = TabsterTypes.MoverKey;
+export type KeyboardKey = (typeof KeyboardKey)[keyof typeof KeyboardKey];
 
-export const MoverKeys = TabsterTypes.MoverKeys;
+export const MoverKeys = TabsterMoverKeys;
+
+export type MoverKey = (typeof TabsterMoverKeys)[keyof typeof TabsterMoverKeys];

--- a/packages/react-gamepad-navigation/src/types/Trigger.ts
+++ b/packages/react-gamepad-navigation/src/types/Trigger.ts
@@ -1,4 +1,6 @@
-export enum Trigger {
-  Left = 'left',
-  Right = 'right',
-}
+export const Trigger = {
+  Left: 'left',
+  Right: 'right',
+} as const;
+
+export type Trigger = (typeof Trigger)[keyof typeof Trigger];

--- a/packages/react-tree-grid/package.json
+++ b/packages/react-tree-grid/package.json
@@ -12,7 +12,7 @@
     "@fluentui/react-context-selector": "~9.1.47",
     "@fluentui/react-jsx-runtime": ">=9.0.29 < 10.0.0",
     "@fluentui/keyboard-keys": "~9.0.6",
-    "@fluentui/react-tabster": "~9.23.2",
+    "@fluentui/react-tabster": "~9.14.0",
     "@fluentui/react-utilities": ">=9.16.0 < 10.0.0"
   }
 }

--- a/packages/react-tree-grid/package.json
+++ b/packages/react-tree-grid/package.json
@@ -12,7 +12,7 @@
     "@fluentui/react-context-selector": "~9.1.47",
     "@fluentui/react-jsx-runtime": ">=9.0.29 < 10.0.0",
     "@fluentui/keyboard-keys": "~9.0.6",
-    "@fluentui/react-tabster": "~9.23.2",
+    "@fluentui/react-tabster": ">=9.17.2 < 10.0.0",
     "@fluentui/react-utilities": ">=9.16.0 < 10.0.0"
   }
 }

--- a/packages/react-tree-grid/package.json
+++ b/packages/react-tree-grid/package.json
@@ -12,7 +12,7 @@
     "@fluentui/react-context-selector": "~9.1.47",
     "@fluentui/react-jsx-runtime": ">=9.0.29 < 10.0.0",
     "@fluentui/keyboard-keys": "~9.0.6",
-    "@fluentui/react-tabster": "~9.14.0",
+    "@fluentui/react-tabster": "~9.23.2",
     "@fluentui/react-utilities": ">=9.16.0 < 10.0.0"
   }
 }


### PR DESCRIPTION
In newer version of @fluentui/react-tabster some types are no longer available, so user get "type not found"
when using a "9.14.0" > version of @fluentui/react-tabster.
also upgraded @fluentui/react-tree-grid since all dependencies in repo need to match

![image](https://github.com/user-attachments/assets/dcff656f-c79c-40e2-af23-6021b2034e90)
