### PR TITLE
fix(react-virtualizer): resolve react 19 integration test type-check issues

### DIFF
--- a/packages/react-virtualizer/stories/Virtualizer/Default.stories.tsx
+++ b/packages/react-virtualizer/stories/Virtualizer/Default.stories.tsx
@@ -4,6 +4,7 @@ import {
   useStaticVirtualizerMeasure,
 } from '@fluentui-contrib/react-virtualizer';
 import { makeStyles } from '@fluentui/react-components';
+import type { JSXElement } from '@fluentui/react-components';
 
 const useStyles = makeStyles({
   container: {
@@ -22,7 +23,7 @@ const useStyles = makeStyles({
   },
 });
 
-export const Default = () => {
+export const Default = (): JSXElement => {
   const styles = useStyles();
   const childLength = 1000;
 

--- a/packages/react-virtualizer/stories/Virtualizer/DefaultUnbounded.stories.tsx
+++ b/packages/react-virtualizer/stories/Virtualizer/DefaultUnbounded.stories.tsx
@@ -3,9 +3,8 @@ import {
   Virtualizer,
   useStaticVirtualizerMeasure,
 } from '@fluentui-contrib/react-virtualizer';
-import { makeStyles } from '@fluentui/react-components';
-
-import { useFluent } from '@fluentui/react-components';
+import { makeStyles, useFluent } from '@fluentui/react-components';
+import type { JSXElement } from '@fluentui/react-components';
 
 const useStyles = makeStyles({
   container: {
@@ -36,7 +35,7 @@ const useStyles = makeStyles({
   },
 });
 
-export const DefaultUnbounded = () => {
+export const DefaultUnbounded = (): JSXElement => {
   const styles = useStyles();
   const childLength = 1000;
   const {

--- a/packages/react-virtualizer/stories/Virtualizer/Horizontal.stories.tsx
+++ b/packages/react-virtualizer/stories/Virtualizer/Horizontal.stories.tsx
@@ -4,6 +4,7 @@ import {
   Virtualizer,
 } from '@fluentui-contrib/react-virtualizer';
 import { makeStyles } from '@fluentui/react-components';
+import type { JSXElement } from '@fluentui/react-components';
 
 const useStyles = makeStyles({
   container: {
@@ -21,7 +22,7 @@ const useStyles = makeStyles({
   },
 });
 
-export const Horizontal = () => {
+export const Horizontal = (): JSXElement => {
   const styles = useStyles();
   const childLength = 1000;
   const itemWidth = 100;

--- a/packages/react-virtualizer/stories/Virtualizer/MultiUnbounded.stories.tsx
+++ b/packages/react-virtualizer/stories/Virtualizer/MultiUnbounded.stories.tsx
@@ -4,6 +4,7 @@ import {
   useStaticVirtualizerMeasure,
 } from '@fluentui-contrib/react-virtualizer';
 import { makeStyles, useFluent } from '@fluentui/react-components';
+import type { JSXElement } from '@fluentui/react-components';
 
 const useStyles = makeStyles({
   container: {
@@ -34,7 +35,7 @@ const useStyles = makeStyles({
   },
 });
 
-export const MultiUnbounded = () => {
+export const MultiUnbounded = (): JSXElement => {
   const styles = useStyles();
   const childLength = 100;
   const repeatingVirtualizers = 5;

--- a/packages/react-virtualizer/stories/Virtualizer/RTL.stories.tsx
+++ b/packages/react-virtualizer/stories/Virtualizer/RTL.stories.tsx
@@ -4,6 +4,7 @@ import {
   Virtualizer,
 } from '@fluentui-contrib/react-virtualizer';
 import { makeStyles } from '@fluentui/react-components';
+import type { JSXElement } from '@fluentui/react-components';
 
 const useStyles = makeStyles({
   container: {
@@ -22,7 +23,7 @@ const useStyles = makeStyles({
   },
 });
 
-export const RTL = () => {
+export const RTL = (): JSXElement => {
   const styles = useStyles();
   const childLength = 1000;
 

--- a/packages/react-virtualizer/stories/Virtualizer/Reversed.stories.tsx
+++ b/packages/react-virtualizer/stories/Virtualizer/Reversed.stories.tsx
@@ -4,6 +4,7 @@ import {
   Virtualizer,
 } from '@fluentui-contrib/react-virtualizer';
 import { makeStyles } from '@fluentui/react-components';
+import type { JSXElement } from '@fluentui/react-components';
 
 const useStyles = makeStyles({
   container: {
@@ -21,7 +22,7 @@ const useStyles = makeStyles({
   },
 });
 
-export const Reversed = () => {
+export const Reversed = (): JSXElement => {
   const styles = useStyles();
   const childLength = 1000;
   const itemSize = 100;

--- a/packages/react-virtualizer/stories/Virtualizer/ReversedHorizontal.stories.tsx
+++ b/packages/react-virtualizer/stories/Virtualizer/ReversedHorizontal.stories.tsx
@@ -4,6 +4,7 @@ import {
   Virtualizer,
 } from '@fluentui-contrib/react-virtualizer';
 import { makeStyles } from '@fluentui/react-components';
+import type { JSXElement } from '@fluentui/react-components';
 
 const useStyles = makeStyles({
   container: {
@@ -21,7 +22,7 @@ const useStyles = makeStyles({
   },
 });
 
-export const ReversedHorizontal = () => {
+export const ReversedHorizontal = (): JSXElement => {
   const styles = useStyles();
   const childLength = 1000;
 

--- a/packages/react-virtualizer/stories/VirtualizerScrollView/Default.stories.tsx
+++ b/packages/react-virtualizer/stories/VirtualizerScrollView/Default.stories.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { VirtualizerScrollView } from '@fluentui-contrib/react-virtualizer';
 import { makeStyles } from '@fluentui/react-components';
+import type { JSXElement } from '@fluentui/react-components';
 
 const useStyles = makeStyles({
   child: {
@@ -10,7 +11,7 @@ const useStyles = makeStyles({
   },
 });
 
-export const Default = () => {
+export const Default = (): JSXElement => {
   const styles = useStyles();
   const childLength = 10000;
 

--- a/packages/react-virtualizer/stories/VirtualizerScrollView/ScrollTo.stories.tsx
+++ b/packages/react-virtualizer/stories/VirtualizerScrollView/ScrollTo.stories.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import { VirtualizerScrollView } from '@fluentui-contrib/react-virtualizer';
 import type { ScrollToInterface } from '@fluentui-contrib/react-virtualizer';
-import { Text, Input, makeStyles } from '@fluentui/react-components';
-import { Button } from '@fluentui/react-components';
+import { Button, Text, Input, makeStyles } from '@fluentui/react-components';
+import type { JSXElement } from '@fluentui/react-components';
 
 const useStyles = makeStyles({
   child: {
@@ -12,7 +12,7 @@ const useStyles = makeStyles({
   },
 });
 
-export const ScrollTo = () => {
+export const ScrollTo = (): JSXElement => {
   const styles = useStyles();
   const childLength = 1000;
   const scrollRef = React.useRef<ScrollToInterface>(null);

--- a/packages/react-virtualizer/stories/VirtualizerScrollView/SnapToAlignment.stories.tsx
+++ b/packages/react-virtualizer/stories/VirtualizerScrollView/SnapToAlignment.stories.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { VirtualizerScrollView } from '@fluentui-contrib/react-virtualizer';
 import { makeStyles } from '@fluentui/react-components';
+import type { JSXElement } from '@fluentui/react-components';
 
 const useStyles = makeStyles({
   child: {
@@ -15,7 +16,7 @@ const useStyles = makeStyles({
   },
 });
 
-export const SnapToAlignment = () => {
+export const SnapToAlignment = (): JSXElement => {
   const styles = useStyles();
   const childLength = 100;
 

--- a/packages/react-virtualizer/stories/VirtualizerScrollViewDynamic/AutoMeasure.stories.tsx
+++ b/packages/react-virtualizer/stories/VirtualizerScrollViewDynamic/AutoMeasure.stories.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { VirtualizerScrollViewDynamic } from '@fluentui-contrib/react-virtualizer';
 import { makeStyles } from '@fluentui/react-components';
+import type { JSXElement } from '@fluentui/react-components';
 
 const useStyles = makeStyles({
   child: {
@@ -10,7 +11,7 @@ const useStyles = makeStyles({
   },
 });
 
-export const AutoMeasure = () => {
+export const AutoMeasure = (): JSXElement => {
   const styles = useStyles();
   const childLength = 100;
   const minHeight = 25;

--- a/packages/react-virtualizer/stories/VirtualizerScrollViewDynamic/ComplexDynamicList.stories.tsx
+++ b/packages/react-virtualizer/stories/VirtualizerScrollViewDynamic/ComplexDynamicList.stories.tsx
@@ -1,10 +1,5 @@
-/** @jsxRuntime classic */
-/** @jsx createElement */
-/** @jsxFrag Fragment */
 /* eslint-disable no-restricted-globals */
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-import { createElement } from '@fluentui/react-jsx-runtime';
 import * as React from 'react';
 import {
   VirtualizerScrollViewDynamic,
@@ -17,6 +12,7 @@ import {
   makeStyles,
   useMergedRefs,
 } from '@fluentui/react-components';
+import { JSXElement } from '@fluentui/react-utilities';
 
 const useStyles = makeStyles({
   container: {
@@ -277,7 +273,7 @@ const LazyLoadingComponent = React.forwardRef(
   }
 );
 
-export const ComplexDynamicList = () => {
+export const ComplexDynamicList = (): JSXElement => {
   const styles = useStyles();
   const [childLength, setChildLength] = React.useState(100);
   const virtualizerScrollRef = React.useRef<HTMLDivElement & ScrollToInterface>(

--- a/packages/react-virtualizer/stories/VirtualizerScrollViewDynamic/Default.stories.tsx
+++ b/packages/react-virtualizer/stories/VirtualizerScrollViewDynamic/Default.stories.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { VirtualizerScrollViewDynamic } from '@fluentui-contrib/react-virtualizer';
 import { makeStyles } from '@fluentui/react-components';
+import type { JSXElement } from '@fluentui/react-components';
 
 const useStyles = makeStyles({
   child: {
@@ -10,7 +11,7 @@ const useStyles = makeStyles({
   },
 });
 
-export const Default = () => {
+export const Default = (): JSXElement => {
   const styles = useStyles();
   const childLength = 10000;
   const minHeight = 42;

--- a/packages/react-virtualizer/stories/VirtualizerScrollViewDynamic/ScrollLoading.stories.tsx
+++ b/packages/react-virtualizer/stories/VirtualizerScrollViewDynamic/ScrollLoading.stories.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { VirtualizerScrollViewDynamic } from '@fluentui-contrib/react-virtualizer';
 import { makeStyles } from '@fluentui/react-components';
+import type { JSXElement } from '@fluentui/react-components';
 
 const useStyles = makeStyles({
   child: {
@@ -10,7 +11,7 @@ const useStyles = makeStyles({
   },
 });
 
-export const ScrollLoading = () => {
+export const ScrollLoading = (): JSXElement => {
   const styles = useStyles();
   const childLength = 1000;
   const minHeight = 42;

--- a/packages/react-virtualizer/stories/VirtualizerScrollViewDynamic/ScrollTo.stories.tsx
+++ b/packages/react-virtualizer/stories/VirtualizerScrollViewDynamic/ScrollTo.stories.tsx
@@ -3,6 +3,7 @@ import { VirtualizerScrollViewDynamic } from '@fluentui-contrib/react-virtualize
 import type { ScrollToInterface } from '@fluentui-contrib/react-virtualizer';
 import type { VirtualizerDataRef } from '@fluentui-contrib/react-virtualizer';
 import { Button, Input, makeStyles, Text } from '@fluentui/react-components';
+import type { JSXElement } from '@fluentui/react-components';
 
 const useStyles = makeStyles({
   child: {
@@ -12,7 +13,7 @@ const useStyles = makeStyles({
   },
 });
 
-export const ScrollTo = () => {
+export const ScrollTo = (): JSXElement => {
   const styles = useStyles();
   const childLength = 1000;
   const minHeight = 42;

--- a/packages/react-virtualizer/stories/VirtualizerScrollViewDynamic/SnapToAlignment.stories.tsx
+++ b/packages/react-virtualizer/stories/VirtualizerScrollViewDynamic/SnapToAlignment.stories.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { VirtualizerScrollViewDynamic } from '@fluentui-contrib/react-virtualizer';
 import { makeStyles } from '@fluentui/react-components';
+import type { JSXElement } from '@fluentui/react-components';
 
 const useStyles = makeStyles({
   child: {
@@ -12,7 +13,7 @@ const useStyles = makeStyles({
   },
 });
 
-export const SnapToAlignment = () => {
+export const SnapToAlignment = (): JSXElement => {
   const styles = useStyles();
   const childLength = 1000;
   const minHeight = 42;


### PR DESCRIPTION
React 19 integration tests were failing because of Virtualizer stories on both `main` and PRs pipelines:

https://github.com/microsoft/fluentui-contrib/actions/runs/18528698404/job/52805615325

<img width="1406" height="726" alt="image" src="https://github.com/user-attachments/assets/5583db23-037e-465e-848b-6db4680730c7" />

This PR fixes those issues