### PR TITLE
More robust SSR check for `houdini-utils`

### DIFF
--- a/change/@fluentui-contrib-houdini-utils-7e3da416-5d7a-454d-b0e0-32ca2c6fcbf0.json
+++ b/change/@fluentui-contrib-houdini-utils-7e3da416-5d7a-454d-b0e0-32ca2c6fcbf0.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: add more robust feature detection",
+  "packageName": "@fluentui-contrib/houdini-utils",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/houdini-utils/src/paint/fallback/fallbackPaintAnimation.ts
+++ b/packages/houdini-utils/src/paint/fallback/fallbackPaintAnimation.ts
@@ -1,5 +1,9 @@
 import { playAnim } from './anims/play';
-import { hasMozElement, hasWebkitCanvas } from '../../util/featureDetect';
+import {
+  hasDom,
+  hasMozElement,
+  hasWebkitCanvas,
+} from '../../util/featureDetect';
 import { appendWrapper } from './util/wrapper';
 import {
   appendCanvas,
@@ -31,6 +35,10 @@ export const fallbackPaintAnimation = (
   paintWorklet: PaintWorklet,
   animationParams: FallbackAnimationParams
 ): FallbackAnimationReturn => {
+  if (!hasDom()) {
+    return cannotDraw;
+  }
+
   const state: FallbackAnimationState = {
     target,
     ctx: null,

--- a/packages/houdini-utils/src/util/featureDetect.ts
+++ b/packages/houdini-utils/src/util/featureDetect.ts
@@ -24,6 +24,14 @@ declare global {
 export type FeatureDetectFn = () => boolean;
 export type AsyncFeatureDetectFn = () => Promise<boolean>;
 
+export const hasDom: FeatureDetectFn = () => {
+  return (
+    // This will hold regardless of the specific `document` object
+    // eslint-disable-next-line no-restricted-globals
+    typeof document !== 'undefined'
+  );
+};
+
 /**
  * Test if the APIs neccessary for the Firefox fallback exist.
  *
@@ -32,7 +40,7 @@ export type AsyncFeatureDetectFn = () => Promise<boolean>;
 export const hasMozElement: FeatureDetectFn = () => {
   // This will hold regardless of the specific `document` object
   // eslint-disable-next-line no-restricted-globals
-  return typeof document?.mozSetImageElement === 'function';
+  return hasDom() && typeof document.mozSetImageElement === 'function';
 };
 
 /**
@@ -42,7 +50,7 @@ export const hasMozElement: FeatureDetectFn = () => {
 export const hasWebkitCanvas: FeatureDetectFn = () => {
   // This will hold regardless of the specific `document` object
   // eslint-disable-next-line no-restricted-globals
-  return typeof document?.getCSSCanvasContext === 'function';
+  return hasDom() && typeof document.getCSSCanvasContext === 'function';
 };
 
 /**


### PR DESCRIPTION
This PR adds a more robust DOM-feature detect function and it further adds another check before a code path that makes significant use of DOM APIs.

A partner team reported the following error:

```
Server Error
ReferenceError: document is not defined

This error happened while generating the page. Any console logs will be displayed in the terminal window.
Call Stack
hasWebkitCanvas
```

This is from a NextJS app and we established the issue was Next SSRing a Houdini component.