### PR TITLE
fix (react-virtualizer): Ensure IO buffer gets removed, not added from calculation

### DIFF
--- a/change/@fluentui-contrib-react-virtualizer-388fbe2c-fba9-42e7-8369-f6484974f821.json
+++ b/change/@fluentui-contrib-react-virtualizer-388fbe2c-fba9-42e7-8369-f6484974f821.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Ensure IO buffer is ignored in the correct direction (remove, don't add)",
+  "packageName": "@fluentui-contrib/react-virtualizer",
+  "email": "mifraser@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-virtualizer/src/components/Virtualizer/useVirtualizer.ts
+++ b/packages/react-virtualizer/src/components/Virtualizer/useVirtualizer.ts
@@ -473,7 +473,7 @@ export function useVirtualizer_unstable(
             // Minus from original before position
             measurementPos -= overflowAmount;
             // Ignore buffer size (IO offset)
-            measurementPos += bufferSize;
+            measurementPos -= bufferSize;
             // Calculate how far past the window bounds we are (this will be zero if IO is within window)
             const hOverflow =
               latestEntry.boundingClientRect.bottom -


### PR DESCRIPTION
Our IO buffer was being appended to the scroll calculation, causing it to be incorrect in very rare (edgecase) scenarios.

We now remove it as intended.