### PR TITLE
fix(resize-handle): update events dispatch order

### DIFF
--- a/change/@fluentui-contrib-react-resize-handle-e309274a-7736-463b-91db-fd3709a9b435.json
+++ b/change/@fluentui-contrib-react-resize-handle-e309274a-7736-463b-91db-fd3709a9b435.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: update events dispatch order",
+  "packageName": "@fluentui-contrib/react-resize-handle",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-resize-handle/src/hooks/useResizeHandle.component-browser-spec.tsx
+++ b/packages/react-resize-handle/src/hooks/useResizeHandle.component-browser-spec.tsx
@@ -1,16 +1,25 @@
 import * as React from 'react';
-import { test, expect } from '@playwright/experimental-ct-react';
+import {
+  test,
+  expect,
+  type MountOptions as PwMountOptions,
+  type MountResult as PwMountResult,
+} from '@playwright/experimental-ct-react';
 
 import {
   TestArea,
   type TestAreaProps,
 } from './useResizeHandleExample.component-browser-spec';
 
+/* eslint-disable no-restricted-globals */
+
 test.use({ viewport: { width: 500, height: 500 } });
 
-type PwTestFn = Parameters<typeof test>['1'];
-type PwMountFn = Parameters<PwTestFn>[0]['mount'];
-type PwPage = Parameters<PwTestFn>[0]['page'];
+type PwMountFn = <HooksConfig>(
+  component: React.JSX.Element,
+  options?: PwMountOptions<HooksConfig>
+) => Promise<PwMountResult>;
+type PwPage = ReturnType<PwMountResult['page']>;
 
 type MountResult = Awaited<ReturnType<typeof mountTest>>;
 
@@ -35,30 +44,30 @@ async function mountTest(mount: PwMountFn, props: TestAreaProps = {}) {
 }
 
 async function validateComponent(
-  component: MountResult,
+  mountResult: MountResult,
   value: number,
   eventType?: string
 ) {
   const variableTarget =
-    component.variableTarget === 'element'
-      ? component.element
-      : component.wrapper;
+    mountResult.variableTarget === 'element'
+      ? mountResult.element
+      : mountResult.wrapper;
 
   await expect(variableTarget).toHaveCSS('--width', `${value}px`);
-  await expect(component.valueEl).toContainText(`--width: ${value}px;`);
+  await expect(mountResult.valueEl).toContainText(`--width: ${value}px;`);
 
   if (eventType) {
-    await expect(component.valueEl).toContainText(`eventType: ${eventType}`);
+    await expect(mountResult.valueEl).toContainText(`eventType: ${eventType}`);
   }
 
-  await expect(component.dragHandle).toHaveAttribute(
+  await expect(mountResult.dragHandle).toHaveAttribute(
     'aria-valuetext',
     `${value}px`
   );
 }
 
-async function dragX(component: MountResult, page: PwPage, amount: number) {
-  await component.dragHandle.hover();
+async function dragX(mountResult: MountResult, page: PwPage, amount: number) {
+  await mountResult.dragHandle.hover();
 
   await page.mouse.down();
   await page.mouse.move(amount, 0);
@@ -121,6 +130,55 @@ test.describe('useResizeHandle', () => {
 
       await dragX(result, page, 100);
       await validateComponent(result, 83);
+    });
+  });
+
+  test.describe('events', () => {
+    test('events are called in order', async ({ mount, page }) => {
+      const dragStartCalls: number[] = [];
+      const dragEndCalls: number[] = [];
+      const onChangeCalls: number[] = [];
+
+      const result = await mountTest(mount, {
+        onDragStart: () => {
+          dragStartCalls.push(performance.now());
+        },
+        onDragEnd: () => {
+          dragEndCalls.push(performance.now());
+        },
+        onChange: () => {
+          onChangeCalls.push(performance.now());
+        },
+      });
+
+      // Drag start
+      // --------------------
+
+      await result.dragHandle.hover();
+
+      await page.mouse.down();
+      await page.mouse.move(100, 0);
+
+      await validateComponent(result, 83);
+
+      expect(dragStartCalls.length).toBe(1);
+      expect(dragEndCalls.length).toBe(0);
+      expect(onChangeCalls.length).toBe(1);
+
+      expect(dragStartCalls[0]).toBeLessThan(onChangeCalls[0]);
+
+      // Drag end
+      // --------------------
+
+      await page.mouse.move(200, 0);
+      await page.mouse.up();
+
+      await validateComponent(result, 183);
+
+      expect(dragStartCalls.length).toBe(1);
+      expect(dragEndCalls.length).toBe(1);
+      expect(onChangeCalls.length).toBe(2);
+      expect(onChangeCalls[1]).toBeLessThan(dragEndCalls[0]);
     });
   });
 });

