### PR TITLE
bugfix(react-tree-grid): slot type breaks when using typeof exotic component with react v17

### DIFF
--- a/change/@fluentui-contrib-react-tree-grid-29d75719-930c-4f4a-b9f7-f5593f2734dc.json
+++ b/change/@fluentui-contrib-react-tree-grid-29d75719-930c-4f4a-b9f7-f5593f2734dc.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "bugfix: slot type breaks when using typeof ExoticComponent with v17",
+  "packageName": "@fluentui-contrib/react-tree-grid",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-tree-grid/src/components/TreeGridRow/TreeGridRow.types.ts
+++ b/packages/react-tree-grid/src/components/TreeGridRow/TreeGridRow.types.ts
@@ -15,5 +15,5 @@ export type TreeGridRowProps = ComponentProps<TreeGridRowSlots> & {
   open?: boolean;
   defaultOpen?: boolean;
   onOpenChange?: EventHandler<TreeGridRowOnOpenChangeData>;
-  subtree?: Slot<typeof React.Fragment> | true;
+  subtree?: Slot<{ children?: React.ReactNode }> | true;
 };


### PR DESCRIPTION
Types generated at react-tree-grid v0.1.4:

```tsx
/** @jsxRuntime classic */
/** @jsx createElement */
/** @jsxFrag Fragment */
import { Fragment } from '@fluentui/react-jsx-runtime';
import * as React from 'react';
export declare const TreeGridRow: React.ForwardRefExoticComponent<Omit<import("./TreeGridRow.types").TreeGridRowSlots, "root"> & Omit<{
    as?: "div" | undefined;
} & Omit<React.DetailedHTMLProps<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement>, "ref"> & {
    ref?: ((instance: HTMLDivElement | null) => void | React.DO_NOT_USE_OR_YOU_WILL_BE_FIRED_CALLBACK_REF_RETURN_VALUES[keyof React.DO_NOT_USE_OR_YOU_WILL_BE_FIRED_CALLBACK_REF_RETURN_VALUES]) | React.RefObject<HTMLDivElement> | null | undefined;
} & {
    children?: React.ReactNode | import("@fluentui/react-utilities").SlotRenderFunction<Omit<React.DetailedHTMLProps<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement>, "ref"> & {
        ref?: ((instance: HTMLDivElement | null) => void | React.DO_NOT_USE_OR_YOU_WILL_BE_FIRED_CALLBACK_REF_RETURN_VALUES[keyof React.DO_NOT_USE_OR_YOU_WILL_BE_FIRED_CALLBACK_REF_RETURN_VALUES]) | React.RefObject<HTMLDivElement> | null | undefined;
    }>;
}, "ref"> & {
    open?: boolean;
    defaultOpen?: boolean;
    onOpenChange?: import("@fluentui/react-utilities").EventHandler<import("./TreeGridRow.types").TreeGridRowOnOpenChangeData>;
    subtree?: import("@fluentui/react-utilities").Slot<typeof Fragment> | true;
} & React.RefAttributes<HTMLDivElement>>;
```


Types generated in v0.1.3:

```tsx
/** @jsxRuntime classic */
/** @jsx createElement */
/** @jsxFrag Fragment */
import * as React from 'react';
export declare const TreeGridRow: React.ForwardRefExoticComponent<Omit<import("./TreeGridRow.types").TreeGridRowSlots, "root"> & Omit<{
    as?: "div" | undefined;
} & Omit<React.DetailedHTMLProps<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement>, "ref"> & {
    ref?: ((instance: HTMLDivElement | null) => void) | React.RefObject<HTMLDivElement> | null | undefined;
} & {
    children?: React.ReactNode | import("@fluentui/react-utilities").SlotRenderFunction<Omit<React.DetailedHTMLProps<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement>, "ref"> & {
        ref?: ((instance: HTMLDivElement | null) => void) | React.RefObject<HTMLDivElement> | null | undefined;
    }>;
}, "ref"> & {
    open?: boolean | undefined;
    defaultOpen?: boolean | undefined;
    onOpenChange?: import("@fluentui/react-utilities").EventHandler<import("./TreeGridRow.types").TreeGridRowOnOpenChangeData> | undefined;
    subtree?: true | (string | number | React.ReactPortal | React.ReactElement<any, string | React.JSXElementConstructor<any>> | React.ReactNode[] | ({
        children?: React.ReactNode;
    } & {
        children?: React.ReactNode | import("@fluentui/react-utilities").SlotRenderFunction<{
            children?: React.ReactNode;
        }>;
    })) | null | undefined;
} & React.RefAttributes<HTMLDivElement>>;
```

Focus on `subtree` declaration here:

went from:
```tsx
true | (string | number | React.ReactPortal | React.ReactElement<any, string | React.JSXElementConstructor<any>> | React.ReactNode[] | ({
        children?: React.ReactNode;
    } & {
        children?: React.ReactNode | import("@fluentui/react-utilities").SlotRenderFunction<{
            children?: React.ReactNode;
        }>;
    })) | null | undefined
```
to:
```tsx
import("@fluentui/react-utilities").Slot<typeof Fragment> | true
```

Which is not wrong, but it seems this comparison in `Slot`:

https://github.com/microsoft/fluentui/blob/918dddbf1af1cb16f3e4353004c0231f6bd7da39/packages/react-components/react-utilities/src/compose/types.ts#L108

return `unknown` instead of returning proper properties of the exotic component.


# Modifications

Stops using `typeof Fragment` to infer properties of `Fragment` in `subtree` slot declaration, redeclare the property itself instead.

## notes

Would be good to have a follow up on fluent, but I believe this would be resolve by react 18 investigations