### PR TITLE
Fix typo in `react-keytips` _Overflow_ story

### DIFF
--- a/packages/react-keytips/stories/Overflow/Home/EmailMenuButton.tsx
+++ b/packages/react-keytips/stories/Overflow/Home/EmailMenuButton.tsx
@@ -23,7 +23,7 @@ const menuItems = [
   'Storyline post',
   'Newsletter',
   'Document',
-  'Spreadshit',
+  'Spreadsheet',
   'Presentation',
 ];
 


### PR DESCRIPTION
Release the 🦄 in `EmailMenuButton.tsx`