### PR TITLE
feat: enforce module boundary types

### DIFF
--- a/.storybook/copied-from-fluentui-core/components/FluentDocsPage.tsx
+++ b/.storybook/copied-from-fluentui-core/components/FluentDocsPage.tsx
@@ -8,6 +8,7 @@ import {
 } from '@storybook/addon-docs';
 import type { SBEnumType, PreparedStory, Renderer } from '@storybook/types';
 import { makeStyles, shorthands, tokens } from '@fluentui/react-components';
+import type { JSXElement } from '@fluentui/react-components';
 import { InfoFilled } from '@fluentui/react-icons';
 import { Toc } from './Toc';
 
@@ -65,7 +66,7 @@ const useStyles = makeStyles({
   },
 });
 
-const getNativeElementsList = (elements: SBEnumType['value']): JSX.Element => {
+const getNativeElementsList = (elements: SBEnumType['value']): JSXElement => {
   const elementsArr = elements.map((el, idx) => [
     <code key={idx}>{`<${el}>`}</code>,
     idx !== elements.length - 1 ? ', ' : ' ',
@@ -111,7 +112,7 @@ const RenderArgsTable = ({
   );
 };
 
-export const FluentDocsPage = () => {
+export const FluentDocsPage = (): JSXElement => {
   const context = React.useContext(DocsContext);
   const stories = context.componentStories();
   const primaryStory = stories[0];

--- a/apps/react-17-tests/.eslintrc.json
+++ b/apps/react-17-tests/.eslintrc.json
@@ -8,7 +8,9 @@
     },
     {
       "files": ["*.ts", "*.tsx"],
-      "rules": {}
+      "rules": {
+        "@typescript-eslint/explicit-module-boundary-types": "off"
+      }
     },
     {
       "files": ["*.js", "*.jsx"],

--- a/apps/react-18-tests/.eslintrc.json
+++ b/apps/react-18-tests/.eslintrc.json
@@ -4,9 +4,7 @@
   "overrides": [
     {
       "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
-      "rules": {
-        "@typescript-eslint/explicit-module-boundary-types": "off"
-      }
+      "rules": {}
     },
     {
       "files": ["*.ts", "*.tsx"],
@@ -16,8 +14,7 @@
     },
     {
       "files": ["*.js", "*.jsx"],
-      "rules": {
-        "@typescript-eslint/explicit-module-boundary-types": "off"
-      }
+      "rules": {}
+    }
   ]
 }

--- a/apps/react-18-tests/.eslintrc.json
+++ b/apps/react-18-tests/.eslintrc.json
@@ -4,15 +4,20 @@
   "overrides": [
     {
       "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
-      "rules": {}
+      "rules": {
+        "@typescript-eslint/explicit-module-boundary-types": "off"
+      }
     },
     {
       "files": ["*.ts", "*.tsx"],
-      "rules": {}
+      "rules": {
+        "@typescript-eslint/explicit-module-boundary-types": "off"
+      }
     },
     {
       "files": ["*.js", "*.jsx"],
-      "rules": {}
-    }
+      "rules": {
+        "@typescript-eslint/explicit-module-boundary-types": "off"
+      }
   ]
 }

--- a/apps/react-19-tests/.eslintrc.json
+++ b/apps/react-19-tests/.eslintrc.json
@@ -8,7 +8,9 @@
     },
     {
       "files": ["*.ts", "*.tsx"],
-      "rules": {}
+      "rules": {
+        "@typescript-eslint/explicit-module-boundary-types": "off"
+      }
     },
     {
       "files": ["*.js", "*.jsx"],

--- a/change/@fluentui-contrib-houdini-utils-757838a3-693a-4584-95bb-f3106886a7fe.json
+++ b/change/@fluentui-contrib-houdini-utils-757838a3-693a-4584-95bb-f3106886a7fe.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: enforce explicit module boundary types",
+  "packageName": "@fluentui-contrib/houdini-utils",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-contrib-react-chat-79128f76-feb5-4aa7-8d70-4dab97bfb0ad.json
+++ b/change/@fluentui-contrib-react-chat-79128f76-feb5-4aa7-8d70-4dab97bfb0ad.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: enforce explicit module boundary types",
+  "packageName": "@fluentui-contrib/react-chat",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-contrib-react-data-grid-react-window-a0e2a74a-8259-4062-9a08-4811fbbbfdd1.json
+++ b/change/@fluentui-contrib-react-data-grid-react-window-a0e2a74a-8259-4062-9a08-4811fbbbfdd1.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: enforce explicit module boundary types",
+  "packageName": "@fluentui-contrib/react-data-grid-react-window",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-contrib-react-data-grid-react-window-grid-b7a7db03-8f41-45e3-98a3-058f4b4a4a19.json
+++ b/change/@fluentui-contrib-react-data-grid-react-window-grid-b7a7db03-8f41-45e3-98a3-058f4b4a4a19.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: enforce explicit module boundary types",
+  "packageName": "@fluentui-contrib/react-data-grid-react-window-grid",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-contrib-react-draggable-dialog-f0b0ad09-eba8-4d58-93c3-14fb50df7190.json
+++ b/change/@fluentui-contrib-react-draggable-dialog-f0b0ad09-eba8-4d58-93c3-14fb50df7190.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: enforce explicit module boundary types",
+  "packageName": "@fluentui-contrib/react-draggable-dialog",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-contrib-react-gamepad-navigation-3aa31352-29da-414e-a4c0-b48951bfdb6d.json
+++ b/change/@fluentui-contrib-react-gamepad-navigation-3aa31352-29da-414e-a4c0-b48951bfdb6d.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: enforce explicit module boundary types",
+  "packageName": "@fluentui-contrib/react-gamepad-navigation",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-contrib-react-interactive-tab-3ab66926-921c-4761-ba32-859706d590a0.json
+++ b/change/@fluentui-contrib-react-interactive-tab-3ab66926-921c-4761-ba32-859706d590a0.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: enforce explicit module boundary types",
+  "packageName": "@fluentui-contrib/react-interactive-tab",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-contrib-react-keytips-03281d15-131d-4335-8cc1-bbc194f1af4e.json
+++ b/change/@fluentui-contrib-react-keytips-03281d15-131d-4335-8cc1-bbc194f1af4e.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: enforce explicit module boundary types",
+  "packageName": "@fluentui-contrib/react-keytips",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-contrib-react-resize-handle-99de68bd-979d-44e7-8476-9be920d446db.json
+++ b/change/@fluentui-contrib-react-resize-handle-99de68bd-979d-44e7-8476-9be920d446db.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: enforce explicit module boundary types",
+  "packageName": "@fluentui-contrib/react-resize-handle",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-contrib-react-themeless-provider-c6c7b11c-e7aa-472d-a9c7-7f45280f12a7.json
+++ b/change/@fluentui-contrib-react-themeless-provider-c6c7b11c-e7aa-472d-a9c7-7f45280f12a7.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: enforce explicit module boundary types",
+  "packageName": "@fluentui-contrib/react-themeless-provider",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-contrib-react-tree-grid-02e88201-ed54-4250-ae82-dc7a785943a5.json
+++ b/change/@fluentui-contrib-react-tree-grid-02e88201-ed54-4250-ae82-dc7a785943a5.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: enforce explicit module boundary types",
+  "packageName": "@fluentui-contrib/react-tree-grid",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-contrib-react-virtualizer-6ced3ab3-fb90-46cd-8cc9-fc4b596f440d.json
+++ b/change/@fluentui-contrib-react-virtualizer-6ced3ab3-fb90-46cd-8cc9-fc4b596f440d.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: enforce explicit module boundary types",
+  "packageName": "@fluentui-contrib/react-virtualizer",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-contrib-teams-components-02141313-f82d-40fe-819e-3e4012ac877f.json
+++ b/change/@fluentui-contrib-teams-components-02141313-f82d-40fe-819e-3e4012ac877f.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: enforce explicit module boundary types",
+  "packageName": "@fluentui-contrib/teams-components",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-contrib-variant-theme-0e2cad57-46fb-4ae8-9039-1f3180b17e25.json
+++ b/change/@fluentui-contrib-variant-theme-0e2cad57-46fb-4ae8-9039-1f3180b17e25.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: enforce explicit module boundary types",
+  "packageName": "@fluentui-contrib/variant-theme",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -74,6 +74,7 @@ module.exports = [
     },
     rules: {
       'no-restricted-globals': 'off',
+      '@typescript-eslint/explicit-module-boundary-types': 'off',
     },
   },
   {
@@ -93,6 +94,7 @@ module.exports = [
           ],
         },
       ],
+      '@typescript-eslint/explicit-module-boundary-types': 'error',
     },
   },
   {
@@ -113,6 +115,7 @@ module.exports = [
     files: ['**/*.component-browser-spec.tsx'],
     rules: {
       ...playwright.configs['flat/recommended'].rules,
+      '@typescript-eslint/explicit-module-boundary-types': 'off',
     },
   },
   {

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -94,6 +94,38 @@ module.exports = [
           ],
         },
       ],
+      '@typescript-eslint/no-restricted-types': [
+        'error',
+        {
+          types: {
+            'React.RefAttributes': {
+              message:
+                '`React.RefAttributes` is leaking string starting @types/react@18.2.61 creating invalid type contracts. Use `RefAttributes` from @fluentui/react-utilities instead',
+              fixWith: 'RefAttributes',
+            },
+            'JSX.IntrinsicElements': {
+              message:
+                '`JSX.IntrinsicElements` is not compatible with @types/react@>=19. To access intrinsic element keys Use `JSXIntrinsicElementKeys`, otherwise use `JSXIntrinsicElement<T>` from @fluentui/react-utilities instead',
+              suggest: ['JSXIntrinsicElementKeys', 'JSXIntrinsicElement'],
+            },
+            'React.JSX.IntrinsicElements': {
+              message:
+                '`JSX.IntrinsicElements` is not backwards compatible with @types/react@17. To access intrinsic element keys Use `JSXIntrinsicElementKeys`, otherwise use `JSXIntrinsicElement<T>` from @fluentui/react-utilities instead',
+              suggest: ['JSXIntrinsicElementKeys', 'JSXIntrinsicElement'],
+            },
+            'JSX.Element': {
+              message:
+                '`JSX.Element` is not compatible with @types/react@>=19. Use `JSXElement` from @fluentui/react-utilities instead',
+              fixWith: 'JSXElement',
+            },
+            'React.JSX.Element': {
+              message:
+                '`React.JSX.Element` is not backwards compatible with @types/react@17. Use `JSXElement` from @fluentui/react-utilities instead',
+              fixWith: 'JSXElement',
+            },
+          },
+        },
+      ],
       '@typescript-eslint/explicit-module-boundary-types': 'error',
     },
   },

