### PR TITLE
(chore):Added aria-pressed to a list of allowed props for ToggleButton

### DIFF
--- a/change/@fluentui-contrib-teams-components-832c248a-f82c-432b-bf81-fcd1fffd8599.json
+++ b/change/@fluentui-contrib-teams-components-832c248a-f82c-432b-bf81-fcd1fffd8599.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Added aria-pressed to a list of allowed props for ToggleButton",
+  "packageName": "@fluentui-contrib/teams-components",
+  "email": "patrycja.fogelman@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/teams-components/src/components/ToggleButton/ToggleButton.test.tsx
+++ b/packages/teams-components/src/components/ToggleButton/ToggleButton.test.tsx
@@ -25,8 +25,23 @@ describe('ToggleButton', () => {
   it('should not throw error for button if aria-pressed is provided', () => {
     console.error = jest.fn();
     expect(() =>
-      render(<ToggleButton checked aria-label="label" aria-pressed={true}>Test</ToggleButton>)
+      render(
+        <ToggleButton checked aria-label="label" aria-pressed={undefined}>
+          Test
+        </ToggleButton>
+      )
     ).not.toThrow();
+  });
+
+  it('should throw error for button if aria-pressed is reset and no aria-label is provided', () => {
+    console.error = jest.fn();
+    expect(() =>
+      render(
+        <ToggleButton checked aria-pressed={undefined}>
+          Test
+        </ToggleButton>
+      )
+    ).toThrow();
   });
 
   it('should render title', () => {

--- a/packages/teams-components/src/components/ToggleButton/ToggleButton.test.tsx
+++ b/packages/teams-components/src/components/ToggleButton/ToggleButton.test.tsx
@@ -22,6 +22,13 @@ describe('ToggleButton', () => {
     ).not.toThrow();
   });
 
+  it('should not throw error for button if aria-pressed is provided', () => {
+    console.error = jest.fn();
+    expect(() =>
+      render(<ToggleButton checked aria-label="label" aria-pressed={true}>Test</ToggleButton>)
+    ).not.toThrow();
+  });
+
   it('should render title', () => {
     jest.useFakeTimers();
     const { getByRole } = render(

--- a/packages/teams-components/src/components/ToggleButton/ToggleButton.tsx
+++ b/packages/teams-components/src/components/ToggleButton/ToggleButton.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import {
   type ToggleButtonProps as ToggleButtonPropsBase,
-  type ButtonProps as ButtonPropsBase,
   useToggleButtonStyles_unstable,
   useToggleButton_unstable,
   renderToggleButton_unstable,

--- a/packages/teams-components/src/components/ToggleButton/ToggleButton.tsx
+++ b/packages/teams-components/src/components/ToggleButton/ToggleButton.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import {
   type ToggleButtonProps as ToggleButtonPropsBase,
+  type ButtonProps as ButtonPropsBase,
   useToggleButtonStyles_unstable,
   useToggleButton_unstable,
   renderToggleButton_unstable,
@@ -11,6 +12,7 @@ import { ButtonProps, validateIconButton, validateMenuButton } from '../Button';
 
 export interface ToggleButtonProps extends ButtonProps {
   checked: boolean;
+  'aria-pressed'?: boolean | 'false' | 'mixed' | 'true';
 }
 
 export const ToggleButton = React.forwardRef<
@@ -46,7 +48,7 @@ export const ToggleButton = React.forwardRef<
 });
 
 const validateProps = (props: ToggleButtonProps) => {
-  validateStrictClasses(props.className);
+  validateStrictClasses(props.className);-
   validateIconButton(props);
   validateMenuButton(props);
 };

--- a/packages/teams-components/src/components/ToggleButton/ToggleButton.tsx
+++ b/packages/teams-components/src/components/ToggleButton/ToggleButton.tsx
@@ -12,7 +12,7 @@ import { ButtonProps, validateIconButton, validateMenuButton } from '../Button';
 
 export interface ToggleButtonProps extends ButtonProps {
   checked: boolean;
-  'aria-pressed'?: null | undefined;
+  'aria-pressed'?: undefined;
 }
 
 export const ToggleButton = React.forwardRef<

--- a/packages/teams-components/src/components/ToggleButton/ToggleButton.tsx
+++ b/packages/teams-components/src/components/ToggleButton/ToggleButton.tsx
@@ -7,11 +7,12 @@ import {
   Tooltip,
 } from '@fluentui/react-components';
 import { validateStrictClasses } from '../../strictStyles';
+import { validateAriaPressed } from './validateProps';
 import { ButtonProps, validateIconButton, validateMenuButton } from '../Button';
 
 export interface ToggleButtonProps extends ButtonProps {
   checked: boolean;
-  'aria-pressed'?: boolean | 'false' | 'mixed' | 'true';
+  'aria-pressed'?: null | undefined;
 }
 
 export const ToggleButton = React.forwardRef<
@@ -48,6 +49,7 @@ export const ToggleButton = React.forwardRef<
 
 const validateProps = (props: ToggleButtonProps) => {
   validateStrictClasses(props.className);
+  validateAriaPressed(props);
   validateIconButton(props);
   validateMenuButton(props);
 };

--- a/packages/teams-components/src/components/ToggleButton/ToggleButton.tsx
+++ b/packages/teams-components/src/components/ToggleButton/ToggleButton.tsx
@@ -47,7 +47,7 @@ export const ToggleButton = React.forwardRef<
 });
 
 const validateProps = (props: ToggleButtonProps) => {
-  validateStrictClasses(props.className);-
+  validateStrictClasses(props.className);
   validateIconButton(props);
   validateMenuButton(props);
 };

--- a/packages/teams-components/src/components/ToggleButton/validateProps.ts
+++ b/packages/teams-components/src/components/ToggleButton/validateProps.ts
@@ -1,5 +1,3 @@
-import { ToggleButtonProps } from '@fluentui-contrib/teams-components';
-
 export const validateAriaPressed = (props: {
   'aria-pressed'?: null | undefined;
   'aria-label'?: string;

--- a/packages/teams-components/src/components/ToggleButton/validateProps.ts
+++ b/packages/teams-components/src/components/ToggleButton/validateProps.ts
@@ -1,0 +1,16 @@
+import { ToggleButtonProps } from '@fluentui-contrib/teams-components';
+
+export const validateAriaPressed = (props: {
+  'aria-pressed'?: null | undefined;
+  'aria-label'?: string;
+  'aria-labelledby'?: string;
+}) => {
+  if (
+    'aria-pressed' in props &&
+    !(props['aria-label'] || props['aria-labelledby'])
+  ) {
+    throw new Error(
+      '@fluentui-contrib/teams-components::ToggleButton with aria-pressed removed must have aria-label or aria-labelledby provided'
+    );
+  }
+};


### PR DESCRIPTION
Adds aria-pressed prop for ToggleButton for UX backward compatibility with screen readers