### PR TITLE
fix(react-gamepad-navigation): upgrade @fluentui/react-tabster to match new package API

### DIFF
--- a/change/@fluentui-contrib-react-gamepad-navigation-07db730c-7bbc-48f5-b9b6-91ce98c7a613.json
+++ b/change/@fluentui-contrib-react-gamepad-navigation-07db730c-7bbc-48f5-b9b6-91ce98c7a613.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "upgrade packages",
+  "comment": "upgrading react-tabster dependency",
   "packageName": "@fluentui-contrib/react-gamepad-navigation",
   "email": "hectorjimenez@outlook.com",
   "dependentChangeType": "patch"

--- a/change/@fluentui-contrib-react-gamepad-navigation-07db730c-7bbc-48f5-b9b6-91ce98c7a613.json
+++ b/change/@fluentui-contrib-react-gamepad-navigation-07db730c-7bbc-48f5-b9b6-91ce98c7a613.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "upgrade packages",
+  "packageName": "@fluentui-contrib/react-gamepad-navigation",
+  "email": "hectorjimenez@outlook.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-contrib-react-tree-grid-39254e8f-2624-4d20-85d0-57ecfeba096f.json
+++ b/change/@fluentui-contrib-react-tree-grid-39254e8f-2624-4d20-85d0-57ecfeba096f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "upgrade packages",
+  "packageName": "@fluentui-contrib/react-tree-grid",
+  "email": "hectorjimenez@outlook.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-contrib-react-tree-grid-39254e8f-2624-4d20-85d0-57ecfeba096f.json
+++ b/change/@fluentui-contrib-react-tree-grid-39254e8f-2624-4d20-85d0-57ecfeba096f.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "upgrade packages",
+  "comment": "upgrading react-tabster dependency",
   "packageName": "@fluentui-contrib/react-tree-grid",
   "email": "hectorjimenez@outlook.com",
   "dependentChangeType": "patch"

--- a/packages/react-gamepad-navigation/package.json
+++ b/packages/react-gamepad-navigation/package.json
@@ -2,7 +2,7 @@
   "name": "@fluentui-contrib/react-gamepad-navigation",
   "version": "0.1.0",
   "dependencies": {
-    "@fluentui/react-tabster": "~9.14.0"
+    "@fluentui/react-tabster": ">=9.17.2 < 10.0.0"
   },
   "main": "./src/index.js",
   "typings": "./src/index.d.ts",

--- a/packages/react-tree-grid/package.json
+++ b/packages/react-tree-grid/package.json
@@ -12,7 +12,7 @@
     "@fluentui/react-context-selector": "~9.1.47",
     "@fluentui/react-jsx-runtime": ">=9.0.29 < 10.0.0",
     "@fluentui/keyboard-keys": "~9.0.6",
-    "@fluentui/react-tabster": "~9.14.0",
+    "@fluentui/react-tabster": ">=9.17.2 < 10.0.0",
     "@fluentui/react-utilities": ">=9.16.0 < 10.0.0"
   }
 }


### PR DESCRIPTION
In newer version of @fluentui/react-tabster some types are no longer available, so user get "type not found"
when using a "9.14.0" > version of @fluentui/react-tabster.
also upgraded @fluentui/react-tree-grid since all dependencies in repo need to match

![image](https://github.com/user-attachments/assets/2e4769e2-7215-4652-826d-651b1a0efab3)