--- a/packages/houdini-utils/src/paint/fallback/anims/play.ts
+++ b/packages/houdini-utils/src/paint/fallback/anims/play.ts
@@ -14,7 +14,7 @@ export const playAnim = (
   state: FallbackAnimationState,
   paintWorklet: PaintWorklet,
   animationParams: FallbackAnimationParams
-) => {
+): ((onComplete: CallbackFn, onUpdate?: CallbackFn) => void) => {
   const props = new Map<string, string>();
   // TODO: fix global. See: https://github.com/microsoft/fluentui-contrib/issues/183
   // eslint-disable-next-line no-restricted-globals

--- a/packages/houdini-utils/src/paint/houdini/registerPaintWorklet.ts
+++ b/packages/houdini-utils/src/paint/houdini/registerPaintWorklet.ts
@@ -1,7 +1,10 @@
 import { addModule } from '../../util/addModule';
 import { hasHoudini } from '../../util/featureDetect';
 
-export const registerPaintWorklet = (baseUrl: string, filebaseUrl: string) => {
+export const registerPaintWorklet = (
+  baseUrl: string,
+  filebaseUrl: string
+): Promise<void> => {
   if (hasHoudini()) {
     return addModule(baseUrl, filebaseUrl);
   }

--- a/packages/houdini-utils/src/util/addModule.ts
+++ b/packages/houdini-utils/src/util/addModule.ts
@@ -13,7 +13,7 @@ declare namespace CSS {
  * @param fileName Name of the PaintWorklet file (e.g., "Flair.min.js")
  * @returns Promise that resolves when the module is added and throws when there is an error.
  */
-export const addModule = (baseUrl: string, fileName: string) => {
+export const addModule = (baseUrl: string, fileName: string): Promise<void> => {
   if (hasHoudini()) {
     const url = `${baseUrl}${fileName}`;
     return CSS.paintWorklet.addModule(url);

--- a/packages/nx-plugin/eslint.config.js
+++ b/packages/nx-plugin/eslint.config.js
@@ -37,6 +37,7 @@ module.exports = [
       '@typescript-eslint/await-thenable': 'error',
       '@typescript-eslint/no-misused-promises': 'error',
       '@typescript-eslint/no-floating-promises': 'error',
+      '@typescript-eslint/explicit-module-boundary-types': 'off',
     },
   },
   {

--- a/packages/react-chat/src/components/Chat/renderChat.tsx
+++ b/packages/react-chat/src/components/Chat/renderChat.tsx
@@ -5,12 +5,13 @@
 import { createElement } from '@fluentui/react-jsx-runtime';
 
 import { assertSlots } from '@fluentui/react-components';
+import type { JSXElement } from '@fluentui/react-components';
 import type { ChatState, ChatSlots } from './Chat.types';
 
 /**
  * Render the final JSX of Chat
  */
-export const renderChat_unstable = (state: ChatState): JSX.Element => {
+export const renderChat_unstable = (state: ChatState): JSXElement => {
   assertSlots<ChatSlots>(state);
 
   return <state.root />;

--- a/packages/react-chat/src/components/Chat/renderChat.tsx
+++ b/packages/react-chat/src/components/Chat/renderChat.tsx
@@ -10,7 +10,7 @@ import type { ChatState, ChatSlots } from './Chat.types';
 /**
  * Render the final JSX of Chat
  */
-export const renderChat_unstable = (state: ChatState) => {
+export const renderChat_unstable = (state: ChatState): JSX.Element => {
   assertSlots<ChatSlots>(state);
 
   return <state.root />;

--- a/packages/react-chat/src/components/ChatMessage/ChatMessage.styles.ts
+++ b/packages/react-chat/src/components/ChatMessage/ChatMessage.styles.ts
@@ -118,7 +118,9 @@ export const useChatMessageBodyClasses = makeStyles({
 /**
  * Apply styling to the ChatMessage slots based on the state
  */
-export const useChatMessageStyles_unstable = (state: ChatMessageState) => {
+export const useChatMessageStyles_unstable = (
+  state: ChatMessageState
+): ChatMessageState => {
   const classes = useChatMessageClasses();
   state.root.className = mergeClasses(
     chatMessageClassNames.root,

--- a/packages/react-chat/src/components/ChatMessage/renderChatMessage.tsx
+++ b/packages/react-chat/src/components/ChatMessage/renderChatMessage.tsx
@@ -5,6 +5,7 @@
 import { createElement } from '@fluentui/react-jsx-runtime';
 
 import { assertSlots } from '@fluentui/react-components';
+import type { JSXElement } from '@fluentui/react-components';
 import type { ChatMessageState, ChatMessageSlots } from './ChatMessage.types';
 
 /**
@@ -12,7 +13,7 @@ import type { ChatMessageState, ChatMessageSlots } from './ChatMessage.types';
  */
 export const renderChatMessage_unstable = (
   state: ChatMessageState
-): JSX.Element => {
+): JSXElement => {
   assertSlots<ChatMessageSlots>(state);
 
   return (

--- a/packages/react-chat/src/components/ChatMessage/renderChatMessage.tsx
+++ b/packages/react-chat/src/components/ChatMessage/renderChatMessage.tsx
@@ -10,7 +10,9 @@ import type { ChatMessageState, ChatMessageSlots } from './ChatMessage.types';
 /**
  * Render the final JSX of ChatMessage
  */
-export const renderChatMessage_unstable = (state: ChatMessageState) => {
+export const renderChatMessage_unstable = (
+  state: ChatMessageState
+): JSX.Element => {
   assertSlots<ChatMessageSlots>(state);
 
   return (

--- a/packages/react-chat/src/components/ChatMyMessage/ChatMyMessage.styles.ts
+++ b/packages/react-chat/src/components/ChatMyMessage/ChatMyMessage.styles.ts
@@ -155,7 +155,9 @@ export const chatMyMessageClassNames: SlotClassNames<ChatMyMessageSlots> = {
   timestamp: 'fui-ChatMyMessage__timestamp',
 };
 
-export const useChatMyMessageStyles_unstable = (state: ChatMyMessageState) => {
+export const useChatMyMessageStyles_unstable = (
+  state: ChatMyMessageState
+): ChatMyMessageState => {
   const classes = useChatMyMessageClasses();
 
   state.root.className = mergeClasses(

--- a/packages/react-chat/src/components/ChatMyMessage/renderChatMyMessage.tsx
+++ b/packages/react-chat/src/components/ChatMyMessage/renderChatMyMessage.tsx
@@ -11,7 +11,9 @@ import type {
   ChatMyMessageState,
 } from './ChatMyMessage.types';
 
-export const renderChatMyMessage_unstable = (state: ChatMyMessageState) => {
+export const renderChatMyMessage_unstable = (
+  state: ChatMyMessageState
+): JSX.Element => {
   assertSlots<ChatMyMessageSlots>(state);
   return (
     <state.root>

--- a/packages/react-chat/src/components/ChatMyMessage/renderChatMyMessage.tsx
+++ b/packages/react-chat/src/components/ChatMyMessage/renderChatMyMessage.tsx
@@ -5,7 +5,7 @@
 import { createElement } from '@fluentui/react-jsx-runtime';
 
 import { assertSlots } from '@fluentui/react-components';
-
+import type { JSXElement } from '@fluentui/react-components';
 import type {
   ChatMyMessageSlots,
   ChatMyMessageState,
@@ -13,7 +13,7 @@ import type {
 
 export const renderChatMyMessage_unstable = (
   state: ChatMyMessageState
-): JSX.Element => {
+): JSXElement => {
   assertSlots<ChatMyMessageSlots>(state);
   return (
     <state.root>

--- a/packages/react-chat/src/components/utils/getDecorationIcon.tsx
+++ b/packages/react-chat/src/components/utils/getDecorationIcon.tsx
@@ -8,7 +8,7 @@ import {
 
 export const getDecorationIcon = (
   decoration?: 'important' | 'urgent' | 'mention' | 'mentionEveryone'
-) => {
+): JSX.Element | null => {
   switch (decoration) {
     case 'important':
       return <ImportantFilled />;

--- a/packages/react-chat/src/components/utils/getDecorationIcon.tsx
+++ b/packages/react-chat/src/components/utils/getDecorationIcon.tsx
@@ -5,10 +5,11 @@ import {
   MentionFilled,
   PeopleFilled,
 } from '@fluentui/react-icons';
+import type { JSXElement } from '@fluentui/react-components';
 
 export const getDecorationIcon = (
   decoration?: 'important' | 'urgent' | 'mention' | 'mentionEveryone'
-): JSX.Element | null => {
+): JSXElement | null => {
   switch (decoration) {
     case 'important':
       return <ImportantFilled />;

--- a/packages/react-chat/src/components/utils/mergeCallbacks.ts
+++ b/packages/react-chat/src/components/utils/mergeCallbacks.ts
@@ -5,7 +5,7 @@
 export function mergeCallbacks<Args extends unknown[]>(
   callback1: ((...args: Args) => void) | undefined,
   callback2: ((...args: Args) => void) | undefined
-) {
+): (...args: Args) => void {
   return (...args: Args) => {
     callback1?.(...args);
     callback2?.(...args);

--- a/packages/react-chat/src/components/utils/useChatMessagePopoverTrigger.ts
+++ b/packages/react-chat/src/components/utils/useChatMessagePopoverTrigger.ts
@@ -10,7 +10,7 @@ import { ChatMyMessageState } from '../ChatMyMessage/ChatMyMessage.types';
 
 export const useChatMessagePopoverTrigger = (
   state: Pick<ChatMessageState | ChatMyMessageState, 'body'>
-) => {
+): void => {
   // V9 PopoverTrigger uses useARIAButtonProps and triggers click event on space key.
   // We don't want this behavior because it means we can't type with space key in the `input` within chat message.
   // If we don't do custom trigger, we'd have to stop keydown/keyup propagation for space key within chat message children.

--- a/packages/react-chat/src/components/utils/useEventCallback.ts
+++ b/packages/react-chat/src/components/utils/useEventCallback.ts
@@ -7,7 +7,7 @@ import { useIsomorphicLayoutEffect } from '@fluentui/react-components';
  */
 export const useEventCallback = <Args extends unknown[], Return>(
   fn: (...args: Args) => Return
-) => {
+): ((...args: Args) => Return) => {
   const callbackRef = React.useRef<typeof fn>(() => {
     throw new Error('Cannot call an event handler while rendering');
   });

--- a/packages/react-contextual-pane/src/components/Footer/Footer.tsx
+++ b/packages/react-contextual-pane/src/components/Footer/Footer.tsx
@@ -16,7 +16,7 @@ export const Footer = ({
   rightActions,
   toolbarLables,
   children,
-}: React.PropsWithChildren<FooterProps>) => {
+}: React.PropsWithChildren<FooterProps>): JSX.Element => {
   const styles = useStyles();
 
   return (

--- a/packages/react-contextual-pane/src/components/Footer/Footer.tsx
+++ b/packages/react-contextual-pane/src/components/Footer/Footer.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { Toolbar } from '@fluentui/react-components';
+import type { JSXElement } from '@fluentui/react-components';
 import { useStyles } from './Footer.styles';
 
 export type FooterProps = {
@@ -16,7 +17,7 @@ export const Footer = ({
   rightActions,
   toolbarLables,
   children,
-}: React.PropsWithChildren<FooterProps>): JSX.Element => {
+}: React.PropsWithChildren<FooterProps>): JSXElement => {
   const styles = useStyles();
 
   return (

--- a/packages/react-contextual-pane/src/components/Header/Header.tsx
+++ b/packages/react-contextual-pane/src/components/Header/Header.tsx
@@ -5,6 +5,7 @@ import {
   Toolbar,
   ToolbarButton,
 } from '@fluentui/react-components';
+import type { JSXElement } from '@fluentui/react-components';
 import { ArrowLeftRegular, DismissRegular } from '@fluentui/react-icons';
 import { HeaderTitle } from './HeaderTitle';
 
@@ -40,7 +41,7 @@ export const Header = ({
   toolbarLabels = defaultToolbarLabels,
   onArrowBackClick,
   onDismissClick,
-}: HeaderProps): JSX.Element => {
+}: HeaderProps): JSXElement => {
   const styles = useStyles();
 
   const hasLeftConetent = Boolean(hasArrowBack || brandIcon);

--- a/packages/react-contextual-pane/src/components/Header/Header.tsx
+++ b/packages/react-contextual-pane/src/components/Header/Header.tsx
@@ -40,7 +40,7 @@ export const Header = ({
   toolbarLabels = defaultToolbarLabels,
   onArrowBackClick,
   onDismissClick,
-}: HeaderProps) => {
+}: HeaderProps): JSX.Element => {
   const styles = useStyles();
 
   const hasLeftConetent = Boolean(hasArrowBack || brandIcon);

--- a/packages/react-contextual-pane/src/components/Header/HeaderTitle.tsx
+++ b/packages/react-contextual-pane/src/components/Header/HeaderTitle.tsx
@@ -7,7 +7,7 @@ export type HeaderTitleProps = {
   caption: string;
 };
 
-export function HeaderTitle({ caption }: HeaderTitleProps) {
+export function HeaderTitle({ caption }: HeaderTitleProps): JSX.Element {
   const [titleHasEllipsis, titleRef] = useEllipsisCheck();
   const [isVisibleTooltip, setIsVisibleTooltip] = React.useState(false);
 

--- a/packages/react-contextual-pane/src/components/Header/HeaderTitle.tsx
+++ b/packages/react-contextual-pane/src/components/Header/HeaderTitle.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { Tooltip, TooltipProps } from '@fluentui/react-components';
+import type { JSXElement } from '@fluentui/react-components';
 import { useStyles } from './Header.styles';
 import { useEllipsisCheck } from '../../lib/useEllipsisCheck';
 
@@ -7,7 +8,7 @@ export type HeaderTitleProps = {
   caption: string;
 };
 
-export function HeaderTitle({ caption }: HeaderTitleProps): JSX.Element {
+export function HeaderTitle({ caption }: HeaderTitleProps): JSXElement {
   const [titleHasEllipsis, titleRef] = useEllipsisCheck();
   const [isVisibleTooltip, setIsVisibleTooltip] = React.useState(false);
 

--- a/packages/react-contextual-pane/src/lib/useEllipsisCheck.tsx
+++ b/packages/react-contextual-pane/src/lib/useEllipsisCheck.tsx
@@ -11,7 +11,8 @@ export function createResizeObserver(
   host: Window & typeof globalThis,
   setHasEllipsisState: (hasEllipsis: boolean) => void,
   element: HTMLDivElement
-) {
+  // eslint-disable-next-line no-restricted-globals
+): ResizeObserver {
   return new host.ResizeObserver(() => {
     if (timeoutId) host.clearTimeout(timeoutId);
 
@@ -44,7 +45,7 @@ export function useEllipsisCheck(): [boolean, React.RefObject<HTMLDivElement>] {
 
     resizeObserver.observe(element);
 
-    return () => {
+    return (): void => {
       resizeObserver.disconnect();
       if (timeoutId) host.clearTimeout(timeoutId);
     };

--- a/packages/react-data-grid-react-window-grid/src/components/DataGrid/renderDataGrid.tsx
+++ b/packages/react-data-grid-react-window-grid/src/components/DataGrid/renderDataGrid.tsx
@@ -3,6 +3,7 @@ import {
   renderDataGrid_unstable as renderDataGridBase,
   DataGridContextValues,
 } from '@fluentui/react-components';
+import type { JSXElement } from '@fluentui/react-components';
 import { HeaderListRefContextProvider } from '../../contexts/headerListRefContext';
 import { BodyRefContextProvider } from '../../contexts/bodyRefContext';
 import { DataGridState } from './DataGrid.types';
@@ -12,7 +13,7 @@ import { DataGridState } from './DataGrid.types';
 export const renderDataGrid_unstable = (
   state: DataGridState,
   contextValues: DataGridContextValues
-): JSX.Element => {
+): JSXElement => {
   return (
     <HeaderListRefContextProvider value={state.headerRef}>
       <BodyRefContextProvider value={state.bodyRef}>

--- a/packages/react-data-grid-react-window-grid/src/components/DataGrid/renderDataGrid.tsx
+++ b/packages/react-data-grid-react-window-grid/src/components/DataGrid/renderDataGrid.tsx
@@ -12,7 +12,7 @@ import { DataGridState } from './DataGrid.types';
 export const renderDataGrid_unstable = (
   state: DataGridState,
   contextValues: DataGridContextValues
-) => {
+): JSX.Element => {
   return (
     <HeaderListRefContextProvider value={state.headerRef}>
       <BodyRefContextProvider value={state.bodyRef}>

--- a/packages/react-data-grid-react-window-grid/src/components/DataGridBody/renderDataGridBody.tsx
+++ b/packages/react-data-grid-react-window-grid/src/components/DataGridBody/renderDataGridBody.tsx
@@ -10,7 +10,9 @@ import { dataGridBodyGridClassName } from './useDataGridBodyStyles.styles';
 /**
  * Render the final JSX of DataGridVirtualizedBody
  */
-export const renderDataGridBody_unstable = (state: DataGridBodyState) => {
+export const renderDataGridBody_unstable = (
+  state: DataGridBodyState
+): JSX.Element => {
   const { slots, slotProps } = getSlots<DataGridBodySlots>(state);
 
   return (

--- a/packages/react-data-grid-react-window-grid/src/components/DataGridBody/renderDataGridBody.tsx
+++ b/packages/react-data-grid-react-window-grid/src/components/DataGridBody/renderDataGridBody.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { getSlots } from '@fluentui/react-components';
+import type { JSXElement } from '@fluentui/react-components';
 import type {
   DataGridBodyState,
   DataGridBodySlots,
@@ -12,7 +13,7 @@ import { dataGridBodyGridClassName } from './useDataGridBodyStyles.styles';
  */
 export const renderDataGridBody_unstable = (
   state: DataGridBodyState
-): JSX.Element => {
+): JSXElement => {
   const { slots, slotProps } = getSlots<DataGridBodySlots>(state);
 
   return (

--- a/packages/react-data-grid-react-window-grid/src/components/DataGridHeaderRow/renderDataGridHeaderRow.tsx
+++ b/packages/react-data-grid-react-window-grid/src/components/DataGridHeaderRow/renderDataGridHeaderRow.tsx
@@ -15,7 +15,7 @@ export const dataGridHeaderListClassName =
  */
 export const renderDataGridHeaderRow_unstable = (
   state: DataGridHeaderRowState
-) => {
+): JSX.Element => {
   const { slots, slotProps } = getSlots<DataGridRowSlots>(state);
   const { dir } = useFluent();
   const layout = 'horizontal';

--- a/packages/react-data-grid-react-window-grid/src/components/DataGridHeaderRow/renderDataGridHeaderRow.tsx
+++ b/packages/react-data-grid-react-window-grid/src/components/DataGridHeaderRow/renderDataGridHeaderRow.tsx
@@ -4,6 +4,7 @@ import {
   useFluent,
   getSlots,
 } from '@fluentui/react-components';
+import type { JSXElement } from '@fluentui/react-components';
 import { VariableSizeList as List } from 'react-window';
 import { DataGridHeaderRowState } from './DataGridHeaderRow.types';
 
@@ -15,7 +16,7 @@ export const dataGridHeaderListClassName =
  */
 export const renderDataGridHeaderRow_unstable = (
   state: DataGridHeaderRowState
-): JSX.Element => {
+): JSXElement => {
   const { slots, slotProps } = getSlots<DataGridRowSlots>(state);
   const { dir } = useFluent();
   const layout = 'horizontal';

--- a/packages/react-data-grid-react-window-grid/src/contexts/bodyRefContext.ts
+++ b/packages/react-data-grid-react-window-grid/src/contexts/bodyRefContext.ts
@@ -10,7 +10,8 @@ const bodyRefContext: React.Context<
 export const bodyRefContextDefaultValue: React.MutableRefObject<VariableSizeGrid | null> =
   { current: null };
 
-export const useBodyRefContext = () =>
-  React.useContext(bodyRefContext) ?? bodyRefContextDefaultValue;
+export const useBodyRefContext =
+  (): React.MutableRefObject<VariableSizeGrid | null> =>
+    React.useContext(bodyRefContext) ?? bodyRefContextDefaultValue;
 
 export const BodyRefContextProvider = bodyRefContext.Provider;

--- a/packages/react-data-grid-react-window-grid/src/contexts/columnIndexContext.ts
+++ b/packages/react-data-grid-react-window-grid/src/contexts/columnIndexContext.ts
@@ -5,7 +5,7 @@ const columnIndexContext = React.createContext<number | undefined>(undefined);
 export const columnIndexContextDefaultValue: number | undefined = undefined;
 
 export const ariaColumnIndexStart = 1;
-export const useColumnIndexContext = () =>
+export const useColumnIndexContext = (): number | undefined =>
   React.useContext(columnIndexContext) ?? columnIndexContextDefaultValue;
 
 export const ColumnIndexContextProvider = columnIndexContext.Provider;

--- a/packages/react-data-grid-react-window-grid/src/contexts/headerListRefContext.ts
+++ b/packages/react-data-grid-react-window-grid/src/contexts/headerListRefContext.ts
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import { VariableSizeList } from 'react-window';
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 const headerListRefContext: React.Context<
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   React.RefObject<VariableSizeList<any> | null>
 > =
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -13,9 +13,9 @@ const headerListRefContext: React.Context<
 export const headerListRefContextDefaultValue: React.RefObject<// eslint-disable-next-line @typescript-eslint/no-explicit-any
 VariableSizeList<any> | null> = { current: null };
 
-export const useHeaderListRefContext = (): React.RefObject<
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  VariableSizeList<any>
-> => React.useContext(headerListRefContext) ?? headerListRefContextDefaultValue;
+export const useHeaderListRefContext =
+  (): React.RefObject<// eslint-disable-next-line @typescript-eslint/no-explicit-any
+  VariableSizeList<any> | null> =>
+    React.useContext(headerListRefContext) ?? headerListRefContextDefaultValue;
 
 export const HeaderListRefContextProvider = headerListRefContext.Provider;

--- a/packages/react-data-grid-react-window-grid/src/contexts/headerListRefContext.ts
+++ b/packages/react-data-grid-react-window-grid/src/contexts/headerListRefContext.ts
@@ -13,7 +13,9 @@ const headerListRefContext: React.Context<
 export const headerListRefContextDefaultValue: React.RefObject<// eslint-disable-next-line @typescript-eslint/no-explicit-any
 VariableSizeList<any> | null> = { current: null };
 
-export const useHeaderListRefContext = () =>
-  React.useContext(headerListRefContext) ?? headerListRefContextDefaultValue;
+export const useHeaderListRefContext = (): React.RefObject<
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  VariableSizeList<any>
+> => React.useContext(headerListRefContext) ?? headerListRefContextDefaultValue;
 
 export const HeaderListRefContextProvider = headerListRefContext.Provider;

--- a/packages/react-data-grid-react-window-grid/src/contexts/rowIndexContext.ts
+++ b/packages/react-data-grid-react-window-grid/src/contexts/rowIndexContext.ts
@@ -4,7 +4,7 @@ const rowIndexContext = React.createContext<number | undefined>(undefined);
 
 export const rowIndexContextDefaultValue: number | undefined = undefined;
 
-export const useRowIndexContext = () =>
+export const useRowIndexContext = (): number | undefined =>
   React.useContext(rowIndexContext) ?? rowIndexContextDefaultValue;
 
 export const RowIndexContextProvider = rowIndexContext.Provider;

--- a/packages/react-data-grid-react-window/src/components/DataGrid/renderDataGrid.tsx
+++ b/packages/react-data-grid-react-window/src/components/DataGrid/renderDataGrid.tsx
@@ -13,7 +13,7 @@ import { DataGridState } from './DataGrid.types';
 export const renderDataGrid_unstable = (
   state: DataGridState,
   contextValues: DataGridContextValues
-) => {
+): JSX.Element => {
   return (
     <HeaderRefContextProvider value={state.headerRef}>
       <BodyRefContextProvider value={state.bodyRef}>

--- a/packages/react-data-grid-react-window/src/components/DataGrid/renderDataGrid.tsx
+++ b/packages/react-data-grid-react-window/src/components/DataGrid/renderDataGrid.tsx
@@ -3,6 +3,7 @@ import {
   DataGridContextValues,
   renderDataGrid_unstable as baseRender,
 } from '@fluentui/react-components';
+import type { JSXElement } from '@fluentui/react-components';
 import { HeaderRefContextProvider } from '../../contexts/headerRefContext';
 import { BodyRefContextProvider } from '../../contexts/bodyRefContext';
 import { DataGridState } from './DataGrid.types';
@@ -13,7 +14,7 @@ import { DataGridState } from './DataGrid.types';
 export const renderDataGrid_unstable = (
   state: DataGridState,
   contextValues: DataGridContextValues
-): JSX.Element => {
+): JSXElement => {
   return (
     <HeaderRefContextProvider value={state.headerRef}>
       <BodyRefContextProvider value={state.bodyRef}>

--- a/packages/react-data-grid-react-window/src/components/DataGridBody/renderDataGridBody.tsx
+++ b/packages/react-data-grid-react-window/src/components/DataGridBody/renderDataGridBody.tsx
@@ -9,7 +9,9 @@ import { FixedSizeList as List } from 'react-window';
 /**
  * Render the final JSX of DataGridVirtualizedBody
  */
-export const renderDataGridBody_unstable = (state: DataGridBodyState) => {
+export const renderDataGridBody_unstable = (
+  state: DataGridBodyState
+): JSX.Element => {
   const { slots, slotProps } = getSlots<DataGridBodySlots>(state);
   const { dir } = useFluent();
 

--- a/packages/react-data-grid-react-window/src/components/DataGridBody/renderDataGridBody.tsx
+++ b/packages/react-data-grid-react-window/src/components/DataGridBody/renderDataGridBody.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { getSlots, useFluent } from '@fluentui/react-components';
+import type { JSXElement } from '@fluentui/react-components';
 import type {
   DataGridBodyState,
   DataGridBodySlots,
@@ -11,7 +12,7 @@ import { FixedSizeList as List } from 'react-window';
  */
 export const renderDataGridBody_unstable = (
   state: DataGridBodyState
-): JSX.Element => {
+): JSXElement => {
   const { slots, slotProps } = getSlots<DataGridBodySlots>(state);
   const { dir } = useFluent();
 

--- a/packages/react-data-grid-react-window/src/contexts/bodyRefContext.ts
+++ b/packages/react-data-grid-react-window/src/contexts/bodyRefContext.ts
@@ -9,7 +9,8 @@ const bodyRefContext: React.Context<
 export const bodyRefContextDefaultValue: React.MutableRefObject<HTMLElement | null> =
   { current: null };
 
-export const useBodyRefContext = () =>
-  React.useContext(bodyRefContext) ?? bodyRefContextDefaultValue;
+export const useBodyRefContext =
+  (): React.MutableRefObject<HTMLElement | null> =>
+    React.useContext(bodyRefContext) ?? bodyRefContextDefaultValue;
 
 export const BodyRefContextProvider = bodyRefContext.Provider;

--- a/packages/react-data-grid-react-window/src/contexts/headerRefContext.ts
+++ b/packages/react-data-grid-react-window/src/contexts/headerRefContext.ts
@@ -9,7 +9,8 @@ const headerRefContext: React.Context<
 export const headerRefContextDefaultValue: React.MutableRefObject<HTMLElement | null> =
   { current: null };
 
-export const useHeaderRefContext = () =>
-  React.useContext(headerRefContext) ?? headerRefContextDefaultValue;
+export const useHeaderRefContext =
+  (): React.MutableRefObject<HTMLElement | null> =>
+    React.useContext(headerRefContext) ?? headerRefContextDefaultValue;
 
 export const HeaderRefContextProvider = headerRefContext.Provider;

--- a/packages/react-data-grid-react-window/src/contexts/rowIndexContext.ts
+++ b/packages/react-data-grid-react-window/src/contexts/rowIndexContext.ts
@@ -4,7 +4,7 @@ const rowIndexContext = React.createContext<number | undefined>(undefined);
 
 export const tableRowIndexContextDefaultValue = undefined;
 
-export const useTableRowIndexContext = () =>
+export const useTableRowIndexContext = (): number | undefined =>
   React.useContext(rowIndexContext) ?? tableRowIndexContextDefaultValue;
 
 export const TableRowIndexContextProvider = rowIndexContext.Provider;

--- a/packages/react-draggable-dialog/src/contexts/DraggableDialogContext.ts
+++ b/packages/react-draggable-dialog/src/contexts/DraggableDialogContext.ts
@@ -47,7 +47,7 @@ const draggableDialogContext = React.createContext<DraggableDialogContextValue>(
   draggableDialogContextDefaultValue
 );
 
-export const useDraggableDialogContext = () => {
+export const useDraggableDialogContext = (): DraggableDialogContextValue => {
   return (
     React.useContext(draggableDialogContext) ??
     draggableDialogContextDefaultValue

--- a/packages/react-draggable-dialog/src/utils/assertDialogParent.ts
+++ b/packages/react-draggable-dialog/src/utils/assertDialogParent.ts
@@ -1,7 +1,7 @@
 export const assertDialogParent = (
   hasParent: boolean,
   componentName: string
-) => {
+): void => {
   if (process.env.NODE_ENV !== 'production') {
     if (!hasParent) {
       console.error(

--- a/packages/react-gamepad-navigation/src/core/GamepadEvents.ts
+++ b/packages/react-gamepad-navigation/src/core/GamepadEvents.ts
@@ -30,7 +30,7 @@ export const emitSyntheticKeyboardEvent = (
   key: KeyboardKey,
   bubbles: boolean,
   targetDocument: Document
-) => {
+): void => {
   const activeElement = targetDocument.activeElement;
   const keyboardEvent = new KeyboardEvent(event, {
     key: key,
@@ -55,7 +55,7 @@ export const emitSyntheticMouseEvent = (
   event: 'mousedown' | 'mouseup' | 'click',
   bubbles: boolean,
   targetDocument: Document
-) => {
+): void => {
   const activeElement = targetDocument.activeElement;
   const mouseEvent = new MouseEvent(event, {
     bubbles,
@@ -85,7 +85,7 @@ export const emitSyntheticMouseEvent = (
 export const emitSyntheticMoverMoveFocusEvent = (
   key: MoverKey,
   targetDocument: Document
-) => {
+): void => {
   const activeElement = targetDocument.activeElement;
   if (isComboboxElement(activeElement)) {
     const button = getMoverKeyToKeyboardKeyMapping(key);
@@ -98,7 +98,7 @@ export const emitSyntheticMoverMoveFocusEvent = (
 export const emitSyntheticGroupperMoveFocusEvent = (
   action: KeyboardKey,
   targetDocument: Document
-) => {
+): void => {
   const activeElement = targetDocument.activeElement;
   if (action === KeyboardKey.Enter) {
     // Note: GroupperMoveFocusActions.Enter has no effect on components

--- a/packages/react-gamepad-navigation/src/core/GamepadMappings.ts
+++ b/packages/react-gamepad-navigation/src/core/GamepadMappings.ts
@@ -40,7 +40,8 @@ const gamepadButtonToControllerMappingKey: Map<
 
 export const getControllerMappingKeyFromGamepadButton = (
   button: GamepadButton
-) => gamepadButtonToControllerMappingKey.get(button);
+): keyof ControllerMapping | undefined =>
+  gamepadButtonToControllerMappingKey.get(button);
 
 export const defaultMapping: ControllerMapping = {
   a: { index: 0, isButton: true },
@@ -61,7 +62,7 @@ export const defaultMapping: ControllerMapping = {
 
 let gamepadMappings: ControllerMapping | undefined;
 
-export const getGamepadMappings = () => {
+export const getGamepadMappings = (): ControllerMapping => {
   if (gamepadMappings) {
     return gamepadMappings;
   }
@@ -78,5 +79,5 @@ const moverKeyToKeyboardKeyMapping: Map<MoverKey, KeyboardKey> = new Map([
   [MoverKeys.ArrowDown, KeyboardKey.ArrowDown],
 ]);
 
-export const getMoverKeyToKeyboardKeyMapping = (key: MoverKey) =>
+export const getMoverKeyToKeyboardKeyMapping = (key: MoverKey): KeyboardKey =>
   moverKeyToKeyboardKeyMapping.get(key) ?? KeyboardKey.None;

--- a/packages/react-gamepad-navigation/src/core/GamepadUtils.ts
+++ b/packages/react-gamepad-navigation/src/core/GamepadUtils.ts
@@ -1,21 +1,30 @@
-import { WindowWithFluentGPNShadowDOMAPI } from '../types/FluentGPNShadowDOMAPI';
+import {
+  FluentGPNShadowDOMAPI,
+  WindowWithFluentGPNShadowDOMAPI,
+} from '../types/FluentGPNShadowDOMAPI';
 import { consolePrefix } from './Constants';
 
 export type TimeoutId = number | undefined;
 export type IntervalId = number | undefined;
 
-export const shouldSubmitForm = (element: Element | null | undefined) =>
+export const shouldSubmitForm = (
+  element: Element | null | undefined
+): boolean =>
   element instanceof HTMLInputElement &&
   (element.type === 'password' ||
     element.type === 'text' ||
     element.type === 'email' ||
     element.type === 'tel');
 
-export const isComboboxElement = (element: Element | null | undefined) => {
+export const isComboboxElement = (
+  element: Element | null | undefined
+): boolean => {
   return element?.getAttribute('role') === 'combobox';
 };
 
-export const isMenuItemElement = (element: Element | null | undefined) => {
+export const isMenuItemElement = (
+  element: Element | null | undefined
+): boolean => {
   return element?.getAttribute('role') === 'menuitem';
 };
 
@@ -27,7 +36,9 @@ export const isRadioElement = (
   );
 };
 
-export const getShadowDOMAPI = (targetDocument: Document | undefined) => {
+export const getShadowDOMAPI = (
+  targetDocument: Document | undefined
+): FluentGPNShadowDOMAPI | undefined => {
   const defaultView = targetDocument?.defaultView;
   const shadowDOMAPI = (defaultView as WindowWithFluentGPNShadowDOMAPI)
     ?.__FluentGPNShadowDOMAPI;

--- a/packages/react-gamepad-navigation/src/core/InputManager.ts
+++ b/packages/react-gamepad-navigation/src/core/InputManager.ts
@@ -306,13 +306,13 @@ let inputStack: InputStackItem[] = [];
  * Clears any ongoing input direction repetitions.
  * This is typically used to reset the state of repeated navigations.
  */
-export const clearDirectionRepeats = (targetDocument: Document) => {
+export const clearDirectionRepeats = (targetDocument: Document): void => {
   targetDocument.defaultView?.clearTimeout(directionDelayTimer);
   targetDocument.defaultView?.clearInterval(directionRepeatInterval);
   directionRepeatCount = 0;
 };
 
-export const clearDirectionalInputStack = () => {
+export const clearDirectionalInputStack = (): void => {
   inputStack.length = 0;
 };
 
@@ -325,7 +325,7 @@ export const clearDirectionalInputStack = () => {
 export const handleGamepadDisconnect = (
   targetDocument: Document,
   gamepadId: number
-) => {
+): void => {
   const previousDirection = getCurrentFocusDirection();
 
   // Filter out all entries with the disconnected gamepadId

--- a/packages/react-gamepad-navigation/src/core/InputProcessor.ts
+++ b/packages/react-gamepad-navigation/src/core/InputProcessor.ts
@@ -95,7 +95,7 @@ export const handleGamepadInput = (
   gamepadMappings: ControllerMapping,
   gamepadState: GamepadState,
   targetDocument: Document
-) => {
+): void => {
   /*
         Buttons
     */

--- a/packages/react-gamepad-navigation/src/core/NavigationManager.ts
+++ b/packages/react-gamepad-navigation/src/core/NavigationManager.ts
@@ -9,7 +9,7 @@ import { emitSyntheticMoverMoveFocusEvent } from './GamepadEvents';
 export const navigate = (
   direction: FocusDirection,
   targetDocument: Document
-) => {
+): void => {
   const activeElement = targetDocument.activeElement;
   const finalDirection = !activeElement ? FocusDirection.None : direction;
 

--- a/packages/react-gamepad-navigation/src/hooks/useGamepadNavigation.ts
+++ b/packages/react-gamepad-navigation/src/hooks/useGamepadNavigation.ts
@@ -66,7 +66,8 @@ const updateGamepadState = (targetDocument: Document) => {
 };
 
 let windowFocused = true;
-export const shouldPollGamepads = () => windowFocused && isPollingEnabled();
+export const shouldPollGamepads = (): boolean =>
+  windowFocused && isPollingEnabled();
 
 let scanInterval: IntervalId;
 
@@ -190,7 +191,9 @@ export type GamepadNavigationOptions = {
  * @param options {GamepadNavigationOptions} - The options to use for gamepad navigation
  * @returns removeEventListeners function
  */
-export const useGamepadNavigation = (options: GamepadNavigationOptions) => {
+export const useGamepadNavigation = (
+  options: GamepadNavigationOptions
+): (() => void) => {
   const { targetDocument } = useFluent();
   const defaultView = targetDocument?.defaultView;
   let shadowDOMAPI = getShadowDOMAPI(targetDocument);

--- a/packages/react-interactive-tab/src/components/InteractiveTab/renderInteractiveTab.tsx
+++ b/packages/react-interactive-tab/src/components/InteractiveTab/renderInteractiveTab.tsx
@@ -13,7 +13,9 @@ import type {
 /**
  * Render the final JSX of InteractiveTab
  */
-export const renderInteractiveTab_unstable = (state: InteractiveTabState) => {
+export const renderInteractiveTab_unstable = (
+  state: InteractiveTabState
+): JSX.Element => {
   assertSlots<InteractiveTabInternalSlots>(state);
 
   return (

--- a/packages/react-interactive-tab/src/components/InteractiveTab/renderInteractiveTab.tsx
+++ b/packages/react-interactive-tab/src/components/InteractiveTab/renderInteractiveTab.tsx
@@ -5,6 +5,7 @@
 import { createElement } from '@fluentui/react-jsx-runtime';
 
 import { assertSlots } from '@fluentui/react-components';
+import type { JSXElement } from '@fluentui/react-components';
 import type {
   InteractiveTabState,
   InteractiveTabInternalSlots,
@@ -15,7 +16,7 @@ import type {
  */
 export const renderInteractiveTab_unstable = (
   state: InteractiveTabState
-): JSX.Element => {
+): JSXElement => {
   assertSlots<InteractiveTabInternalSlots>(state);
 
   return (

--- a/packages/react-keytips/src/components/Keytip/Keytip.tsx
+++ b/packages/react-keytips/src/components/Keytip/Keytip.tsx
@@ -8,7 +8,7 @@ import { useKeytipStyles_unstable } from './useKeytipStyles.styles';
  * is not supposed to be used directly, but is used by the Keytips component.
  *
  */
-export const Keytip = (props: KeytipProps) => {
+export const Keytip = (props: KeytipProps): JSX.Element | null => {
   const state = useKeytip_unstable(props);
   useKeytipStyles_unstable(state);
 

--- a/packages/react-keytips/src/components/Keytip/Keytip.tsx
+++ b/packages/react-keytips/src/components/Keytip/Keytip.tsx
@@ -1,3 +1,4 @@
+import type { JSXElement } from '@fluentui/react-components';
 import { useKeytip_unstable } from './useKeytip';
 import { renderKeytip_unstable } from './renderKeytip';
 import type { KeytipProps } from './Keytip.types';
@@ -8,7 +9,7 @@ import { useKeytipStyles_unstable } from './useKeytipStyles.styles';
  * is not supposed to be used directly, but is used by the Keytips component.
  *
  */
-export const Keytip = (props: KeytipProps): JSX.Element | null => {
+export const Keytip = (props: KeytipProps): JSXElement | null => {
   const state = useKeytip_unstable(props);
   useKeytipStyles_unstable(state);
 

--- a/packages/react-keytips/src/components/Keytip/renderKeytip.tsx
+++ b/packages/react-keytips/src/components/Keytip/renderKeytip.tsx
@@ -1,6 +1,7 @@
 /** @jsxRuntime classic */
 /** @jsx createElement */
 
+import type { JSXElement } from '@fluentui/react-components';
 import type { KeytipSlots, KeytipState } from './Keytip.types';
 import { assertSlots } from '@fluentui/react-utilities';
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -11,7 +12,7 @@ import { createElement } from '@fluentui/react-jsx-runtime';
  */
 export const renderKeytip_unstable = (
   state: KeytipState
-): JSX.Element | null => {
+): JSXElement | null => {
   assertSlots<KeytipSlots>(state);
   if (!state.shouldRenderKeytip) return null;
   return <state.content>{state.content.children}</state.content>;

--- a/packages/react-keytips/src/components/Keytip/renderKeytip.tsx
+++ b/packages/react-keytips/src/components/Keytip/renderKeytip.tsx
@@ -9,7 +9,9 @@ import { createElement } from '@fluentui/react-jsx-runtime';
 /**
  * Render the final JSX of Keytip
  */
-export const renderKeytip_unstable = (state: KeytipState) => {
+export const renderKeytip_unstable = (
+  state: KeytipState
+): JSX.Element | null => {
   assertSlots<KeytipSlots>(state);
   if (!state.shouldRenderKeytip) return null;
   return <state.content>{state.content.children}</state.content>;

--- a/packages/react-keytips/src/components/Keytips/renderKeytips.tsx
+++ b/packages/react-keytips/src/components/Keytips/renderKeytips.tsx
@@ -16,7 +16,7 @@ const useStyles = makeStyles({
   },
 });
 
-export const renderKeytips_unstable = (state: KeytipsState) => {
+export const renderKeytips_unstable = (state: KeytipsState): JSX.Element => {
   assertSlots<KeytipsSlots>(state);
   const classes = useStyles();
 

--- a/packages/react-keytips/src/components/Keytips/renderKeytips.tsx
+++ b/packages/react-keytips/src/components/Keytips/renderKeytips.tsx
@@ -5,6 +5,7 @@
 import { createElement } from '@fluentui/react-jsx-runtime';
 import type { KeytipsState, KeytipsSlots } from './Keytips.types';
 import { Portal, makeStyles, assertSlots } from '@fluentui/react-components';
+import type { JSXElement } from '@fluentui/react-components';
 import { KTP_ROOT_ID, VISUALLY_HIDDEN_STYLES } from '../../constants';
 /**
  * Render the final JSX of Keytips
@@ -16,7 +17,7 @@ const useStyles = makeStyles({
   },
 });
 
-export const renderKeytips_unstable = (state: KeytipsState): JSX.Element => {
+export const renderKeytips_unstable = (state: KeytipsState): JSXElement => {
   assertSlots<KeytipsSlots>(state);
   const classes = useStyles();
 

--- a/packages/react-keytips/src/hooks/useEventService.ts
+++ b/packages/react-keytips/src/hooks/useEventService.ts
@@ -31,7 +31,18 @@ function createEventHandler<T>(
   };
 }
 
-export function useEventService() {
+export function useEventService(): {
+  dispatch: <T extends EventType>(
+    eventName: T,
+    payload?: PayloadDefinition[T]
+  ) => void;
+  subscribe: <T extends EventType>(
+    event: T,
+    handler: (payload: PayloadDefinition[T]) => void
+  ) => () => void;
+  reset: () => void;
+  abort: () => void;
+} {
   const { targetDocument } = useFluent();
   const controller = React.useRef<AbortController | null>(
     new AbortController()

--- a/packages/react-keytips/src/hooks/useHotkeys/parseHotkey.ts
+++ b/packages/react-keytips/src/hooks/useHotkeys/parseHotkey.ts
@@ -1,6 +1,13 @@
 const MODIFIERS = new Set(['shift', 'alt', 'control', 'meta', 'mod']);
 
-export function parseHotkey(hotkey: string) {
+export function parseHotkey(hotkey: string): {
+  key: string | undefined;
+  alt: boolean;
+  ctrl: boolean;
+  shift: boolean;
+  meta: boolean;
+  mod: boolean;
+} {
   const keys = hotkey.toLowerCase().split('+');
 
   const modifiers = {

--- a/packages/react-keytips/src/hooks/useHotkeys/useHotkeys.ts
+++ b/packages/react-keytips/src/hooks/useHotkeys/useHotkeys.ts
@@ -8,7 +8,7 @@ import { parseHotkey } from './parseHotkey';
 export const useHotkeys = (
   hotkeys: Hotkey[],
   options?: { invokeEvent?: KeytipsProps['invokeEvent']; target?: Document }
-) => {
+): void => {
   const { targetDocument } = useFluent();
   const { target, invokeEvent = 'keydown' } = options ?? {};
   const [setDelayTimeout, clearDelayTimeout] = useTimeout();

--- a/packages/react-keytips/src/hooks/useIsMacOS.ts
+++ b/packages/react-keytips/src/hooks/useIsMacOS.ts
@@ -1,6 +1,6 @@
 import { useFluent } from '@fluentui/react-components';
 
-export function useIsMacOS() {
+export function useIsMacOS(): boolean {
   const { targetDocument } = useFluent();
   const platform =
     targetDocument?.defaultView?.navigator?.platform || 'Windows';

--- a/packages/react-keytips/src/hooks/useKeytipRef.ts
+++ b/packages/react-keytips/src/hooks/useKeytipRef.ts
@@ -6,7 +6,7 @@ import { usePrevious } from '@fluentui/react-utilities';
 import type { KeytipProps } from '../components/Keytip';
 import { sequencesToID } from '../utilities/index';
 
-const isEqualArray = (a: string[], b: string[]) => {
+const isEqualArray = (a: string[], b: string[]): boolean => {
   return a.length === b.length && a.every((v, i) => v === b[i]);
 };
 
@@ -16,7 +16,7 @@ export const useKeytipRef = <
   content,
   truncated = true,
   ...keytip
-}: KeytipProps) => {
+}: KeytipProps): React.Dispatch<React.SetStateAction<T | null>> => {
   const { targetDocument } = useFluent();
   const [node, setNode] = React.useState<T | null>(null);
   const { register, unregister, update } = useKeytipsManager();
@@ -72,7 +72,7 @@ export const useKeytipRef = <
     }
 
     register(ktp);
-    return () => {
+    return (): void => {
       unregister(ktp.uniqueId);
     };
   }, [node]);

--- a/packages/react-keytips/src/hooks/useKeytipsManager.ts
+++ b/packages/react-keytips/src/hooks/useKeytipsManager.ts
@@ -3,7 +3,15 @@ import { useEventService } from './useEventService';
 import { EVENTS } from '../constants';
 import type { KeytipProps } from '../Keytip';
 
-export function useKeytipsManager() {
+export function useKeytipsManager(): {
+  enterKeytipMode: () => void;
+  exitKeytipMode: () => void;
+  update: (keytip: KeytipProps & { uniqueId: string }) => void;
+  register: (keytip: KeytipProps) => string;
+  unregister: (uniqueId: string) => void;
+  getKeytips: () => Record<string, KeytipProps>;
+  getKeytipsModeStatus: () => boolean;
+} {
   const { dispatch, subscribe, reset } = useEventService();
   const id = React.useId();
   const keytips = React.useRef<Record<string, KeytipProps>>({});

--- a/packages/react-keytips/src/hooks/useTree.ts
+++ b/packages/react-keytips/src/hooks/useTree.ts
@@ -26,7 +26,20 @@ const getParentID = (sequence: string[]): string =>
     ? KTP_ROOT_ID
     : sequencesToID(sequence.slice(0, sequence.length - 1));
 
-export function useTree() {
+export function useTree(): {
+  nodeMap: React.MutableRefObject<Map<string, KeytipTreeNode>>;
+  addNode: (newNode: KeytipWithId) => void;
+  getNode: (id: string) => KeytipTreeNode | undefined;
+  updateNode: (keytip: KeytipWithId) => void;
+  root: KeytipTreeNode;
+  currentKeytip: React.MutableRefObject<KeytipTreeNode | undefined>;
+  getMatchingNode: (sequence: string) => KeytipTreeNode | undefined;
+  getPartiallyMatched: (sequence: string) => (KeytipTreeNode | undefined)[];
+  getChildren: (node?: KeytipTreeNode) => string[];
+  removeNode: (id: string) => void;
+  isCurrentKeytipParent: (keytip: KeytipProps) => boolean;
+  getBack: () => void;
+} {
   const { targetDocument } = useFluent();
   const root: KeytipTreeNode = React.useMemo(
     () => ({

--- a/packages/react-keytips/src/utilities/omit.ts
+++ b/packages/react-keytips/src/utilities/omit.ts
@@ -1,7 +1,8 @@
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const omit = <T extends Record<string, any>, K extends keyof T>(
   obj: T,
   keys: K[]
-) => {
+): Omit<T, K> => {
   return Object.keys(obj).reduce((result, key) => {
     if (!keys.includes(key as K)) {
       (result as T)[key as K] = obj[key];

--- a/packages/react-resize-handle/src/hooks/useKeyboardHandler.ts
+++ b/packages/react-resize-handle/src/hooks/useKeyboardHandler.ts
@@ -50,7 +50,12 @@ function isSupportedKey(
   );
 }
 
-export const useKeyboardHandler = (options: UseKeyboardHandlerOptions) => {
+export const useKeyboardHandler = (
+  options: UseKeyboardHandlerOptions
+): {
+  attachHandlers: (node: HTMLElement) => void;
+  detachHandlers: (node: HTMLElement) => void;
+} => {
   const { onValueChange, growDirection, getCurrentValue, unitHandle } = options;
   const { dir } = useFluent();
 

--- a/packages/react-resize-handle/src/hooks/useMouseHandler.ts
+++ b/packages/react-resize-handle/src/hooks/useMouseHandler.ts
@@ -21,7 +21,10 @@ export type UseMouseHandlerParams = {
   unitHandle: UnitHandle;
 };
 
-export function useMouseHandler(params: UseMouseHandlerParams) {
+export function useMouseHandler(params: UseMouseHandlerParams): {
+  attachHandlers: (node: HTMLElement) => void;
+  detachHandlers: (node: HTMLElement) => void;
+} {
   const { targetDocument, dir } = useFluent();
   const targetWindow = targetDocument?.defaultView;
 

--- a/packages/react-resize-handle/src/hooks/useResizeHandle.component-browser-spec.tsx
+++ b/packages/react-resize-handle/src/hooks/useResizeHandle.component-browser-spec.tsx
@@ -16,6 +16,7 @@ import {
 test.use({ viewport: { width: 500, height: 500 } });
 
 type PwMountFn = <HooksConfig>(
+  // eslint-disable-next-line @typescript-eslint/no-restricted-types
   component: React.JSX.Element,
   options?: PwMountOptions<HooksConfig>
 ) => Promise<PwMountResult>;

--- a/packages/react-resize-handle/src/hooks/useResizeHandle.ts
+++ b/packages/react-resize-handle/src/hooks/useResizeHandle.ts
@@ -97,7 +97,15 @@ const DEFAULT_GET_A11_VALUE_TEXT: UseResizeHandleParams['getA11ValueText'] = (
   unit
 ) => (value === UNMEASURED ? undefined : `${value.toFixed(0)}${unit}`);
 
-export const useResizeHandle = (params: UseResizeHandleParams) => {
+export const useResizeHandle = (
+  params: UseResizeHandleParams
+): {
+  setValue: (value: number) => void;
+  elementRef: React.RefCallback<HTMLElement>;
+  handleRef: React.RefCallback<HTMLElement>;
+  wrapperRef: React.RefCallback<HTMLElement>;
+  growDirection: GrowDirection;
+} => {
   const {
     growDirection,
     variableName,

--- a/packages/react-resize-handle/src/utils/clamp.ts
+++ b/packages/react-resize-handle/src/utils/clamp.ts
@@ -6,6 +6,6 @@
  * @param max - The maximum value of the range.
  * @returns The clamped value.
  */
-export function clamp(value: number, min: number, max: number) {
+export function clamp(value: number, min: number, max: number): number {
   return Math.max(Math.min(value, max), min);
 }

--- a/packages/react-themeless-provider/package.json
+++ b/packages/react-themeless-provider/package.json
@@ -11,7 +11,7 @@
   "peerDependencies": {
     "@fluentui/react-components": ">=9.70.0 <10.0.0",
     "@fluentui/react-icons": ">=2.0.204 <3.0.0",
-    "@fluentui/react-shared-contexts": ">=9.70.0 <10.0.0",
+    "@fluentui/react-shared-contexts": ">=9.7.2 <10.0.0",
     "@types/react": ">=16.8.0 <19.0.0",
     "react": ">=16.8.0 <19.0.0"
   }

--- a/packages/react-themeless-provider/package.json
+++ b/packages/react-themeless-provider/package.json
@@ -11,7 +11,7 @@
   "peerDependencies": {
     "@fluentui/react-components": ">=9.70.0 <10.0.0",
     "@fluentui/react-icons": ">=2.0.204 <3.0.0",
-    "@fluentui/react-shared-contexts": ">=9.7.2 <10.0.0",
+    "@fluentui/react-shared-contexts": ">=9.70.0 <10.0.0",
     "@types/react": ">=16.8.0 <19.0.0",
     "react": ">=16.8.0 <19.0.0"
   }

--- a/packages/react-themeless-provider/src/components/ThemelessFluentProvider/renderThemelessFluentProvider.tsx
+++ b/packages/react-themeless-provider/src/components/ThemelessFluentProvider/renderThemelessFluentProvider.tsx
@@ -4,6 +4,7 @@
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { createElement, Fragment } from '@fluentui/react-jsx-runtime';
 import { assertSlots } from '@fluentui/react-components';
+import type { JSXElement } from '@fluentui/react-components';
 import { TextDirectionProvider } from '@griffel/react';
 import {
   OverridesProvider_unstable as OverridesProvider,
@@ -25,7 +26,7 @@ import { IconDirectionContextProvider } from '@fluentui/react-icons';
 export const renderThemelessFluentProvider_unstable = (
   state: FluentProviderState,
   contextValues: FluentProviderContextValues
-): JSX.Element => {
+): JSXElement => {
   assertSlots<FluentProviderSlots>(state);
 
   // Typescript (vscode) incorrectly references the FluentProviderProps.customStyleHooks_unstable

--- a/packages/react-themeless-provider/src/components/ThemelessFluentProvider/renderThemelessFluentProvider.tsx
+++ b/packages/react-themeless-provider/src/components/ThemelessFluentProvider/renderThemelessFluentProvider.tsx
@@ -25,7 +25,7 @@ import { IconDirectionContextProvider } from '@fluentui/react-icons';
 export const renderThemelessFluentProvider_unstable = (
   state: FluentProviderState,
   contextValues: FluentProviderContextValues
-) => {
+): JSX.Element => {
   assertSlots<FluentProviderSlots>(state);
 
   // Typescript (vscode) incorrectly references the FluentProviderProps.customStyleHooks_unstable

--- a/packages/react-tree-grid/src/components/TreeGridRow/useTreeGridRowStyles.styles.ts
+++ b/packages/react-tree-grid/src/components/TreeGridRow/useTreeGridRowStyles.styles.ts
@@ -10,5 +10,5 @@ const useResetStyles = makeResetStyles({
   ...createFocusOutlineStyle(),
 });
 
-export const useTreeGridRowStyles = () =>
+export const useTreeGridRowStyles = (): string =>
   mergeClasses('fui-TreeGridRow', useResetStyles());

--- a/packages/react-tree-grid/src/contexts/TreeGridRowContext.ts
+++ b/packages/react-tree-grid/src/contexts/TreeGridRowContext.ts
@@ -28,7 +28,7 @@ const TreeGridRowContext = React.createContext<
 
 export const { Provider: TreeGridRowProvider } = TreeGridRowContext;
 
-export const useTreeGridRowContext = () =>
+export const useTreeGridRowContext = (): TreeGridRowContextValue =>
   React.useContext(TreeGridRowContext) ?? defaultTreeGridRowContextValue;
 
 export const useTreeGridRowContextValue = (

--- a/packages/react-tree-grid/src/hooks/useFindParentRow.ts
+++ b/packages/react-tree-grid/src/hooks/useFindParentRow.ts
@@ -4,7 +4,9 @@ import { useFocusFinders } from '@fluentui/react-components';
 /**
  * returns a method to find the parent row of the current row
  */
-export const useFindParentRow = () => {
+export const useFindParentRow = (): ((
+  currentRow: HTMLElement
+) => HTMLElement | null) => {
   const { findPrevFocusable } = useFocusFinders();
   return React.useCallback(
     (currentRow: HTMLElement): HTMLElement | null => {

--- a/packages/react-tree-grid/stories/EmailInbox.stories.tsx
+++ b/packages/react-tree-grid/stories/EmailInbox.stories.tsx
@@ -139,7 +139,7 @@ type EmailProps = {
   subject: React.ReactNode;
   summary: React.ReactNode;
   email: string;
-  replies?: Slot<{ children?: React.ReactNode }>;
+  replies?: Slot<typeof React.Fragment>;
 };
 
 const Email = (props: EmailProps) => {

--- a/packages/react-tree-grid/stories/EmailInbox.stories.tsx
+++ b/packages/react-tree-grid/stories/EmailInbox.stories.tsx
@@ -139,7 +139,7 @@ type EmailProps = {
   subject: React.ReactNode;
   summary: React.ReactNode;
   email: string;
-  replies?: Slot<typeof React.Fragment>;
+  replies?: Slot<{ children?: React.ReactNode }>;
 };
 
 const Email = (props: EmailProps) => {

--- a/packages/react-virtualizer/package.json
+++ b/packages/react-virtualizer/package.json
@@ -14,7 +14,7 @@
     "jsonc-eslint-parser": "2.4.0"
   },
   "peerDependencies": {
-    "@fluentui/react-shared-contexts": ">=9.7.2 <10.0.0",
+    "@fluentui/react-shared-contexts": ">=9.70.0 <10.0.0",
     "@types/react": ">=16.8.0 <19.0.0",
     "@types/react-dom": ">=16.9.0 <19.0.0",
     "react": ">=16.8.0 <19.0.0",

--- a/packages/react-virtualizer/package.json
+++ b/packages/react-virtualizer/package.json
@@ -14,7 +14,7 @@
     "jsonc-eslint-parser": "2.4.0"
   },
   "peerDependencies": {
-    "@fluentui/react-shared-contexts": ">=9.70.0 <10.0.0",
+    "@fluentui/react-shared-contexts": ">=9.7.2 <10.0.0",
     "@types/react": ">=16.8.0 <19.0.0",
     "@types/react-dom": ">=16.9.0 <19.0.0",
     "react": ">=16.8.0 <19.0.0",

--- a/packages/react-virtualizer/src/components/Virtualizer/renderVirtualizer.tsx
+++ b/packages/react-virtualizer/src/components/Virtualizer/renderVirtualizer.tsx
@@ -5,8 +5,11 @@ import * as React from 'react';
 import type { VirtualizerSlots, VirtualizerState } from './Virtualizer.types';
 
 import { assertSlots } from '@fluentui/react-utilities';
+import type { JSXElement } from '@fluentui/react-utilities';
 
-export const renderVirtualizer_unstable = (state: VirtualizerState) => {
+export const renderVirtualizer_unstable = (
+  state: VirtualizerState
+): JSXElement => {
   assertSlots<VirtualizerSlots>(state);
   return (
     <React.Fragment>
@@ -27,7 +30,7 @@ export const renderVirtualizer_unstable = (state: VirtualizerState) => {
 export const renderVirtualizerChildPlaceholder = (
   child: React.ReactNode,
   index: number
-) => {
+): JSXElement => {
   return (
     <React.Suspense
       key={`fui-virtualizer-placeholder-${index}`}

--- a/packages/react-virtualizer/src/components/VirtualizerScrollView/renderVirtualizerScrollView.tsx
+++ b/packages/react-virtualizer/src/components/VirtualizerScrollView/renderVirtualizerScrollView.tsx
@@ -11,7 +11,7 @@ import { renderVirtualizer_unstable } from '../Virtualizer/renderVirtualizer';
 
 export const renderVirtualizerScrollView_unstable = (
   state: VirtualizerScrollViewState
-) => {
+): JSX.Element => {
   assertSlots<VirtualizerScrollViewSlots>(state);
 
   return <state.container>{renderVirtualizer_unstable(state)}</state.container>;

--- a/packages/react-virtualizer/src/components/VirtualizerScrollView/renderVirtualizerScrollView.tsx
+++ b/packages/react-virtualizer/src/components/VirtualizerScrollView/renderVirtualizerScrollView.tsx
@@ -7,11 +7,12 @@ import type {
 } from './VirtualizerScrollView.types';
 
 import { assertSlots } from '@fluentui/react-utilities';
+import type { JSXElement } from '@fluentui/react-utilities';
 import { renderVirtualizer_unstable } from '../Virtualizer/renderVirtualizer';
 
 export const renderVirtualizerScrollView_unstable = (
   state: VirtualizerScrollViewState
-): JSX.Element => {
+): JSXElement => {
   assertSlots<VirtualizerScrollViewSlots>(state);
 
   return <state.container>{renderVirtualizer_unstable(state)}</state.container>;

--- a/packages/react-virtualizer/src/components/VirtualizerScrollViewDynamic/renderVirtualizerScrollViewDynamic.tsx
+++ b/packages/react-virtualizer/src/components/VirtualizerScrollViewDynamic/renderVirtualizerScrollViewDynamic.tsx
@@ -1,7 +1,7 @@
 /** @jsxRuntime classic */
 /** @jsx createElement */
 import { createElement } from '@fluentui/react-jsx-runtime';
-import { assertSlots } from '@fluentui/react-utilities';
+import { assertSlots, JSXElement } from '@fluentui/react-utilities';
 import {
   VirtualizerScrollViewDynamicSlots,
   VirtualizerScrollViewDynamicState,
@@ -10,7 +10,7 @@ import { renderVirtualizer_unstable } from '../Virtualizer/renderVirtualizer';
 
 export const renderVirtualizerScrollViewDynamic_unstable = (
   state: VirtualizerScrollViewDynamicState
-) => {
+): JSXElement => {
   assertSlots<VirtualizerScrollViewDynamicSlots>(state);
   return <state.container>{renderVirtualizer_unstable(state)}</state.container>;
 };

--- a/packages/react-virtualizer/src/hooks/useDynamicPagination.ts
+++ b/packages/react-virtualizer/src/hooks/useDynamicPagination.ts
@@ -11,7 +11,7 @@ import { useTimeout } from '@fluentui/react-utilities';
 export const useDynamicVirtualizerPagination = (
   virtualizerProps: VirtualizerDynamicPaginationProps,
   paginationEnabled = true
-) => {
+): React.RefCallback<HTMLElement | HTMLDivElement | null> => {
   'use no memo';
 
   const {

--- a/packages/react-virtualizer/src/hooks/useMeasureList.ts
+++ b/packages/react-virtualizer/src/hooks/useMeasureList.ts
@@ -19,7 +19,15 @@ export function useMeasureList<
   refLength: number,
   totalLength: number,
   defaultItemSize: number
-) {
+): {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  widthArray: React.MutableRefObject<any[]>;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  heightArray: React.MutableRefObject<any[]>;
+  createIndexedRef: (index: number) => (el: TElement) => void;
+  refArray: React.MutableRefObject<(TElement | null | undefined)[]>;
+  sizeUpdateCount: number;
+} {
   const widthArray = React.useRef(new Array(totalLength).fill(defaultItemSize));
   const heightArray = React.useRef(
     new Array(totalLength).fill(defaultItemSize)
@@ -157,7 +165,8 @@ export function useMeasureList<
 export function createResizeObserverFromDocument(
   targetDocument: Document | null | undefined,
   callback: ResizeObserverCallback
-) {
+  // eslint-disable-next-line no-restricted-globals
+): ResizeObserver | null {
   if (!targetDocument?.defaultView?.ResizeObserver) {
     return null;
   }

--- a/packages/react-virtualizer/src/hooks/useResizeObserverRef.ts
+++ b/packages/react-virtualizer/src/hooks/useResizeObserverRef.ts
@@ -9,7 +9,7 @@ import { ResizeCallbackWithRef } from './hooks.types';
  */
 export const useResizeObserverRef_unstable = (
   resizeCallback: ResizeCallbackWithRef
-) => {
+): React.RefCallback<HTMLElement | HTMLDivElement | null> => {
   'use no memo';
 
   const { targetDocument } = useFluent();

--- a/packages/react-virtualizer/src/hooks/useStaticPagination.ts
+++ b/packages/react-virtualizer/src/hooks/useStaticPagination.ts
@@ -11,7 +11,7 @@ import { useTimeout } from '@fluentui/react-utilities';
 export const useStaticVirtualizerPagination = (
   virtualizerProps: VirtualizerStaticPaginationProps,
   paginationEnabled = true
-) => {
+): React.RefCallback<HTMLElement | HTMLDivElement | null> => {
   'use no memo';
 
   const { itemSize, axis = 'vertical' } = virtualizerProps;

--- a/packages/react-virtualizer/src/utilities/ImperativeScrolling/imperativeScrolling.ts
+++ b/packages/react-virtualizer/src/utilities/ImperativeScrolling/imperativeScrolling.ts
@@ -1,6 +1,6 @@
 import { ScrollToItemStaticParams } from './imperativeScrolling.types';
 
-export const scrollToItemStatic = (params: ScrollToItemStaticParams) => {
+export const scrollToItemStatic = (params: ScrollToItemStaticParams): void => {
   const {
     index,
     itemSize,

--- a/packages/react-virtualizer/src/utilities/ImperativeScrolling/imperativeScrollingDynamic.ts
+++ b/packages/react-virtualizer/src/utilities/ImperativeScrolling/imperativeScrollingDynamic.ts
@@ -1,6 +1,8 @@
 import { ScrollToItemDynamicParams } from './imperativeScrolling.types';
 
-export const scrollToItemDynamic = (params: ScrollToItemDynamicParams) => {
+export const scrollToItemDynamic = (
+  params: ScrollToItemDynamicParams
+): void => {
   const {
     index,
     itemSizes,

--- a/packages/react-virtualizer/src/utilities/VirtualizerContext/VirtualizerContext.ts
+++ b/packages/react-virtualizer/src/utilities/VirtualizerContext/VirtualizerContext.ts
@@ -10,7 +10,9 @@ const VirtualizerContext = React.createContext<
 
 export const VirtualizerContextProvider = VirtualizerContext.Provider;
 
-export const useVirtualizerContext_unstable = () => {
+export const useVirtualizerContext_unstable = ():
+  | VirtualizerContextProps
+  | undefined => {
   return React.useContext(VirtualizerContext);
 };
 

--- a/packages/react-virtualizer/src/utilities/createResizeObserverFromDocument.ts
+++ b/packages/react-virtualizer/src/utilities/createResizeObserverFromDocument.ts
@@ -8,7 +8,8 @@
 export function createResizeObserverFromDocument(
   targetDocument: Document | null | undefined,
   callback: ResizeObserverCallback
-) {
+  // eslint-disable-next-line no-restricted-globals
+): ResizeObserver | null {
   if (!targetDocument?.defaultView?.ResizeObserver) {
     return null;
   }

--- a/packages/react-virtualizer/src/utilities/debounce.ts
+++ b/packages/react-virtualizer/src/utilities/debounce.ts
@@ -5,7 +5,7 @@
  * @returns debounced function
  */
 // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
-export function debounce(fn: Function) {
+export function debounce(fn: Function): () => void {
   let pending: boolean;
   return () => {
     if (!pending) {

--- a/packages/react-virtualizer/stories/VirtualizerScrollView/ScrollTo.stories.tsx
+++ b/packages/react-virtualizer/stories/VirtualizerScrollView/ScrollTo.stories.tsx
@@ -53,7 +53,7 @@ export const ScrollTo = () => {
           tabIndex: 0,
           style: { maxHeight: '80vh' },
         }}
-        imperativeRef={scrollRef}
+        imperativeRef={scrollRef as React.RefObject<ScrollToInterface>}
       >
         {(index: number) => {
           return (

--- a/packages/react-virtualizer/stories/VirtualizerScrollView/ScrollTo.stories.tsx
+++ b/packages/react-virtualizer/stories/VirtualizerScrollView/ScrollTo.stories.tsx
@@ -53,7 +53,7 @@ export const ScrollTo = () => {
           tabIndex: 0,
           style: { maxHeight: '80vh' },
         }}
-        imperativeRef={scrollRef as React.RefObject<ScrollToInterface>}
+        imperativeRef={scrollRef}
       >
         {(index: number) => {
           return (

--- a/packages/react-virtualizer/stories/VirtualizerScrollViewDynamic/ScrollTo.stories.tsx
+++ b/packages/react-virtualizer/stories/VirtualizerScrollViewDynamic/ScrollTo.stories.tsx
@@ -73,10 +73,8 @@ export const ScrollTo = () => {
         numItems={childLength}
         itemSize={100}
         getItemSize={getItemSizeCallback}
-        imperativeRef={scrollRef as React.RefObject<ScrollToInterface>}
-        imperativeVirtualizerRef={
-          sizeRef as React.RefObject<VirtualizerDataRef>
-        }
+        imperativeRef={scrollRef}
+        imperativeVirtualizerRef={sizeRef}
         container={{
           role: 'list',
           'aria-label': `Virtualized list with ${childLength} children`,

--- a/packages/react-virtualizer/stories/VirtualizerScrollViewDynamic/ScrollTo.stories.tsx
+++ b/packages/react-virtualizer/stories/VirtualizerScrollViewDynamic/ScrollTo.stories.tsx
@@ -73,8 +73,10 @@ export const ScrollTo = () => {
         numItems={childLength}
         itemSize={100}
         getItemSize={getItemSizeCallback}
-        imperativeRef={scrollRef}
-        imperativeVirtualizerRef={sizeRef}
+        imperativeRef={scrollRef as React.RefObject<ScrollToInterface>}
+        imperativeVirtualizerRef={
+          sizeRef as React.RefObject<VirtualizerDataRef>
+        }
         container={{
           role: 'list',
           'aria-label': `Virtualized list with ${childLength} children`,

--- a/packages/stylelint-plugin/eslint.config.js
+++ b/packages/stylelint-plugin/eslint.config.js
@@ -10,7 +10,9 @@ module.exports = [
   {
     files: ['**/*.ts', '**/*.tsx'],
     // Override or add rules here
-    rules: {},
+    rules: {
+      '@typescript-eslint/explicit-module-boundary-types': 'off',
+    },
   },
   {
     files: ['**/*.js', '**/*.jsx'],

--- a/packages/teams-components/src/components/Button/validateProps.ts
+++ b/packages/teams-components/src/components/Button/validateProps.ts
@@ -7,7 +7,7 @@ export const validateIconButton = (props: {
   title?: unknown;
   'aria-label'?: string;
   'aria-labelledby'?: string;
-}) => {
+}): void => {
   if (
     !props.children &&
     props.icon &&
@@ -24,7 +24,7 @@ export const validateIconButton = (props: {
  * Infers a Menu being used by detecting `aria-haspopup` of the MenuTrigger
  * @throws Error if a menu is used
  */
-export const validateMenuButton = (props: unknown) => {
+export const validateMenuButton = (props: unknown): void => {
   if (
     typeof props === 'object' &&
     props &&

--- a/packages/teams-components/src/components/ToggleButton/validateProps.ts
+++ b/packages/teams-components/src/components/ToggleButton/validateProps.ts
@@ -2,7 +2,7 @@ export const validateAriaPressed = (props: {
   'aria-pressed'?: null | undefined;
   'aria-label'?: string;
   'aria-labelledby'?: string;
-}) => {
+}): void => {
   if (
     'aria-pressed' in props &&
     !(props['aria-label'] || props['aria-labelledby'])

--- a/packages/teams-components/src/strictStyles/validateStrictClasses.ts
+++ b/packages/teams-components/src/strictStyles/validateStrictClasses.ts
@@ -3,7 +3,7 @@ import type { StrictCssClass } from './types';
 
 export const validateStrictClasses = <TExtension>(
   className?: StrictCssClass<TExtension> | false | undefined
-) => {
+): void => {
   if (!className) {
     return;
   }

--- a/packages/variant-theme/src/ThemeDesigner/colors/csswg.ts
+++ b/packages/variant-theme/src/ThemeDesigner/colors/csswg.ts
@@ -69,7 +69,7 @@ export default function multiplyMatrices(
 
 // sRGB-related functions
 
-export function lin_sRGB(RGB: Vec3) {
+export function lin_sRGB(RGB: Vec3): Vec3 {
   // convert an array of sRGB values
   // where in-gamut values are in the range [0 - 1]
   // to linear light (un-companded) form.
@@ -89,7 +89,7 @@ export function lin_sRGB(RGB: Vec3) {
   }) as Vec3;
 }
 
-export function gam_sRGB(RGB: Vec3) {
+export function gam_sRGB(RGB: Vec3): Vec3 {
   // convert an array of linear-light sRGB values in the range 0.0-1.0
   // to gamma corrected form
   // https://en.wikipedia.org/wiki/SRGB
@@ -108,7 +108,7 @@ export function gam_sRGB(RGB: Vec3) {
   }) as Vec3;
 }
 
-export function lin_sRGB_to_XYZ(rgb: Vec3) {
+export function lin_sRGB_to_XYZ(rgb: Vec3): Vec3 {
   // convert an array of linear-light sRGB values to CIE XYZ
   // using sRGB's own white, D65 (no chromatic adaptation)
 
@@ -120,7 +120,7 @@ export function lin_sRGB_to_XYZ(rgb: Vec3) {
   return multiplyMatrices(M, rgb) as Vec3;
 }
 
-export function XYZ_to_lin_sRGB(XYZ: Vec3) {
+export function XYZ_to_lin_sRGB(XYZ: Vec3): Vec3 {
   // convert XYZ to linear-light sRGB
 
   const M = [
@@ -134,21 +134,21 @@ export function XYZ_to_lin_sRGB(XYZ: Vec3) {
 
 //  display-p3-related functions
 
-export function lin_P3(RGB: Vec3) {
+export function lin_P3(RGB: Vec3): Vec3 {
   // convert an array of display-p3 RGB values in the range 0.0 - 1.0
   // to linear light (un-companded) form.
 
   return lin_sRGB(RGB) as Vec3; // same as sRGB
 }
 
-export function gam_P3(RGB: Vec3) {
+export function gam_P3(RGB: Vec3): Vec3 {
   // convert an array of linear-light display-p3 RGB  in the range 0.0-1.0
   // to gamma corrected form
 
   return gam_sRGB(RGB) as Vec3; // same as sRGB
 }
 
-export function lin_P3_to_XYZ(rgb: Vec3) {
+export function lin_P3_to_XYZ(rgb: Vec3): Vec3 {
   // convert an array of linear-light display-p3 values to CIE XYZ
   // using  D65 (no chromatic adaptation)
   // http://www.brucelindbloom.com/index.html?Eqn_RGB_XYZ_Matrix.html
@@ -162,7 +162,7 @@ export function lin_P3_to_XYZ(rgb: Vec3) {
   return multiplyMatrices(M, rgb) as Vec3;
 }
 
-export function XYZ_to_lin_P3(XYZ: Vec3) {
+export function XYZ_to_lin_P3(XYZ: Vec3): Vec3 {
   // convert XYZ to linear-light P3
   const M = [
     [2.493496911941425, -0.9313836179191239, -0.40271078445071684],
@@ -175,7 +175,7 @@ export function XYZ_to_lin_P3(XYZ: Vec3) {
 
 // prophoto-rgb functions
 
-export function lin_ProPhoto(RGB: Vec3) {
+export function lin_ProPhoto(RGB: Vec3): Vec3 {
   // convert an array of prophoto-rgb values
   // where in-gamut colors are in the range [0.0 - 1.0]
   // to linear light (un-companded) form.
@@ -194,7 +194,7 @@ export function lin_ProPhoto(RGB: Vec3) {
   }) as Vec3;
 }
 
-export function gam_ProPhoto(RGB: Vec3) {
+export function gam_ProPhoto(RGB: Vec3): Vec3 {
   // convert an array of linear-light prophoto-rgb  in the range 0.0-1.0
   // to gamma corrected form
   // Transfer curve is gamma 1.8 with a small linear portion
@@ -212,7 +212,7 @@ export function gam_ProPhoto(RGB: Vec3) {
   }) as Vec3;
 }
 
-export function lin_ProPhoto_to_XYZ(rgb: Vec3) {
+export function lin_ProPhoto_to_XYZ(rgb: Vec3): Vec3 {
   // convert an array of linear-light prophoto-rgb values to CIE XYZ
   // using  D50 (so no chromatic adaptation needed afterwards)
   // http://www.brucelindbloom.com/index.html?Eqn_RGB_XYZ_Matrix.html
@@ -225,7 +225,7 @@ export function lin_ProPhoto_to_XYZ(rgb: Vec3) {
   return multiplyMatrices(M, rgb) as Vec3;
 }
 
-export function XYZ_to_lin_ProPhoto(XYZ: Vec3) {
+export function XYZ_to_lin_ProPhoto(XYZ: Vec3): Vec3 {
   // convert XYZ to linear-light prophoto-rgb
   const M = [
     [1.3457989731028281, -0.25558010007997534, -0.05110628506753401],
@@ -238,7 +238,7 @@ export function XYZ_to_lin_ProPhoto(XYZ: Vec3) {
 
 // a98-rgb functions
 
-export function lin_a98rgb(RGB: Vec3) {
+export function lin_a98rgb(RGB: Vec3): Vec3 {
   // convert an array of a98-rgb values in the range 0.0 - 1.0
   // to linear light (un-companded) form.
   // negative values are also now accepted
@@ -250,7 +250,7 @@ export function lin_a98rgb(RGB: Vec3) {
   }) as Vec3;
 }
 
-export function gam_a98rgb(RGB: Vec3) {
+export function gam_a98rgb(RGB: Vec3): Vec3 {
   // convert an array of linear-light a98-rgb  in the range 0.0-1.0
   // to gamma corrected form
   // negative values are also now accepted
@@ -262,7 +262,7 @@ export function gam_a98rgb(RGB: Vec3) {
   }) as Vec3;
 }
 
-export function lin_a98rgb_to_XYZ(rgb: Vec3) {
+export function lin_a98rgb_to_XYZ(rgb: Vec3): Vec3 {
   // convert an array of linear-light a98-rgb values to CIE XYZ
   // http://www.brucelindbloom.com/index.html?Eqn_RGB_XYZ_Matrix.html
   // has greater numerical precision than section 4.3.5.3 of
@@ -279,7 +279,7 @@ export function lin_a98rgb_to_XYZ(rgb: Vec3) {
   return multiplyMatrices(M, rgb) as Vec3;
 }
 
-export function XYZ_to_lin_a98rgb(XYZ: Vec3) {
+export function XYZ_to_lin_a98rgb(XYZ: Vec3): Vec3 {
   // convert XYZ to linear-light a98-rgb
   const M = [
     [2.0415879038107465, -0.5650069742788596, -0.34473135077832956],
@@ -292,7 +292,7 @@ export function XYZ_to_lin_a98rgb(XYZ: Vec3) {
 
 // Rec. 2020-related functions
 
-export function lin_2020(RGB: Vec3) {
+export function lin_2020(RGB: Vec3): Vec3 {
   // convert an array of rec2020 RGB values in the range 0.0 - 1.0
   // to linear light (un-companded) form.
   // ITU-R BT.2020-2 p.4
@@ -312,7 +312,7 @@ export function lin_2020(RGB: Vec3) {
   }) as Vec3;
 }
 
-export function gam_2020(RGB: Vec3) {
+export function gam_2020(RGB: Vec3): Vec3 {
   // convert an array of linear-light rec2020 RGB  in the range 0.0-1.0
   // to gamma corrected form
   // ITU-R BT.2020-2 p.4
@@ -332,7 +332,7 @@ export function gam_2020(RGB: Vec3) {
   }) as Vec3;
 }
 
-export function lin_2020_to_XYZ(rgb: Vec3) {
+export function lin_2020_to_XYZ(rgb: Vec3): Vec3 {
   // convert an array of linear-light rec2020 values to CIE XYZ
   // using  D65 (no chromatic adaptation)
   // http://www.brucelindbloom.com/index.html?Eqn_RGB_XYZ_Matrix.html
@@ -346,7 +346,7 @@ export function lin_2020_to_XYZ(rgb: Vec3) {
   return multiplyMatrices(M, rgb) as Vec3;
 }
 
-export function XYZ_to_lin_2020(XYZ: Vec3) {
+export function XYZ_to_lin_2020(XYZ: Vec3): Vec3 {
   // convert XYZ to linear-light rec2020
   const M = [
     [1.7166511879712674, -0.35567078377639233, -0.25336628137365974],
@@ -359,7 +359,7 @@ export function XYZ_to_lin_2020(XYZ: Vec3) {
 
 // Chromatic adaptation
 
-export function D65_to_D50(XYZ: Vec3) {
+export function D65_to_D50(XYZ: Vec3): Vec3 {
   // Bradford chromatic adaptation from D65 to D50
   // The matrix below is the result of three operations:
   // - convert from XYZ to retinal cone domain
@@ -375,7 +375,7 @@ export function D65_to_D50(XYZ: Vec3) {
   return multiplyMatrices(M, XYZ) as Vec3;
 }
 
-export function D50_to_D65(XYZ: Vec3) {
+export function D50_to_D65(XYZ: Vec3): Vec3 {
   // Bradford chromatic adaptation from D50 to D65
   const M = [
     [0.9554734527042182, -0.023098536874261423, 0.0632593086610217],
@@ -388,7 +388,7 @@ export function D50_to_D65(XYZ: Vec3) {
 
 // Lab and LCH
 
-export function XYZ_to_Lab(XYZ: Vec3) {
+export function XYZ_to_Lab(XYZ: Vec3): Vec3 {
   // Assuming XYZ is relative to D50, convert to CIE Lab
   // from CIE standard, which now defines these as a rational fraction
   const ε = 216 / 24389; // 6^3/29^3
@@ -410,7 +410,7 @@ export function XYZ_to_Lab(XYZ: Vec3) {
   ] as Vec3;
 }
 
-export function Lab_to_XYZ(Lab: Vec3) {
+export function Lab_to_XYZ(Lab: Vec3): Vec3 {
   // Convert Lab to D50-adapted XYZ
   // http://www.brucelindbloom.com/index.html?Eqn_RGB_XYZ_Matrix.html
   const κ = 24389 / 27; // 29^3/3^3
@@ -434,7 +434,7 @@ export function Lab_to_XYZ(Lab: Vec3) {
   return xyz.map((value, i) => value * white[i]) as Vec3;
 }
 
-export function Lab_to_LCH(Lab: Vec3) {
+export function Lab_to_LCH(Lab: Vec3): Vec3 {
   // Convert to polar form
   const hue = (Math.atan2(Lab[2], Lab[1]) * 180) / Math.PI;
   return [
@@ -444,7 +444,7 @@ export function Lab_to_LCH(Lab: Vec3) {
   ] as Vec3;
 }
 
-export function LCH_to_Lab(LCH: Vec3) {
+export function LCH_to_Lab(LCH: Vec3): Vec3 {
   // Convert from polar form
   return [
     LCH[0], // L is still L
@@ -462,7 +462,7 @@ export function LCH_to_Lab(LCH: Vec3) {
  * @param   rgb      The red, green, and blue color values
  * @return  Array    The HSV representation
  */
-export function rgbToHsv(rgb: Vec3) {
+export function rgbToHsv(rgb: Vec3): Vec3 {
   const [r, g, b] = rgb;
   const max = Math.max(r, g, b);
   const min = Math.min(r, g, b);
@@ -498,7 +498,7 @@ export function rgbToHsv(rgb: Vec3) {
 // [willshown]: Adjusted to export a TypeScript module.
 // Retrieved on 24 May 2021 from https://drafts.csswg.org/css-color-4/utilities.js
 
-export function sRGB_to_luminance(RGB: Vec3) {
+export function sRGB_to_luminance(RGB: Vec3): number {
   // convert an array of gamma-corrected sRGB values
   // in the 0.0 to 1.0 range
   // to linear-light sRGB, then to CIE XYZ
@@ -508,7 +508,7 @@ export function sRGB_to_luminance(RGB: Vec3) {
   return XYZ[1];
 }
 
-export function contrast(RGB1: Vec3, RGB2: Vec3) {
+export function contrast(RGB1: Vec3, RGB2: Vec3): number {
   // return WCAG 2.1 contrast ratio
   // https://www.w3.org/TR/WCAG21/#dfn-contrast-ratio
   // for two sRGB values
@@ -524,7 +524,7 @@ export function contrast(RGB1: Vec3, RGB2: Vec3) {
   return (L2 + 0.05) / (L1 + 0.05);
 }
 
-export function sRGB_to_LCH(RGB: Vec3) {
+export function sRGB_to_LCH(RGB: Vec3): Vec3 {
   // convert an array of gamma-corrected sRGB values
   // in the 0.0 to 1.0 range
   // to linear-light sRGB, then to CIE XYZ,
@@ -535,7 +535,7 @@ export function sRGB_to_LCH(RGB: Vec3) {
   return Lab_to_LCH(XYZ_to_Lab(D65_to_D50(lin_sRGB_to_XYZ(lin_sRGB(RGB)))));
 }
 
-export function sRGB_to_LAB(RGB: Vec3) {
+export function sRGB_to_LAB(RGB: Vec3): Vec3 {
   // convert an array of gamma-corrected sRGB values
   // in the 0.0 to 1.0 range
   // to linear-light sRGB, then to CIE XYZ,
@@ -545,7 +545,7 @@ export function sRGB_to_LAB(RGB: Vec3) {
   return XYZ_to_Lab(D65_to_D50(lin_sRGB_to_XYZ(lin_sRGB(RGB))));
 }
 
-export function P3_to_LCH(RGB: Vec3) {
+export function P3_to_LCH(RGB: Vec3): Vec3 {
   // convert an array of gamma-corrected display-p3 values
   // in the 0.0 to 1.0 range
   // to linear-light display-p3, then to CIE XYZ,
@@ -556,7 +556,7 @@ export function P3_to_LCH(RGB: Vec3) {
   return Lab_to_LCH(XYZ_to_Lab(D65_to_D50(lin_P3_to_XYZ(lin_P3(RGB)))));
 }
 
-export function r2020_to_LCH(RGB: Vec3) {
+export function r2020_to_LCH(RGB: Vec3): Vec3 {
   // convert an array of gamma-corrected rec.2020 values
   // in the 0.0 to 1.0 range
   // to linear-light sRGB, then to CIE XYZ,
@@ -567,7 +567,7 @@ export function r2020_to_LCH(RGB: Vec3) {
   return Lab_to_LCH(XYZ_to_Lab(D65_to_D50(lin_2020_to_XYZ(lin_2020(RGB)))));
 }
 
-export function LCH_to_sRGB(LCH: Vec3) {
+export function LCH_to_sRGB(LCH: Vec3): Vec3 {
   // convert an array of CIE LCH values
   // to CIE Lab, and then to XYZ,
   // adapt from D50 to D65,
@@ -581,7 +581,7 @@ export function LCH_to_sRGB(LCH: Vec3) {
   return gam_sRGB(XYZ_to_lin_sRGB(D50_to_D65(Lab_to_XYZ(LCH_to_Lab(LCH)))));
 }
 
-export function LAB_to_sRGB(LAB: Vec3) {
+export function LAB_to_sRGB(LAB: Vec3): Vec3 {
   // convert an array of CIE Lab values to XYZ,
   // adapt from D50 to D65,
   // then convert XYZ to linear-light sRGB
@@ -594,7 +594,7 @@ export function LAB_to_sRGB(LAB: Vec3) {
   return gam_sRGB(XYZ_to_lin_sRGB(D50_to_D65(Lab_to_XYZ(LAB))));
 }
 
-export function LCH_to_P3(LCH: Vec3) {
+export function LCH_to_P3(LCH: Vec3): Vec3 {
   // convert an array of CIE LCH values
   // to CIE Lab, and then to XYZ,
   // adapt from D50 to D65,
@@ -608,7 +608,7 @@ export function LCH_to_P3(LCH: Vec3) {
   return gam_P3(XYZ_to_lin_P3(D50_to_D65(Lab_to_XYZ(LCH_to_Lab(LCH)))));
 }
 
-export function LCH_to_r2020(LCH: Vec3) {
+export function LCH_to_r2020(LCH: Vec3): Vec3 {
   // convert an array of CIE LCH values
   // to CIE Lab, and then to XYZ,
   // adapt from D50 to D65,
@@ -624,7 +624,7 @@ export function LCH_to_r2020(LCH: Vec3) {
 
 // this is straight from the CSS Color 4 spec
 
-export function hslToRgb(hue: number, sat: number, light: number) {
+export function hslToRgb(hue: number, sat: number, light: number): Vec3 {
   // 	For simplicity, this algorithm assumes that the hue has been normalized
   //  to a number in the half-open range [0, 6), and the saturation and lightness
   //  have been normalized to the range [0, 1]. It returns an array of three numbers
@@ -659,7 +659,7 @@ export function hueToChannel(t1: number, t2: number, hue: number): number {
 
 // These are the naive algorithms from CS Color 4
 
-export function naive_CMYK_to_sRGB(CMYK: Vec4) {
+export function naive_CMYK_to_sRGB(CMYK: Vec4): Vec3 {
   // CMYK is an array of four values
   // in the range [0.0, 1.0]
   // the optput is an array of [RGB]
@@ -679,7 +679,7 @@ export function naive_CMYK_to_sRGB(CMYK: Vec4) {
   return [red, green, blue] as Vec3;
 }
 
-export function naive_sRGB_to_CMYK(RGB: Vec3) {
+export function naive_sRGB_to_CMYK(RGB: Vec3): Vec4 {
   // RGB is an arravy of three values
   // in the range [0.0, 1.0]
   // the output is an array of [CMYK]
@@ -702,7 +702,7 @@ export function naive_sRGB_to_CMYK(RGB: Vec3) {
 
 // Chromaticity utilities
 
-export function XYZ_to_xy(XYZ: Vec3) {
+export function XYZ_to_xy(XYZ: Vec3): Vec2 {
   // Convert an array of three XYZ values
   // to x,y chromaticity coordinates
 
@@ -713,7 +713,7 @@ export function XYZ_to_xy(XYZ: Vec3) {
   return [X / sum, Y / sum] as Vec2;
 }
 
-export function xy_to_uv(xy: Vec2) {
+export function xy_to_uv(xy: Vec2): Vec2 {
   // convert an x,y chromaticity pair
   // to u*,v* chromaticities
 
@@ -723,7 +723,7 @@ export function xy_to_uv(xy: Vec2) {
   return [(4 * x) / denom, (9 * y) / denom] as Vec2;
 }
 
-export function XYZ_to_uv(XYZ: Vec3) {
+export function XYZ_to_uv(XYZ: Vec3): Vec2 {
   // Convert an array of three XYZ values
   // to u*,v* chromaticity coordinates
 

--- a/packages/variant-theme/src/ThemeDesigner/colors/hueMap.ts
+++ b/packages/variant-theme/src/ThemeDesigner/colors/hueMap.ts
@@ -1,4 +1,4 @@
-export function hexToHue(hexColor: string) {
+export function hexToHue(hexColor: string): number {
   // Parse the hex color string into its red, green, and blue components
   const red = parseInt(hexColor.substring(1, 3), 16);
   const green = parseInt(hexColor.substring(3, 5), 16);

--- a/packages/variant-theme/src/ThemeDesigner/utils/getBrandTokensFromPalette.ts
+++ b/packages/variant-theme/src/ThemeDesigner/utils/getBrandTokensFromPalette.ts
@@ -25,7 +25,7 @@ type Options = {
 export function getBrandTokensFromPalette(
   keyColor: string,
   options: Options = {}
-) {
+): BrandVariants {
   const { darkCp = 2 / 3, lightCp = 1 / 3, hueTorsion = 0 } = options;
   const brandPalette: Palette = {
     keyColor: hex_to_LCH(keyColor),

--- a/packages/variant-theme/src/ThemeDesigner/utils/getOverridableTokenBrandColors.ts
+++ b/packages/variant-theme/src/ThemeDesigner/utils/getOverridableTokenBrandColors.ts
@@ -10,7 +10,7 @@ export const brandRamp: Brands[] = [
 
 export const sortOverrideableColorTokens = (
   overridableColorTokens: string[]
-) => {
+): string[] => {
   return overridableColorTokens.sort((a, b) => {
     if (a.includes('Inverted') && b.includes('Inverted')) {
       return a.localeCompare(b);

--- a/packages/variant-theme/src/ThemeDesigner/utils/toString.ts
+++ b/packages/variant-theme/src/ThemeDesigner/utils/toString.ts
@@ -6,7 +6,7 @@ export const getBrandValues = (
   overrideList: Partial<Theme>,
   name: string,
   spacer: string
-) => {
+): string => {
   const hexToBrand: Record<string, string> = {};
 
   brandRamp.map((i) => {
@@ -28,7 +28,7 @@ export const getBrandValues = (
 export const objectToString = (
   input: Record<string, string>,
   spacer: string
-) => {
+): string => {
   return (
     Object.keys(input).map((key) => {
       return '\n' + spacer + key + ': "' + input[key].toUpperCase() + '"';

--- a/packages/variant-theme/src/ThemeDesigner/utils/useDebounce.ts
+++ b/packages/variant-theme/src/ThemeDesigner/utils/useDebounce.ts
@@ -1,14 +1,14 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { useEffect, useState } from 'react';
 
-export function useDebounce(value: any, delay: number) {
+export function useDebounce<T = any>(value: T, delay: number): T {
   const [debouncedValue, setDebouncedValue] = useState(value);
   useEffect(() => {
     // eslint-disable-next-line no-restricted-globals
     const handler = document.defaultView?.setTimeout(() => {
       setDebouncedValue(value);
     }, delay);
-    return () => {
+    return (): void => {
       // eslint-disable-next-line no-restricted-globals
       clearTimeout(handler);
     };

--- a/packages/variant-theme/src/ThemeGenerator.ts
+++ b/packages/variant-theme/src/ThemeGenerator.ts
@@ -31,7 +31,7 @@ export function getVariantTheme(
   theme: Theme,
   type: VariantThemeType,
   isInverted: boolean
-) {
+): Theme {
   // Need a way to detect custom neutrals in the theme
   // Need a way to detect if the theme is light or dark
 


### PR DESCRIPTION
- enable `@typescript-eslint/no-restricted-types` to restrict global `JSX.*` types usage
- enable `@typescript-eslint/explicit-module-boundary-types` ESLint rule for packages to enforce explicit types for module exports similar to what we did in core https://github.com/microsoft/fluentui/pull/35080
- explicitly define types for module exports

~Blocked by #478~