### PR TITLE
fix(houdini-utils): Give wrapper element a different id 

### DIFF
--- a/change/@fluentui-contrib-houdini-utils-86e06910-e1e9-4dbc-ba21-b984551a5a04.json
+++ b/change/@fluentui-contrib-houdini-utils-86e06910-e1e9-4dbc-ba21-b984551a5a04.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Give fallback wrapper a different id.",
+  "packageName": "@fluentui-contrib/houdini-utils",
+  "email": "owcampbe@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/houdini-utils/src/paint/fallback/fallbackPaintAnimation.ts
+++ b/packages/houdini-utils/src/paint/fallback/fallbackPaintAnimation.ts
@@ -47,11 +47,13 @@ export const fallbackPaintAnimation = (
     running: false,
   };
 
+
   // Non-Houdini fallbacks require a canvas element be present in the DOM.
   // Create a wrapper for us to store these elements in so we avoid
   // thrashing the DOM with appends.
   if (!state.wrapper) {
-    state.wrapper = appendWrapper(state.id, targetDocument.body);
+    const wrapperId = `houdini-fallback-wrapper-${flairFallbackId}`;
+    state.wrapper = appendWrapper(wrapperId, targetDocument.body);
   }
 
   if (hasMozElement(targetWindow)) {

--- a/packages/houdini-utils/src/paint/fallback/fallbackPaintAnimation.ts
+++ b/packages/houdini-utils/src/paint/fallback/fallbackPaintAnimation.ts
@@ -47,7 +47,6 @@ export const fallbackPaintAnimation = (
     running: false,
   };
 
-
   // Non-Houdini fallbacks require a canvas element be present in the DOM.
   // Create a wrapper for us to store these elements in so we avoid
   // thrashing the DOM with appends.


### PR DESCRIPTION
In #514 the creation of the wrapper element for the fallback canvas was given the same id as the canvas element itself. This means that when the id is used to reference the canvas to display the fallback paint animation it is blank instead.

This change gives the wrapper a stable `houdini-fallback-wrapper-<x>` id 