--- a/packages/react-resize-handle/src/hooks/useResizeHandle.test.tsx
+++ b/packages/react-resize-handle/src/hooks/useResizeHandle.test.tsx
@@ -1,0 +1,77 @@
+import { render, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useResizeHandle, UseResizeHandleParams } from './useResizeHandle';
+import * as React from 'react';
+
+const TestComponent = (
+  props: Pick<UseResizeHandleParams, 'onDragStart' | 'onDragEnd' | 'onChange'>
+) => {
+  const { onChange, onDragStart, onDragEnd } = props;
+
+  const { elementRef, handleRef } = useResizeHandle({
+    growDirection: 'end',
+    variableName: '--width',
+
+    onChange,
+    onDragEnd,
+    onDragStart,
+  });
+
+  return (
+    <div>
+      <div ref={elementRef} data-testid="element" />
+      <div ref={handleRef} data-testid="handle" />
+    </div>
+  );
+};
+
+jest.useFakeTimers();
+
+describe('useResizeHandle', () => {
+  describe('events', () => {
+    it('should call events in proper order', () => {
+      const onChange = jest.fn();
+      const onDragStart = jest.fn();
+      const onDragEnd = jest.fn();
+
+      const { getByTestId } = render(
+        <TestComponent
+          onDragStart={onDragStart}
+          onDragEnd={onDragEnd}
+          onChange={onChange}
+        />
+      );
+      const handleEl = getByTestId('handle');
+
+      fireEvent.mouseDown(handleEl);
+      fireEvent.mouseMove(handleEl, { clientX: 100, clientY: 0 });
+
+      // Drag start
+      // ----------------
+
+      // Drag started, onChange will be called in rAF
+      expect(onDragStart).toHaveBeenCalledTimes(1);
+      expect(onDragEnd).toHaveBeenCalledTimes(0);
+      expect(onChange).toHaveBeenCalledTimes(0);
+
+      jest.advanceTimersToNextTimer();
+      expect(onChange).toHaveBeenCalledTimes(1);
+
+      // Drag end
+      // ----------------
+
+      jest.clearAllMocks();
+
+      fireEvent.mouseMove(handleEl, { clientX: 200, clientY: 0 });
+      fireEvent.mouseUp(document.body);
+
+      // onChange will be called immediately and *before* onDragEnd as the drag ends
+      expect(onDragStart).toHaveBeenCalledTimes(0);
+      expect(onDragEnd).toHaveBeenCalledTimes(1);
+      expect(onChange).toHaveBeenCalledTimes(1);
+      expect(onChange.mock.invocationCallOrder[0]).toBeLessThan(
+        onDragEnd.mock.invocationCallOrder[0]
+      );
+    });
+  });
+});

--- a/packages/react-resize-handle/src/hooks/useResizeHandleExample.component-browser-spec.tsx
+++ b/packages/react-resize-handle/src/hooks/useResizeHandleExample.component-browser-spec.tsx
@@ -1,24 +1,39 @@
 import * as React from 'react';
+import { useEventCallback } from '@fluentui/react-components';
 import { useResizeHandle, type UseResizeHandleParams } from './useResizeHandle';
 
-export type TestAreaProps = Pick<UseResizeHandleParams, 'variableTarget'>;
+export type TestAreaProps = Pick<
+  UseResizeHandleParams,
+  'variableTarget' | 'onDragStart' | 'onDragEnd' | 'onChange'
+>;
 
 export function TestArea(props: TestAreaProps) {
-  const { variableTarget = 'wrapper' } = props;
+  const {
+    onDragEnd,
+    onDragStart,
+    onChange,
+    variableTarget = 'wrapper',
+  } = props;
 
   const codeRef = React.useRef<HTMLElement>(null);
-  const handleChange = React.useCallback((_, { value, type }) => {
-    if (codeRef.current) {
-      codeRef.current.textContent = `--width: ${value}px; eventType: ${type}`;
-    }
-  }, []);
+  const handleChange: NonNullable<UseResizeHandleParams['onChange']> =
+    useEventCallback((ev, data) => {
+      onChange?.(ev, data);
+
+      if (codeRef.current) {
+        codeRef.current.textContent = `--width: ${data.value}px; eventType: ${data.type}`;
+      }
+    });
 
   const handle = useResizeHandle({
     variableName: '--width',
     growDirection: 'end',
     minValue: 50,
     maxValue: 400,
+
     onChange: handleChange,
+    onDragEnd,
+    onDragStart,
   });
 
   return (


### PR DESCRIPTION
### Changes

This PR changes the order of events dispatch in the `resize-handle` component. 

#### Before

- There was a `requestAnimationFrame` that could scheduled multiple times (via `mousemove` event) as it gets never cancelled
- `onChange` is dispatched by `rAF` so it always happened after `onDragEnd` (`mouseup` event) that was not expected

#### After

- `requestAnimationFrame` calls don't collide
- if `onDragEnd` (`mouseup` event) is dispatched, we will cancel current `rAF` (from `mousemove` event) and invoke `onChange` immediately so it will happen **before** `onDragEnd`

### Tests coverage

- Browser tests updated (also fixed types issues)
- Unit tests added for this specific scenario