### PR TITLE
Fix Safari bug in Houdini utils

### DIFF
--- a/change/@fluentui-contrib-houdini-utils-11b65663-b7d6-4a80-8b7a-ef970d56300d.json
+++ b/change/@fluentui-contrib-houdini-utils-11b65663-b7d6-4a80-8b7a-ef970d56300d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: resolve Safari issue when referencing fallback",
+  "packageName": "@fluentui-contrib/houdini-utils",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/houdini-utils/src/paint/fallback/anims/play.ts
+++ b/packages/houdini-utils/src/paint/fallback/anims/play.ts
@@ -72,7 +72,9 @@ export const playAnim = (
       if (hasMozElement()) {
         state.target.style.backgroundImage = `-moz-element(#${state.id})`;
       } else if (hasWebkitCanvas()) {
-        state.target.style.backgroundImage = `-webkit-canvas(#${state.id})`;
+        // Note: Safari references its vendor-specific CSSCanvasContext
+        // ID which does not use the CSS ID selector (#).
+        state.target.style.backgroundImage = `-webkit-canvas(${state.id})`;
       } else {
         const urlBackgroundImage = `url(${state.ctx.canvas.toDataURL(
           'image/png'


### PR DESCRIPTION
For the fallback Safari implementation we rely on the vendor-specific, undocumented `-webkit-canvas()` CSS function. This function takes an ID but not a CSS ID. In other words:

```css

/* ⛔ nope */
background-image: -webkit-canvas(#css-id-selector-will-not-work);

/* ✅ yep */
background-image: -webkit-canvas(id-selector-will-work);
```
