### PR TITLE
fix(react-draggable-dialog): drag ux and position issue

### DIFF
--- a/packages/react-draggable-dialog/src/components/DraggableDialog/useDraggableDialog.ts
+++ b/packages/react-draggable-dialog/src/components/DraggableDialog/useDraggableDialog.ts
@@ -108,9 +108,11 @@ export const useDraggableDialog = (
         return;
       }
 
+      const { deltaX, deltaY } = calcPositionDelta(boundary);
+
       setInitialDropPosition({
-        x: rect.left,
-        y: rect.top,
+        x: rect.left - deltaX,
+        y: rect.top - deltaY,
       });
       onDragMove(event);
     },
@@ -187,3 +189,24 @@ export const useDraggableDialog = (
     ]
   );
 };
+
+function calcPositionDelta(
+  boundary: React.RefObject<HTMLElement> | 'viewport' | null
+) {
+  let deltaX = 0;
+  let deltaY = 0;
+
+  if (!boundary || boundary === 'viewport') {
+    return { deltaX, deltaY };
+  }
+
+  const boundaryEl = boundary.current;
+
+  if (boundaryEl) {
+    const boundingClientRect = boundaryEl.getBoundingClientRect();
+    deltaX = boundingClientRect.left - boundaryEl.offsetLeft;
+    deltaY = boundingClientRect.top - boundaryEl.offsetTop;
+  }
+
+  return { deltaX, deltaY };
+}

--- a/packages/react-draggable-dialog/src/components/DraggableDialog/utils/restrictToMarginModifier.ts
+++ b/packages/react-draggable-dialog/src/components/DraggableDialog/utils/restrictToMarginModifier.ts
@@ -48,14 +48,7 @@ export const restrictToMarginModifier: RestrictToMarginModifier =
       return transform;
     }
 
-    const virtualRect = {
-      width: boundaryEl.offsetWidth,
-      height: boundaryEl.offsetHeight,
-      top: boundaryEl.offsetTop,
-      right: boundaryEl.offsetLeft + boundaryEl.offsetWidth,
-      bottom: boundaryEl.offsetTop + boundaryEl.offsetHeight,
-      left: boundaryEl.offsetLeft,
-    };
+    const virtualRect = boundaryEl.getBoundingClientRect();
 
     return restrictToEdges({
       ...modifier,

--- a/packages/react-draggable-dialog/src/components/DraggableDialogSurface/useDraggableDialogSurface.ts
+++ b/packages/react-draggable-dialog/src/components/DraggableDialogSurface/useDraggableDialogSurface.ts
@@ -92,7 +92,8 @@ export const useDraggableDialogSurface = (
 
     if (isDragging) {
       const baseStyles = {
-        transform: CSS.Translate.toString(transform),
+        top: dropPosition.y + (transform?.y ?? 0),
+        left: dropPosition.x + (transform?.x ?? 0),
       };
 
       if (!hasBeenDragged) {
@@ -102,8 +103,6 @@ export const useDraggableDialogSurface = (
       return {
         ...baseStyles,
         margin: 0,
-        top: dropPosition.y,
-        left: dropPosition.x,
       };
     }
 


### PR DESCRIPTION
This PR fixes:

- Bad UX while dragging the `react-draggable-dialog` dialog, since no realtime position feedback was provided.
- A related positioning issue in existing code.

Details:

The prior implementation uses `transform: CSS.Translate.toString(transform),` to reflect the latest dragging position. But this CSS style is ignored, since the `react-dialog` component adds its own `transform` CSS property. So we have to use `top, left` CSS properties instead.

To the repo owners, feel free to edit the PR or create new based on my implementation.