### PR TITLE
docs(react-virtualizer): Update virtualizer stories to use the same storybook Meta format as contrib repo

### DIFF
--- a/apps/docsite/src/Welcome.mdx
+++ b/apps/docsite/src/Welcome.mdx
@@ -30,6 +30,8 @@ Explore the various packages available to extend your Fluent UI capabilities:
 
 - [**react-tree-grid**](/docs/packages-react-tree-grid--docs): TreeGrid component for hierarchical data.
 
+- [**react-virtualizer**](/docs/packages-react-virtualizer--docs): Virtualizer hooks and scroll view component for optimizing long-list renders
+
 ## Getting Started
 
 To get started with any of these packages in your project:

--- a/packages/react-virtualizer/stories/Virtualizer/index.stories.ts
+++ b/packages/react-virtualizer/stories/Virtualizer/index.stories.ts
@@ -1,6 +1,3 @@
-import { Virtualizer } from '@fluentui/react-virtualizer';
-import descriptionMd from './VirtualizerDescription.md';
-
 export { Default } from './Default.stories';
 export { DefaultUnbounded } from './DefaultUnbounded.stories';
 export { Dynamic } from './Dynamic.stories';
@@ -10,14 +7,18 @@ export { Reversed } from './Reversed.stories';
 export { RTL } from './RTL.stories';
 export { MultiUnbounded } from './MultiUnbounded.stories';
 
-export default {
-  title: 'Preview Components/Virtualizer',
-  component: Virtualizer,
+import { Meta } from '@storybook/react';
+import description from '../../README.md';
+
+const meta: Meta = {
+  title: 'Packages/react-virtualizer/Virtualizer',
   parameters: {
     docs: {
       description: {
-        component: [descriptionMd].join('\n'),
+        component: description,
       },
     },
   },
 };
+
+export default meta;

--- a/packages/react-virtualizer/stories/VirtualizerScrollView/index.stories.ts
+++ b/packages/react-virtualizer/stories/VirtualizerScrollView/index.stories.ts
@@ -1,19 +1,22 @@
-import { VirtualizerScrollView } from '@fluentui/react-virtualizer';
-import descriptionMd from './VirtualizerScrollViewDescription.md';
 import accessibilityMd from './VirtualizerScrollViewAccessibility.md';
 
 export { Default } from './Default.stories';
 export { ScrollTo } from './ScrollTo.stories';
 export { SnapToAlignment } from './SnapToAlignment.stories';
 
-export default {
-  title: 'Preview Components/VirtualizerScrollView',
-  component: VirtualizerScrollView,
+import { Meta } from '@storybook/react';
+import description from '../../README.md';
+
+const meta: Meta = {
+  title: 'Packages/react-virtualizer/VirtualizerScrollView',
   parameters: {
     docs: {
       description: {
-        component: [descriptionMd, accessibilityMd].join('\n'),
+        accessibilityMd: accessibilityMd,
+        component: description,
       },
     },
   },
 };
+
+export default meta;

--- a/packages/react-virtualizer/stories/VirtualizerScrollViewDynamic/index.stories.ts
+++ b/packages/react-virtualizer/stories/VirtualizerScrollViewDynamic/index.stories.ts
@@ -8,14 +8,19 @@ export { ScrollTo } from './ScrollTo.stories';
 export { ScrollLoading } from './ScrollLoading.stories';
 export { SnapToAlignment } from './SnapToAlignment.stories';
 
-export default {
-  title: 'Preview Components/VirtualizerScrollViewDynamic',
-  component: VirtualizerScrollViewDynamic,
+import { Meta } from '@storybook/react';
+import description from '../../README.md';
+
+const meta: Meta = {
+  title: 'Packages/react-virtualizer/VirtualizerScrollViewDynamic',
   parameters: {
     docs: {
       description: {
-        component: [descriptionMd, accessibilityMd].join('\n'),
+        accessibilityMd: accessibilityMd,
+        component: description,
       },
     },
   },
 };
+
+export default meta;


### PR DESCRIPTION
Our virtualizer stories currently aren't displayed on the docsite, assuming this is due to storybook type (works on local storybook).

Updating to match the other story setups.