### PR TITLE
chore: trigger release for react packages to publish a new version with react 19 peer deps fix

### DIFF
--- a/change/@fluentui-contrib-react-chat-d21bab38-617e-4a7c-84d0-34db24db9ef1.json
+++ b/change/@fluentui-contrib-react-chat-d21bab38-617e-4a7c-84d0-34db24db9ef1.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: bump react-dom versions to support React 19",
+  "packageName": "@fluentui-contrib/react-chat",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-contrib-react-contextual-pane-94c8294d-1e89-42af-a8b8-48d8bef278d9.json
+++ b/change/@fluentui-contrib-react-contextual-pane-94c8294d-1e89-42af-a8b8-48d8bef278d9.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: bump react-dom versions to support React 19",
+  "packageName": "@fluentui-contrib/react-contextual-pane",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-contrib-react-data-grid-react-window-c168558a-1994-4ab9-9118-2c95f8adeac6.json
+++ b/change/@fluentui-contrib-react-data-grid-react-window-c168558a-1994-4ab9-9118-2c95f8adeac6.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: bump react-dom versions to support React 19",
+  "packageName": "@fluentui-contrib/react-data-grid-react-window",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-contrib-react-data-grid-react-window-grid-5f4823d4-bd99-4b32-81cc-9416678e1ece.json
+++ b/change/@fluentui-contrib-react-data-grid-react-window-grid-5f4823d4-bd99-4b32-81cc-9416678e1ece.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: bump react-dom versions to support React 19",
+  "packageName": "@fluentui-contrib/react-data-grid-react-window-grid",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-contrib-react-draggable-dialog-1ab69158-206c-4f40-8538-27dc019c39d2.json
+++ b/change/@fluentui-contrib-react-draggable-dialog-1ab69158-206c-4f40-8538-27dc019c39d2.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: bump react-dom versions to support React 19",
+  "packageName": "@fluentui-contrib/react-draggable-dialog",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-contrib-react-gamepad-navigation-40d70c3a-cbab-4052-97c5-0ceed1f77fae.json
+++ b/change/@fluentui-contrib-react-gamepad-navigation-40d70c3a-cbab-4052-97c5-0ceed1f77fae.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: bump react-dom versions to support React 19",
+  "packageName": "@fluentui-contrib/react-gamepad-navigation",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-contrib-react-headless-provider-42142e29-f5af-4335-acfc-38594f6c0da0.json
+++ b/change/@fluentui-contrib-react-headless-provider-42142e29-f5af-4335-acfc-38594f6c0da0.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: bump react-dom versions to support React 19",
+  "packageName": "@fluentui-contrib/react-headless-provider",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-contrib-react-interactive-tab-7bcfaa22-deb3-4df5-8255-e9a86695228d.json
+++ b/change/@fluentui-contrib-react-interactive-tab-7bcfaa22-deb3-4df5-8255-e9a86695228d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: bump react-dom versions to support React 19",
+  "packageName": "@fluentui-contrib/react-interactive-tab",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-contrib-react-keytips-d4b6e76e-5fe5-4bca-99aa-a33a1fb6c500.json
+++ b/change/@fluentui-contrib-react-keytips-d4b6e76e-5fe5-4bca-99aa-a33a1fb6c500.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: bump react-dom versions to support React 19",
+  "packageName": "@fluentui-contrib/react-keytips",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-contrib-react-resize-handle-97a754ab-6fd2-4913-a1b6-655a922e4b52.json
+++ b/change/@fluentui-contrib-react-resize-handle-97a754ab-6fd2-4913-a1b6-655a922e4b52.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: bump react-dom versions to support React 19",
+  "packageName": "@fluentui-contrib/react-resize-handle",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-contrib-react-shadow-10bf007c-a3aa-4b86-a0b6-9592e58d4605.json
+++ b/change/@fluentui-contrib-react-shadow-10bf007c-a3aa-4b86-a0b6-9592e58d4605.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: bump react-dom versions to support React 19",
+  "packageName": "@fluentui-contrib/react-shadow",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-contrib-react-themeless-provider-1f62a89e-d87b-4848-a11c-6d339e47f4ff.json
+++ b/change/@fluentui-contrib-react-themeless-provider-1f62a89e-d87b-4848-a11c-6d339e47f4ff.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: bump react-dom versions to support React 19",
+  "packageName": "@fluentui-contrib/react-themeless-provider",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-contrib-react-tree-grid-d967c25e-5c45-49dc-bbc6-8ba5d256f252.json
+++ b/change/@fluentui-contrib-react-tree-grid-d967c25e-5c45-49dc-bbc6-8ba5d256f252.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: bump react-dom versions to support React 19",
+  "packageName": "@fluentui-contrib/react-tree-grid",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
Fixes #537 #550

Some packages had `react/react-dom` as peer dependencies added automatically during build/publish, and they were using React 18, which got sorted out in #533. This PR is just to force-publish new versions for those packages so the update goes through.