### PR TITLE
feature(react-tree-grid): TreeGridRowTrigger component

### DIFF
--- a/change/@fluentui-contrib-react-tree-grid-23f7ff6f-2457-4944-bb7f-a1f273d876be.json
+++ b/change/@fluentui-contrib-react-tree-grid-23f7ff6f-2457-4944-bb7f-a1f273d876be.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feature(react-tree-grid): TreeGridRowTrigger component",
+  "packageName": "@fluentui-contrib/react-tree-grid",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-tree-grid/package.json
+++ b/packages/react-tree-grid/package.json
@@ -11,6 +11,7 @@
     "@fluentui/react-jsx-runtime": "^9.0.29",
     "@fluentui/keyboard-keys": "~9.0.6",
     "@fluentui/react-tabster": "^9.17.2",
+    "@fluentui/react-aria": "^9.13.5",
     "@fluentui/react-utilities": "^9.16.0"
   }
 }

--- a/packages/react-tree-grid/src/components/TreeGridRow/TreeGridRow.tsx
+++ b/packages/react-tree-grid/src/components/TreeGridRow/TreeGridRow.tsx
@@ -70,10 +70,7 @@ export const TreeGridRow = React.forwardRef(
     const handleClick = useEventCallback(
       (event: React.MouseEvent<HTMLDivElement>) => {
         props.onClick?.(event);
-        if (!isHTMLElement(event.target)) {
-          return;
-        }
-        let element: HTMLElement | null = event.target;
+        let element = event.target as HTMLElement | SVGElement | null;
         while (element && element !== event.currentTarget) {
           if (element.tabIndex >= 0) return;
           element = element.parentElement;
@@ -103,14 +100,10 @@ export const TreeGridRow = React.forwardRef(
       { elementType: 'div' }
     );
     return (
-      <>
+      <TreeGridRowProvider value={context}>
         <Root />
-        {open && Subtree && (
-          <TreeGridRowProvider value={context}>
-            <Subtree />
-          </TreeGridRowProvider>
-        )}
-      </>
+        {open && Subtree && <Subtree />}
+      </TreeGridRowProvider>
     );
   }
 );

--- a/packages/react-tree-grid/src/components/TreeGridRow/TreeGridRow.tsx
+++ b/packages/react-tree-grid/src/components/TreeGridRow/TreeGridRow.tsx
@@ -19,7 +19,6 @@ import {
   TabsterDOMAttribute,
   useMergedTabsterAttributes_unstable,
 } from '@fluentui/react-tabster';
-import { isHTMLElement } from '@fluentui/react-utilities';
 import { ArrowLeft, ArrowRight, Enter } from '@fluentui/keyboard-keys';
 import {
   TreeGridRowProvider,

--- a/packages/react-tree-grid/src/components/TreeGridRow/TreeGridRow.types.ts
+++ b/packages/react-tree-grid/src/components/TreeGridRow/TreeGridRow.types.ts
@@ -7,8 +7,8 @@ export type TreeGridRowSlots = {
 };
 
 export type TreeGridRowOnOpenChangeData = { open: boolean } & (
-  | EventData<'click', React.MouseEvent<HTMLDivElement>>
-  | EventData<'keydown', React.KeyboardEvent<HTMLDivElement>>
+  | EventData<'click', React.MouseEvent>
+  | EventData<'keydown', React.KeyboardEvent>
 );
 
 export type TreeGridRowProps = ComponentProps<TreeGridRowSlots> & {

--- a/packages/react-tree-grid/src/components/TreeGridRowTrigger/TreeGridRowTrigger.tsx
+++ b/packages/react-tree-grid/src/components/TreeGridRowTrigger/TreeGridRowTrigger.tsx
@@ -1,0 +1,75 @@
+import * as React from 'react';
+import {
+  applyTriggerPropsToChildren,
+  getTriggerChild,
+  useEventCallback,
+  type FluentTriggerComponent,
+  type TriggerProps,
+} from '@fluentui/react-utilities';
+import { useTreeGridRowContext } from '../../contexts/TreeGridRowContext';
+import { useARIAButtonProps } from '@fluentui/react-aria';
+
+export interface TreeGridRowTriggerProps
+  extends TriggerProps<TreeGridRowTriggerChildProps> {
+  /**
+   * Enables internal trigger mechanism that ensures the child provided will be a compliant ARIA button.
+   * @default false
+   */
+  enableButtonEnhancement?: boolean;
+}
+
+/**
+ * Props that are passed to the child of the TreeGridTrigger when cloned to ensure correct behaviour for the TreeGrid
+ */
+interface TreeGridRowTriggerChildProps {
+  onClick?(event: React.MouseEvent): void;
+}
+
+/**
+ * A non-visual component that wraps its child
+ * and configures them to be the trigger that will open or close a `TreeGridRow`.
+ * This component should only accept one child.
+ *
+ * This component sole purpose is to avoid opting out of the internal controlled open state of a `TreeGrid`
+ * Besides being a trigger that opens/close a TreeGrid through context this component doesn't do much,
+ * making it basically unnecessary in cases where the trigger is outside of the `TreeGrid` component.
+ */
+export const TreeGridRowTrigger: React.FC<TreeGridRowTriggerProps> = (
+  props
+) => {
+  const { children, enableButtonEnhancement = false } = props;
+
+  const child = getTriggerChild(children);
+
+  const { requestOpenChange, open } = useTreeGridRowContext();
+
+  const handleClick = useEventCallback((event: React.MouseEvent) => {
+    child?.props.onClick?.(event);
+    if (!event.isDefaultPrevented()) {
+      requestOpenChange({ open: !open, event, type: 'click' });
+    }
+  });
+
+  const triggerChildProps = {
+    ...child?.props,
+    ref: child?.ref,
+    onClick: handleClick,
+  } as const;
+
+  const ariaButtonTriggerChildProps = useARIAButtonProps(
+    child?.type === 'button' || child?.type === 'a' ? child.type : 'div',
+    {
+      ...triggerChildProps,
+      type: 'button',
+    }
+  );
+
+  return applyTriggerPropsToChildren(
+    children,
+    enableButtonEnhancement ? ariaButtonTriggerChildProps : triggerChildProps
+  );
+};
+
+TreeGridRowTrigger.displayName = 'TreeGridRowTrigger';
+// type casting here is required to ensure internal type FluentTriggerComponent is not leaked
+(TreeGridRowTrigger as FluentTriggerComponent).isFluentTriggerComponent = true;

--- a/packages/react-tree-grid/src/components/TreeGridRowTrigger/index.ts
+++ b/packages/react-tree-grid/src/components/TreeGridRowTrigger/index.ts
@@ -1,0 +1,1 @@
+export * from './TreeGridRowTrigger';

--- a/packages/react-tree-grid/src/index.ts
+++ b/packages/react-tree-grid/src/index.ts
@@ -1,3 +1,6 @@
+export { TreeGridRowTrigger } from './components/TreeGridRowTrigger';
+export type { TreeGridRowTriggerProps } from './components/TreeGridRowTrigger';
+
 export { TreeGrid } from './components/TreeGrid';
 export type { TreeGridProps, TreeGridSlots } from './components/TreeGrid';
 

--- a/packages/react-tree-grid/stories/Calls.stories.tsx
+++ b/packages/react-tree-grid/stories/Calls.stories.tsx
@@ -4,6 +4,7 @@ import {
   TreeGridCell,
   TreeGridInteraction,
   TreeGridRow,
+  TreeGridRowTrigger,
 } from '@fluentui-contrib/react-tree-grid';
 import {
   Avatar,
@@ -161,14 +162,14 @@ const HistoryCalls = (props: { children?: React.ReactNode }) => {
         className={mergeClasses(styles.cell, styles.historyRowHeader)}
         header
       >
-        <Button
-          autoFocus
-          onClick={() => setOpen(!open)}
-          icon={open ? <CaretDownFilled /> : <CaretRightFilled />}
-          appearance="transparent"
-        >
-          History
-        </Button>
+        <TreeGridRowTrigger>
+          <Button
+            icon={open ? <CaretDownFilled /> : <CaretRightFilled />}
+            appearance="transparent"
+          >
+            History
+          </Button>
+        </TreeGridRowTrigger>
       </TreeGridCell>
       <TreeGridCell className={styles.cell}>
         <TreeGridInteraction

--- a/packages/react-tree-grid/stories/LiveMeetingsList.stories.tsx
+++ b/packages/react-tree-grid/stories/LiveMeetingsList.stories.tsx
@@ -4,7 +4,6 @@ import {
   TreeGridProps,
   TreeGridCell,
   TreeGridRow,
-  TreeGridRowOnOpenChangeData,
 } from '@fluentui-contrib/react-tree-grid';
 import {
   Button,


### PR DESCRIPTION
Creates a Trigger component to simplify use cases where a trigger to open/close the current row is required

1. Creates `TreeGridRowTrigger` component
2. Adds usage of it in `Calls` example
3. Bugfix to ensure SVGElements won't be ignored on a click https://github.com/microsoft/fluentui-contrib/pull/364#discussion_r2053768358