### PR TITLE
chore: add cxe-prg to react-virtualizer codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -23,7 +23,7 @@ packages/react-gamepad-navigation @microsoft/cxe-prg @hectorjjb
 packages/teams-components @microsoft/teams-prg
 packages/token-analyzer @microsoft/xc-uxe
 packages/react-contextual-pane @microsoft/teams-prg
-packages/react-virtualizer @microsoft/xc-uxe
+packages/react-virtualizer @microsoft/xc-uxe @microsoft/cxe-prg
 # <%= NX-CODEOWNER-PLACEHOLDER %>
 
 #### Build/Infra


### PR DESCRIPTION
This pull request makes a small update to the `CODEOWNERS` file, adding an additional team as co-owner for the `packages/react-virtualizer` package. This change ensures that both the `@microsoft/xc-uxe` and `@microsoft/cxe-prg` teams are now responsible for this package.