### PR TITLE
fix (react-virtualizer): Ensure base virtualizer hook recalcs array if numItems change at end

### DIFF
--- a/change/@fluentui-contrib-react-virtualizer-a47074a8-2c13-4436-8bda-ba0941b109ad.json
+++ b/change/@fluentui-contrib-react-virtualizer-a47074a8-2c13-4436-8bda-ba0941b109ad.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Ensure base virtualizer hooks recalc index if numItems changes",
+  "packageName": "@fluentui-contrib/react-virtualizer",
+  "email": "mifraser@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-virtualizer/src/components/Virtualizer/useVirtualizer.ts
+++ b/packages/react-virtualizer/src/components/Virtualizer/useVirtualizer.ts
@@ -528,7 +528,6 @@ export function useVirtualizer_unstable(
             // We've already hit the end, no need to update state.
             return;
           }
-
           if (actualIndex !== newStartIndex) {
             batchUpdateNewIndex(newStartIndex);
           }

--- a/packages/react-virtualizer/src/components/Virtualizer/useVirtualizer.ts
+++ b/packages/react-virtualizer/src/components/Virtualizer/useVirtualizer.ts
@@ -375,7 +375,6 @@ export function useVirtualizer_unstable(
 
   // We store the number of items since last render, we will allow an update if the number of items changes
   const previousNumItems = React.useRef<number>(numItems);
-
   // Observe intersections of virtualized components
   const { setObserverList } = useIntersectionObserver(
     React.useCallback(

--- a/packages/react-virtualizer/src/components/Virtualizer/useVirtualizer.ts
+++ b/packages/react-virtualizer/src/components/Virtualizer/useVirtualizer.ts
@@ -375,6 +375,7 @@ export function useVirtualizer_unstable(
 
   // We store the number of items since last render, we will allow an update if the number of items changes
   const previousNumItems = React.useRef<number>(numItems);
+
   // Observe intersections of virtualized components
   const { setObserverList } = useIntersectionObserver(
     React.useCallback(
@@ -517,13 +518,18 @@ export function useVirtualizer_unstable(
         // Safety limits
         const newStartIndex = Math.min(Math.max(startIndex, 0), maxIndex);
         flushSync(() => {
+          // When the number of items change, we DO want to recalc even if at end of list
+          const numItemsChanged = previousNumItems.current !== numItems;
+          previousNumItems.current = numItems;
           if (
             newStartIndex + virtualizerLength >= numItems &&
-            actualIndex + virtualizerLength >= numItems
+            actualIndex + virtualizerLength >= numItems &&
+            !numItemsChanged
           ) {
             // We've already hit the end, no need to update state.
             return;
           }
+
           if (actualIndex !== newStartIndex) {
             batchUpdateNewIndex(newStartIndex);
           }

--- a/packages/react-virtualizer/src/hooks/useDynamicVirtualizerMeasure.ts
+++ b/packages/react-virtualizer/src/hooks/useDynamicVirtualizerMeasure.ts
@@ -129,7 +129,6 @@ export const useDynamicVirtualizerMeasure = <TElement extends HTMLElement>(
       const totalLength = length + newBufferItems * 2;
 
       if (numItemsChanged && indexMod - newBufferItems > 0) {
-        console.log('Num items changed, adjusting index');
         // Virtualizer will recalculate on numItems change, but from the old index
         // We should get ahead of that update to prevent unnessecary recalculations
         virtualizerContext.setContextIndex(


### PR DESCRIPTION
Previously, we had a safety check to ensure we don't re-render if the virtualizer is at the 'end' of the array.

While this check is important, if the number of items rendered is modified, we do want to ensure it recalculates the index based on the new array length.

This check should ensure that when items are removed we recalc where nessecary at the BASE virtualizer hook (similar to what we added for the dynamic virtualizer check).