### PR TITLE
fix(docsite): add missing dependency for extract-storybook-llms target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
 
       - run: yarn nx affected --target=verify-integrity
       - run: yarn nx affected --target=build
-      - run: yarn nx affected --target=build-storybook,extract-storybook-llms
+      - run: yarn nx affected --target=build-storybook
       - run: yarn nx affected --target=type-check
       - run: yarn nx affected --target=lint
       - run: yarn nx affected --target=test


### PR DESCRIPTION
Fixes an issue when the `extract-storybook-llms` target is executed before the `build-storybook` https://github.com/microsoft/fluentui-contrib/actions/runs/17131066622/job/48595224133:

<img width="1830" height="1560" alt="image" src="https://github.com/user-attachments/assets/23c1469a-1e93-446c-8d96-833b8478ac31" />


