### PR TITLE
fix(react-tree-grid): fix react 17 integration type-check issue

### DIFF
--- a/apps/react-17-tests/project.json
+++ b/apps/react-17-tests/project.json
@@ -18,7 +18,7 @@
       ]
     },
     "build:integration": {
-      "command": "nx run-many -t build && nx run-many -t type-check"
+      "command": "nx run-many -t build,type-check"
     },
     "e2e:integration": {
       "command": "nx run-many -t component-test --reactVersion 17 --skipInstall",

--- a/apps/react-17-tests/project.json
+++ b/apps/react-17-tests/project.json
@@ -18,7 +18,7 @@
       ]
     },
     "build:integration": {
-      "command": "nx run-many -t build,type-check"
+      "command": "nx run-many -t build && nx run-many -t type-check"
     },
     "e2e:integration": {
       "command": "nx run-many -t component-test --reactVersion 17 --skipInstall",

--- a/packages/react-tree-grid/stories/EmailInbox.stories.tsx
+++ b/packages/react-tree-grid/stories/EmailInbox.stories.tsx
@@ -139,7 +139,7 @@ type EmailProps = {
   subject: React.ReactNode;
   summary: React.ReactNode;
   email: string;
-  replies?: Slot<{ children?: React.ReactNode }>;
+  replies?: Slot<typeof React.Fragment>;
 };
 
 const Email = (props: EmailProps) => {

--- a/packages/react-tree-grid/stories/EmailInbox.stories.tsx
+++ b/packages/react-tree-grid/stories/EmailInbox.stories.tsx
@@ -139,7 +139,7 @@ type EmailProps = {
   subject: React.ReactNode;
   summary: React.ReactNode;
   email: string;
-  replies?: Slot<typeof React.Fragment>;
+  replies?: Slot<{ children?: React.ReactNode }>;
 };
 
 const Email = (props: EmailProps) => {


### PR DESCRIPTION
## Current Behavior
React 17 integration type-check pipeline is failing
https://github.com/microsoft/fluentui-contrib/actions/runs/16508531411/job/46685232442

## New Behavior
Both react 17 and react 18 type-check pipeline are passing

## Related Issues
Fixes #445