### PR TITLE
Fix: Prevent dynamic virtualizer getting stuck at the end

### DIFF
--- a/change/@fluentui-contrib-react-virtualizer-c65aff71-b424-40d9-9d28-673e52c69f77.json
+++ b/change/@fluentui-contrib-react-virtualizer-c65aff71-b424-40d9-9d28-673e52c69f77.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Ensure dynamic virtualizer doesn't get stuck at end",
+  "packageName": "@fluentui-contrib/react-virtualizer",
+  "email": "mifraser@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-virtualizer/src/hooks/useDynamicVirtualizerMeasure.ts
+++ b/packages/react-virtualizer/src/hooks/useDynamicVirtualizerMeasure.ts
@@ -45,7 +45,8 @@ export const useDynamicVirtualizerMeasure = <TElement extends HTMLElement>(
   const container = React.useRef<HTMLElement | null>(null);
   const handleScrollResize = React.useCallback(
     (scrollRef: React.MutableRefObject<HTMLElement | null>) => {
-      if (!scrollRef?.current) {
+      const hasReachedEnd = virtualizerContext.contextIndex + virtualizerLength >= numItems;
+      if (!scrollRef?.current || hasReachedEnd) {
         // Error? ignore?
         return;
       }

--- a/packages/react-virtualizer/src/hooks/useDynamicVirtualizerMeasure.ts
+++ b/packages/react-virtualizer/src/hooks/useDynamicVirtualizerMeasure.ts
@@ -45,7 +45,8 @@ export const useDynamicVirtualizerMeasure = <TElement extends HTMLElement>(
   const container = React.useRef<HTMLElement | null>(null);
   const handleScrollResize = React.useCallback(
     (scrollRef: React.MutableRefObject<HTMLElement | null>) => {
-      const hasReachedEnd = virtualizerContext.contextIndex + virtualizerLength >= numItems;
+      const hasReachedEnd =
+        virtualizerContext.contextIndex + virtualizerLength >= numItems;
       if (!scrollRef?.current || hasReachedEnd) {
         // Error? ignore?
         return;


### PR DESCRIPTION
Virtualizer would occasionally get stuck at the end due to it trying to optimize the required length, however we can simply enable Virtualizer length to go beyond the end item and stay there.

Once we reach the end, no optimizations needed until index change requires a recalculation.