### PR TITLE
feat(resize-handle): add onChangeRejected() callback

### DIFF
--- a/change/@fluentui-contrib-react-resize-handle-52670819-1a5d-4c12-96f1-836c93979a33.json
+++ b/change/@fluentui-contrib-react-resize-handle-52670819-1a5d-4c12-96f1-836c93979a33.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "feat: add onChangeRejected() callback",
+  "packageName": "@fluentui-contrib/react-resize-handle",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-resize-handle/src/hooks/useResizeHandleExample.component-browser-spec.tsx
+++ b/packages/react-resize-handle/src/hooks/useResizeHandleExample.component-browser-spec.tsx
@@ -9,6 +9,7 @@ export type TestAreaProps = Pick<
   | 'onDragStart'
   | 'onDragEnd'
   | 'onChange'
+  | 'onChangeRejected'
   | 'relative'
   | 'minValue'
   | 'maxValue'
@@ -20,6 +21,7 @@ export function TestArea(props: TestAreaProps) {
     onDragEnd,
     onDragStart,
     onChange,
+    onChangeRejected,
 
     minValue,
     maxValue,
@@ -59,6 +61,7 @@ export function TestArea(props: TestAreaProps) {
     maxValue,
 
     onChange: handleChange,
+    onChangeRejected,
     onDragEnd,
     onDragStart,
   });


### PR DESCRIPTION
As we don't call `onChange()` without actual changes in DOM (#375), there is no way to know that there is a resize attempt outside of CSS clamp range. This PR adds `onChangeRejected()` callback:

<img width="887" alt="image" src="https://github.com/user-attachments/assets/9eaf5d0b-518c-4641-a862-f65dc0ffc7bd" />

New test cases added, the story is updated.