### PR TITLE
feat(react-cap-theme): sync react-menu styles

### DIFF
--- a/change/@fluentui-contrib-react-cap-theme-input-component.json
+++ b/change/@fluentui-contrib-react-cap-theme-input-component.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "add react-input component",
+  "packageName": "@fluentui-contrib/react-cap-theme",
+  "email": "dzukowski@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-contrib-react-cap-theme-menu-sync.json
+++ b/change/@fluentui-contrib-react-cap-theme-menu-sync.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "sync react-menu styles",
+  "packageName": "@fluentui-contrib/react-cap-theme",
+  "email": "dzukowski@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-cap-theme/src/components/react-input/components/Input/Input.types.ts
+++ b/packages/react-cap-theme/src/components/react-input/components/Input/Input.types.ts
@@ -1,0 +1,22 @@
+import type {
+  InputProps as BaseInputProps,
+  InputState as BaseInputState,
+} from '@fluentui/react-input';
+
+export type InputProps = BaseInputProps & {
+  /**
+   * The color variant.
+   *
+   * - 'brand' (default): Primary emphasis using brand colors.
+   * - 'neutral': Secondary emphasis using neutral colors.
+   *
+   * @default 'brand'
+   */
+  // FIXME: Must not graduate to beta. Style implementation references Fluent tokens directly.
+  // `color` and `NeutralThemeProvider` solve the same brand/neutral switching problem at different
+  // levels of the stack with no defined interaction. Graduating locks in an API contract that may
+  // need to change once a proper token-based theming approach is defined.
+  color?: 'brand' | 'neutral';
+};
+
+export type InputState = BaseInputState & Required<Pick<InputProps, 'color'>>;

--- a/packages/react-cap-theme/src/components/react-input/components/Input/useInputStyles.styles.ts
+++ b/packages/react-cap-theme/src/components/react-input/components/Input/useInputStyles.styles.ts
@@ -113,7 +113,9 @@ const useIsEditableStyles = makeStyles({
   noValue: {
     color: capTokens.colorNeutralForeground5,
     ':hover': { color: capTokens.colorNeutralForeground5Hover },
-    ':active,:focus-within': { color: capTokens.colorNeutralForeground5Pressed },
+    ':active,:focus-within': {
+      color: capTokens.colorNeutralForeground5Pressed,
+    },
   },
   brand: {
     ':active,:focus-within': {
@@ -239,7 +241,7 @@ export const useInputStyles = (state: InputState): InputState => {
     invalid && styles.invalid,
     disabled && styles.disabled,
     disabled && appearance === 'underline' && styles.disabledUnderline,
-    getSlotClassNameProp_unstable(state.root),
+    getSlotClassNameProp_unstable(state.root)
   );
 
   state.input.className = mergeClasses(
@@ -247,7 +249,7 @@ export const useInputStyles = (state: InputState): InputState => {
     inputClassNames.input,
     inputStyles.base,
     disabled && inputStyles.disabled,
-    getSlotClassNameProp_unstable(state.input),
+    getSlotClassNameProp_unstable(state.input)
   );
 
   if (state.contentBefore) {
@@ -258,7 +260,7 @@ export const useInputStyles = (state: InputState): InputState => {
       contentStyles[size],
       contentStyles[`${size}ContentBefore`],
       disabled && contentStyles.disabled,
-      getSlotClassNameProp_unstable(state.contentBefore),
+      getSlotClassNameProp_unstable(state.contentBefore)
     );
   }
 
@@ -270,7 +272,7 @@ export const useInputStyles = (state: InputState): InputState => {
       contentStyles[size],
       contentStyles[`${size}ContentAfter`],
       disabled && contentStyles.disabled,
-      getSlotClassNameProp_unstable(state.contentAfter),
+      getSlotClassNameProp_unstable(state.contentAfter)
     );
   }
 

--- a/packages/react-cap-theme/src/components/react-input/components/Input/useInputStyles.styles.ts
+++ b/packages/react-cap-theme/src/components/react-input/components/Input/useInputStyles.styles.ts
@@ -1,5 +1,6 @@
 import { inputClassNames } from '@fluentui/react-input';
 import { makeStyles, mergeClasses, shorthands } from '@griffel/react';
+import { getSlotClassNameProp_unstable } from '@fluentui/react-utilities';
 import { tokens, typographyStyles } from '@fluentui/tokens';
 import { capTokens } from '../../../tokens';
 import type { InputState } from './Input.types';
@@ -224,6 +225,7 @@ export const useInputStyles = (state: InputState): InputState => {
   const invalid = `${state.input['aria-invalid']}` === 'true';
 
   state.root.className = mergeClasses(
+    state.root.className,
     inputClassNames.root,
     styles.root,
     styles[size],
@@ -237,35 +239,38 @@ export const useInputStyles = (state: InputState): InputState => {
     invalid && styles.invalid,
     disabled && styles.disabled,
     disabled && appearance === 'underline' && styles.disabledUnderline,
-    state.root.className,
+    getSlotClassNameProp_unstable(state.root),
   );
 
   state.input.className = mergeClasses(
+    state.input.className,
     inputClassNames.input,
     inputStyles.base,
     disabled && inputStyles.disabled,
-    state.input.className,
+    getSlotClassNameProp_unstable(state.input),
   );
 
   if (state.contentBefore) {
     state.contentBefore.className = mergeClasses(
+      state.contentBefore.className,
       inputClassNames.contentBefore,
       contentStyles.base,
       contentStyles[size],
       contentStyles[`${size}ContentBefore`],
       disabled && contentStyles.disabled,
-      state.contentBefore.className,
+      getSlotClassNameProp_unstable(state.contentBefore),
     );
   }
 
   if (state.contentAfter) {
     state.contentAfter.className = mergeClasses(
+      state.contentAfter.className,
       inputClassNames.contentAfter,
       contentStyles.base,
       contentStyles[size],
       contentStyles[`${size}ContentAfter`],
       disabled && contentStyles.disabled,
-      state.contentAfter.className,
+      getSlotClassNameProp_unstable(state.contentAfter),
     );
   }
 

--- a/packages/react-cap-theme/src/components/react-input/components/Input/useInputStyles.styles.ts
+++ b/packages/react-cap-theme/src/components/react-input/components/Input/useInputStyles.styles.ts
@@ -1,0 +1,273 @@
+import { inputClassNames } from '@fluentui/react-input';
+import { makeStyles, mergeClasses, shorthands } from '@griffel/react';
+import { tokens, typographyStyles } from '@fluentui/tokens';
+import { capTokens } from '../../../tokens';
+import type { InputState } from './Input.types';
+
+const iconFilledClassName = 'fui-Icon-filled';
+const iconRegularClassName = 'fui-Icon-regular';
+
+const useStyles = makeStyles({
+  root: {
+    boxSizing: 'border-box',
+    display: 'inline-flex',
+    flexWrap: 'nowrap',
+    alignItems: 'center',
+    verticalAlign: 'middle',
+    minHeight: '36px',
+    padding: `${tokens.spacingVerticalNone} ${tokens.spacingHorizontalMNudge}`,
+    color: tokens.colorNeutralForeground1,
+    backgroundColor: tokens.colorNeutralBackground1,
+    border: `${tokens.strokeWidthThin} solid ${tokens.colorNeutralStrokeAccessible}`,
+    borderRadius: capTokens.borderRadius2XLarge,
+    ...typographyStyles.body1,
+  },
+  small: {
+    minHeight: '28px',
+    padding: `${tokens.spacingVerticalNone} ${tokens.spacingHorizontalS}`,
+    ...typographyStyles.caption1,
+    borderRadius: tokens.borderRadiusXLarge,
+  },
+  medium: {
+    /* same as root */
+  },
+  large: {
+    minHeight: '44px',
+    ...typographyStyles.body2,
+    padding: `${tokens.spacingVerticalNone} ${tokens.spacingHorizontalM}`,
+  },
+  disabled: {
+    ...shorthands.borderColor(tokens.colorNeutralStrokeDisabled),
+    backgroundColor: tokens.colorTransparentBackground,
+    color: tokens.colorNeutralForegroundDisabled,
+    cursor: 'not-allowed',
+
+    '@media (forced-colors: active)': {
+      ...shorthands.borderColor('GrayText'),
+    },
+  },
+  disabledUnderline: {
+    borderRadius: '0',
+    borderTopStyle: 'none',
+    borderRightStyle: 'none',
+    borderLeftStyle: 'none',
+    '@media (forced-colors: active)': {
+      borderTopColor: 'Canvas',
+      borderRightColor: 'Canvas',
+      borderLeftColor: 'Canvas',
+
+      ':focus': {
+        borderBottomColor: 'Canvas',
+      },
+    },
+  },
+  invalid: {
+    ...shorthands.borderColor(tokens.colorStatusDangerBorder2),
+    ':hover': {
+      ...shorthands.borderColor(tokens.colorStatusDangerBorder2),
+    },
+  },
+});
+
+const useIsEditableStyles = makeStyles({
+  base: {
+    ':hover': {
+      [`& .${inputClassNames.contentBefore} > .${iconRegularClassName}`]: {
+        display: 'none',
+      },
+      [`& .${inputClassNames.contentBefore} > .${iconFilledClassName}`]: {
+        display: 'inline',
+      },
+      [`& .${inputClassNames.contentAfter} > .${iconRegularClassName}`]: {
+        display: 'none',
+      },
+      [`& .${inputClassNames.contentAfter} > .${iconFilledClassName}`]: {
+        display: 'inline',
+      },
+    },
+    ':active,:focus-within': {
+      [`& .${inputClassNames.contentBefore} > .${iconRegularClassName}`]: {
+        display: 'none',
+      },
+      [`& .${inputClassNames.contentBefore} > .${iconFilledClassName}`]: {
+        display: 'inline',
+      },
+      [`& .${inputClassNames.contentAfter} > .${iconRegularClassName}`]: {
+        display: 'none',
+      },
+      [`& .${inputClassNames.contentAfter} > .${iconFilledClassName}`]: {
+        display: 'inline',
+      },
+    },
+
+    ':focus-within': {
+      outline: `${tokens.strokeWidthThick} solid ${tokens.colorTransparentStroke}`,
+    },
+  },
+
+  hasValue: {
+    ':hover': { color: tokens.colorNeutralForeground1Hover },
+    ':active,:focus-within': { color: tokens.colorNeutralForeground1Pressed },
+  },
+  noValue: {
+    color: tokens.colorNeutralForeground5,
+    ':hover': { color: tokens.colorNeutralForeground5Hover },
+    ':active,:focus-within': { color: tokens.colorNeutralForeground5Pressed },
+  },
+  brand: {
+    ':active,:focus-within': {
+      ...shorthands.borderColor(tokens.colorBrandStroke1),
+      [`& .${inputClassNames.contentBefore}`]: {
+        color: tokens.colorBrandForeground2,
+      },
+    },
+  },
+  neutral: {
+    ':active,:focus-within': {
+      ...shorthands.borderColor(tokens.colorNeutralStrokeAccessiblePressed),
+      [`& .${inputClassNames.contentBefore}`]: {
+        color: tokens.colorNeutralForeground1Pressed,
+      },
+    },
+  },
+});
+
+const useAppearanceStyles = makeStyles({
+  outline: {
+    ':hover': {
+      ...shorthands.borderColor(tokens.colorNeutralStrokeAccessibleHover),
+    },
+  },
+  underline: {
+    backgroundColor: tokens.colorTransparentBackground,
+    borderRadius: '0',
+    borderTopStyle: 'none',
+    borderRightStyle: 'none',
+    borderLeftStyle: 'none',
+    borderBottomColor: tokens.colorNeutralStrokeAccessible,
+    '@media (forced-colors: active)': {
+      ':focus-within': {
+        borderBottomColor: 'Canvas',
+      },
+    },
+  },
+});
+
+const useContentStyles = makeStyles({
+  base: {
+    display: 'flex',
+    color: 'inherit',
+    '> svg': { fontSize: tokens.fontSizeBase500 },
+  },
+  small: { '> svg': { fontSize: tokens.fontSizeBase400 } },
+  medium: {
+    /* same as base */
+  },
+  large: { '> svg': { fontSize: tokens.fontSizeBase600 } },
+
+  smallContentBefore: { paddingRight: tokens.spacingHorizontalXS },
+  smallContentAfter: { paddingLeft: tokens.spacingHorizontalS },
+
+  mediumContentBefore: { paddingRight: tokens.spacingHorizontalSNudge },
+  mediumContentAfter: { paddingLeft: tokens.spacingHorizontalMNudge },
+
+  largeContentBefore: { paddingRight: tokens.spacingHorizontalS },
+  largeContentAfter: { paddingLeft: tokens.spacingHorizontalM },
+
+  disabled: { color: 'inherit' },
+});
+
+const useInputElementStyles = makeStyles({
+  base: {
+    alignSelf: 'stretch',
+    boxSizing: 'border-box',
+    flexGrow: 1,
+    minWidth: 0,
+    backgroundColor: tokens.colorTransparentBackground,
+    border: 'none',
+    outline: 'none',
+    color: 'inherit',
+    fontFamily: 'inherit',
+    fontSize: 'inherit',
+    fontWeight: 'inherit',
+    lineHeight: 'inherit',
+
+    '::placeholder': {
+      opacity: 1,
+      color: 'inherit',
+    },
+  },
+  disabled: {
+    cursor: 'inherit',
+  },
+});
+
+/**
+ * Apply styling to the Input based on the state.
+ * @param state - The current Input state
+ * @returns The updated Input state with applied styles
+ * @alpha
+ */
+export const useInputStyles = (state: InputState): InputState => {
+  const styles = useStyles();
+  const isEditableStyles = useIsEditableStyles();
+  const appearanceStyles = useAppearanceStyles();
+  const contentStyles = useContentStyles();
+  const inputStyles = useInputElementStyles();
+
+  const appearance = state.appearance ?? 'outline';
+  const color = state.color ?? 'brand';
+  const { size } = state;
+  const { disabled, value } = state.input;
+  const isEditable = !disabled;
+  const hasValue = !!value;
+  const invalid = `${state.input['aria-invalid']}` === 'true';
+
+  state.root.className = mergeClasses(
+    inputClassNames.root,
+    styles.root,
+    styles[size],
+    isEditable && isEditableStyles.base,
+    isEditable &&
+      (hasValue ? isEditableStyles.hasValue : isEditableStyles.noValue),
+    isEditable &&
+      (appearance === 'outline' || appearance === 'underline') &&
+      appearanceStyles[appearance],
+    isEditable && isEditableStyles[color],
+    invalid && styles.invalid,
+    disabled && styles.disabled,
+    disabled && appearance === 'underline' && styles.disabledUnderline,
+    state.root.className,
+  );
+
+  state.input.className = mergeClasses(
+    inputClassNames.input,
+    inputStyles.base,
+    disabled && inputStyles.disabled,
+    state.input.className,
+  );
+
+  if (state.contentBefore) {
+    state.contentBefore.className = mergeClasses(
+      inputClassNames.contentBefore,
+      contentStyles.base,
+      contentStyles[size],
+      contentStyles[`${size}ContentBefore`],
+      disabled && contentStyles.disabled,
+      state.contentBefore.className,
+    );
+  }
+
+  if (state.contentAfter) {
+    state.contentAfter.className = mergeClasses(
+      inputClassNames.contentAfter,
+      contentStyles.base,
+      contentStyles[size],
+      contentStyles[`${size}ContentAfter`],
+      disabled && contentStyles.disabled,
+      state.contentAfter.className,
+    );
+  }
+
+  return state;
+};

--- a/packages/react-cap-theme/src/components/react-input/components/Input/useInputStyles.styles.ts
+++ b/packages/react-cap-theme/src/components/react-input/components/Input/useInputStyles.styles.ts
@@ -111,9 +111,9 @@ const useIsEditableStyles = makeStyles({
     ':active,:focus-within': { color: tokens.colorNeutralForeground1Pressed },
   },
   noValue: {
-    color: tokens.colorNeutralForeground5,
-    ':hover': { color: tokens.colorNeutralForeground5Hover },
-    ':active,:focus-within': { color: tokens.colorNeutralForeground5Pressed },
+    color: capTokens.colorNeutralForeground5,
+    ':hover': { color: capTokens.colorNeutralForeground5Hover },
+    ':active,:focus-within': { color: capTokens.colorNeutralForeground5Pressed },
   },
   brand: {
     ':active,:focus-within': {

--- a/packages/react-cap-theme/src/components/react-input/index.ts
+++ b/packages/react-cap-theme/src/components/react-input/index.ts
@@ -1,0 +1,1 @@
+export { useInputStyles } from './components/Input/useInputStyles.styles';

--- a/packages/react-cap-theme/src/components/react-menu/components/MenuDivider/useMenuDividerStyles.styles.ts
+++ b/packages/react-cap-theme/src/components/react-menu/components/MenuDivider/useMenuDividerStyles.styles.ts
@@ -7,6 +7,7 @@ import {
   type SlotClassNames,
 } from '@fluentui/react-utilities';
 import { tokens } from '@fluentui/tokens';
+import { capTokens } from '../../../tokens';
 import { makeStyles, mergeClasses } from '@griffel/react';
 
 export const menuDividerClassNames: SlotClassNames<MenuDividerSlots> = {
@@ -15,8 +16,8 @@ export const menuDividerClassNames: SlotClassNames<MenuDividerSlots> = {
 
 const useStyles = makeStyles({
   root: {
-    borderBottomColor: tokens.colorNeutralStroke3,
-    margin: `${tokens.spacingVerticalSNudge} ${tokens.spacingHorizontalXS}`,
+    borderBottomColor: capTokens.colorNeutralStroke4,
+    margin: `${tokens.spacingVerticalSNudge} ${tokens.spacingHorizontalSNudge}`,
   },
 });
 

--- a/packages/react-cap-theme/src/components/react-menu/components/MenuGroupHeader/useMenuGroupHeaderStyles.styles.ts
+++ b/packages/react-cap-theme/src/components/react-menu/components/MenuGroupHeader/useMenuGroupHeaderStyles.styles.ts
@@ -6,8 +6,7 @@ import {
   getSlotClassNameProp_unstable,
   type SlotClassNames,
 } from '@fluentui/react-utilities';
-import { tokens } from '@fluentui/tokens';
-import { typographyStyles } from '@fluentui/tokens';
+import { tokens, typographyStyles } from '@fluentui/tokens';
 import { makeStyles, mergeClasses } from '@griffel/react';
 
 export const menuGroupHeaderClassNames: SlotClassNames<MenuGroupHeaderSlots> = {
@@ -19,6 +18,7 @@ const useStyles = makeStyles({
     ...typographyStyles.caption1Strong,
     height: 'auto',
     padding: `${tokens.spacingVerticalSNudge} ${tokens.spacingHorizontalS} ${tokens.spacingVerticalS}`,
+    color: tokens.colorNeutralForeground2,
   },
 });
 

--- a/packages/react-cap-theme/src/components/react-menu/components/MenuItem/useMenuItemStyles.styles.ts
+++ b/packages/react-cap-theme/src/components/react-menu/components/MenuItem/useMenuItemStyles.styles.ts
@@ -153,14 +153,14 @@ export const useMenuItemStyles = (state: MenuItemState): MenuItemState => {
     menuItemClassNames.root,
     styles.root,
     disabled ? styles.disabled : interactiveStyles.root,
-    getSlotClassNameProp_unstable(state.root),
+    getSlotClassNameProp_unstable(state.root)
   );
 
   if (state.content) {
     state.content.className = mergeClasses(
       state.content.className,
       menuItemClassNames.content,
-      styles.content,
+      styles.content
     );
   }
   if (state.icon) {
@@ -168,7 +168,7 @@ export const useMenuItemStyles = (state: MenuItemState): MenuItemState => {
       state.icon.className,
       menuItemClassNames.icon,
       styles.icon,
-      getSlotClassNameProp_unstable(state.icon),
+      getSlotClassNameProp_unstable(state.icon)
     );
   }
   if (state.secondaryContent) {
@@ -176,7 +176,7 @@ export const useMenuItemStyles = (state: MenuItemState): MenuItemState => {
       state.secondaryContent.className,
       menuItemClassNames.secondaryContent,
       styles.secondaryContent,
-      getSlotClassNameProp_unstable(state.secondaryContent),
+      getSlotClassNameProp_unstable(state.secondaryContent)
     );
   }
   if (state.submenuIndicator) {
@@ -184,7 +184,7 @@ export const useMenuItemStyles = (state: MenuItemState): MenuItemState => {
       state.submenuIndicator.className,
       menuItemClassNames.submenuIndicator,
       styles.submenuIndicator,
-      getSlotClassNameProp_unstable(state.submenuIndicator),
+      getSlotClassNameProp_unstable(state.submenuIndicator)
     );
   }
   if (state.subText) {
@@ -192,7 +192,7 @@ export const useMenuItemStyles = (state: MenuItemState): MenuItemState => {
       state.subText.className,
       menuItemClassNames.subText,
       styles.subText,
-      getSlotClassNameProp_unstable(state.subText),
+      getSlotClassNameProp_unstable(state.subText)
     );
   }
 
@@ -202,7 +202,7 @@ export const useMenuItemStyles = (state: MenuItemState): MenuItemState => {
     state.content.className = mergeClasses(
       state.content.className,
       multiline && multilineStyles.content,
-      getSlotClassNameProp_unstable(state.content),
+      getSlotClassNameProp_unstable(state.content)
     );
   }
 

--- a/packages/react-cap-theme/src/components/react-menu/components/MenuItem/useMenuItemStyles.styles.ts
+++ b/packages/react-cap-theme/src/components/react-menu/components/MenuItem/useMenuItemStyles.styles.ts
@@ -2,13 +2,14 @@ import {
   menuItemClassNames as fluentMenuItemClassNames,
   type MenuItemSlots,
   type MenuItemState,
+  useMenuItemStyles_unstable,
 } from '@fluentui/react-menu';
 import {
   getSlotClassNameProp_unstable,
   type SlotClassNames,
 } from '@fluentui/react-utilities';
-import { tokens } from '@fluentui/tokens';
-import { typographyStyles } from '@fluentui/tokens';
+import { createFocusOutlineStyle } from '@fluentui/react-tabster';
+import { tokens, typographyStyles } from '@fluentui/tokens';
 import { makeStyles, mergeClasses } from '@griffel/react';
 
 export const menuItemClassNames: SlotClassNames<MenuItemSlots> = {
@@ -23,73 +24,124 @@ export const menuItemClassNames: SlotClassNames<MenuItemSlots> = {
 
 const useStyles = makeStyles({
   root: {
-    borderRadius: tokens.borderRadiusXLarge,
-    color: tokens.colorNeutralForeground3,
+    borderRadius: tokens.borderRadiusLarge,
+    color: tokens.colorNeutralForeground5,
     gap: 0,
-    minWidth: 0, // allow truncation
+    minWidth: 0,
     padding: `${tokens.spacingVerticalSNudge} ${tokens.spacingHorizontalSNudge}`,
-
-    ':hover': {
-      color: tokens.colorNeutralForeground1Hover,
-      [`& .${fluentMenuItemClassNames.icon}`]: { color: 'currentColor' },
-      [`& .${fluentMenuItemClassNames.subText}`]: {
-        color: 'currentColor',
-      },
-    },
-    ':hover:active': {
-      [`& .${fluentMenuItemClassNames.subText}`]: {
-        color: 'currentColor',
-      },
+    ...createFocusOutlineStyle({
+      style: { outlineRadius: tokens.borderRadiusXLarge },
+    }),
+    '@media (forced-colors: active)': {
+      ...createFocusOutlineStyle({
+        style: { outlineRadius: tokens.borderRadiusXLarge },
+      }),
     },
   },
   disabled: {
     color: tokens.colorNeutralForegroundDisabled,
-    ':hover': { color: tokens.colorNeutralForegroundDisabled },
-    ':hover:active': { color: tokens.colorNeutralForegroundDisabled },
+    [`& .${fluentMenuItemClassNames.subText}`]: { color: 'inherit' },
+    [`& .${fluentMenuItemClassNames.secondaryContent}`]: { color: 'inherit' },
+    [`& .${fluentMenuItemClassNames.submenuIndicator}`]: { color: 'inherit' },
+    ':hover': {
+      backgroundColor: 'unset',
+      color: tokens.colorNeutralForegroundDisabled,
+    },
+    ':hover:active': {
+      backgroundColor: 'unset',
+      color: tokens.colorNeutralForegroundDisabled,
+    },
     ':focus': { color: tokens.colorNeutralForegroundDisabled },
   },
   content: {
-    color: 'currentColor',
+    paddingLeft: tokens.spacingHorizontalNone,
+    paddingRight: tokens.spacingHorizontalNone,
     flex: 1,
     minWidth: '50px',
     overflow: 'hidden',
     textOverflow: 'ellipsis',
   },
-  icon: {
-    color: 'currentColor',
-    marginRight: tokens.spacingHorizontalSNudge,
-  },
+  icon: { marginRight: tokens.spacingHorizontalSNudge },
   secondaryContent: {
-    ...typographyStyles.caption1,
-    color: 'currentColor',
+    ...typographyStyles.body1,
+    color: tokens.colorNeutralForeground3,
     alignSelf: 'center',
     wordBreak: 'break-word',
-    ':hover': { color: 'currentColor' },
+    paddingLeft: tokens.spacingHorizontalSNudge,
+    paddingRight: tokens.spacingHorizontalNone,
     ':focus': { color: 'currentColor' },
   },
   submenuIndicator: {
     alignSelf: 'center',
-    color: 'currentColor',
+    color: tokens.colorNeutralForeground3,
     fontSize: '16px',
     height: '16px',
     paddingLeft: tokens.spacingHorizontalXS,
     width: '16px',
   },
   subText: {
-    color: 'currentColor',
-    display: 'block', // move below
+    color: 'inherit',
+    display: 'block',
     ...typographyStyles.caption1,
+  },
+});
+
+const useInteractiveStyles = makeStyles({
+  root: {
+    ':hover': {
+      color: tokens.colorNeutralForeground5Hover,
+      [`& .${fluentMenuItemClassNames.icon}`]: { color: 'inherit' },
+      [`& .${fluentMenuItemClassNames.subText}`]: { color: 'inherit' },
+      [`& .${fluentMenuItemClassNames.secondaryContent}`]: {
+        color: tokens.colorNeutralForeground3Hover,
+      },
+      [`& .${fluentMenuItemClassNames.submenuIndicator}`]: {
+        color: tokens.colorNeutralForeground3Hover,
+      },
+    },
+    ':hover:active': {
+      color: tokens.colorNeutralForeground5Pressed,
+      [`& .${fluentMenuItemClassNames.subText}`]: { color: 'inherit' },
+      [`& .${fluentMenuItemClassNames.secondaryContent}`]: {
+        color: tokens.colorNeutralForeground3Pressed,
+      },
+      [`& .${fluentMenuItemClassNames.submenuIndicator}`]: {
+        color: tokens.colorNeutralForeground3Pressed,
+      },
+    },
+
+    '@media (forced-colors: active)': {
+      ':hover': {
+        [`& .${fluentMenuItemClassNames.secondaryContent}`]: {
+          color: 'inherit',
+        },
+        [`& .${fluentMenuItemClassNames.submenuIndicator}`]: {
+          color: 'inherit',
+        },
+      },
+      ':hover:active': {
+        backgroundColor: 'Canvas',
+        color: 'Highlight',
+        [`& .${fluentMenuItemClassNames.secondaryContent}`]: {
+          color: 'inherit',
+        },
+        [`& .${fluentMenuItemClassNames.submenuIndicator}`]: {
+          color: 'inherit',
+        },
+      },
+    },
   },
 });
 
 const useMultilineStyles = makeStyles({
   content: {
-    display: 'block', // allow truncation
+    display: 'block',
   },
 });
 
 export const useMenuItemStyles = (state: MenuItemState): MenuItemState => {
   const styles = useStyles();
+  const interactiveStyles = useInteractiveStyles();
   const multilineStyles = useMultilineStyles();
 
   const multiline = !!state.subText;
@@ -99,15 +151,15 @@ export const useMenuItemStyles = (state: MenuItemState): MenuItemState => {
     state.root.className,
     menuItemClassNames.root,
     styles.root,
-    disabled && styles.disabled,
-    getSlotClassNameProp_unstable(state.root)
+    disabled ? styles.disabled : interactiveStyles.root,
+    getSlotClassNameProp_unstable(state.root),
   );
 
   if (state.content) {
     state.content.className = mergeClasses(
       state.content.className,
       menuItemClassNames.content,
-      styles.content
+      styles.content,
     );
   }
   if (state.icon) {
@@ -115,7 +167,7 @@ export const useMenuItemStyles = (state: MenuItemState): MenuItemState => {
       state.icon.className,
       menuItemClassNames.icon,
       styles.icon,
-      getSlotClassNameProp_unstable(state.icon)
+      getSlotClassNameProp_unstable(state.icon),
     );
   }
   if (state.secondaryContent) {
@@ -123,7 +175,7 @@ export const useMenuItemStyles = (state: MenuItemState): MenuItemState => {
       state.secondaryContent.className,
       menuItemClassNames.secondaryContent,
       styles.secondaryContent,
-      getSlotClassNameProp_unstable(state.secondaryContent)
+      getSlotClassNameProp_unstable(state.secondaryContent),
     );
   }
   if (state.submenuIndicator) {
@@ -131,7 +183,7 @@ export const useMenuItemStyles = (state: MenuItemState): MenuItemState => {
       state.submenuIndicator.className,
       menuItemClassNames.submenuIndicator,
       styles.submenuIndicator,
-      getSlotClassNameProp_unstable(state.submenuIndicator)
+      getSlotClassNameProp_unstable(state.submenuIndicator),
     );
   }
   if (state.subText) {
@@ -139,15 +191,17 @@ export const useMenuItemStyles = (state: MenuItemState): MenuItemState => {
       state.subText.className,
       menuItemClassNames.subText,
       styles.subText,
-      getSlotClassNameProp_unstable(state.subText)
+      getSlotClassNameProp_unstable(state.subText),
     );
   }
+
+  useMenuItemStyles_unstable(state);
 
   if (state.content) {
     state.content.className = mergeClasses(
       state.content.className,
       multiline && multilineStyles.content,
-      getSlotClassNameProp_unstable(state.content)
+      getSlotClassNameProp_unstable(state.content),
     );
   }
 

--- a/packages/react-cap-theme/src/components/react-menu/components/MenuItem/useMenuItemStyles.styles.ts
+++ b/packages/react-cap-theme/src/components/react-menu/components/MenuItem/useMenuItemStyles.styles.ts
@@ -11,6 +11,7 @@ import {
 import { createFocusOutlineStyle } from '@fluentui/react-tabster';
 import { tokens, typographyStyles } from '@fluentui/tokens';
 import { makeStyles, mergeClasses } from '@griffel/react';
+import { capTokens } from '../../../tokens';
 
 export const menuItemClassNames: SlotClassNames<MenuItemSlots> = {
   root: 'fui-MenuItem',
@@ -25,7 +26,7 @@ export const menuItemClassNames: SlotClassNames<MenuItemSlots> = {
 const useStyles = makeStyles({
   root: {
     borderRadius: tokens.borderRadiusLarge,
-    color: tokens.colorNeutralForeground5,
+    color: capTokens.colorNeutralForeground5,
     gap: 0,
     minWidth: 0,
     padding: `${tokens.spacingVerticalSNudge} ${tokens.spacingHorizontalSNudge}`,
@@ -89,7 +90,7 @@ const useStyles = makeStyles({
 const useInteractiveStyles = makeStyles({
   root: {
     ':hover': {
-      color: tokens.colorNeutralForeground5Hover,
+      color: capTokens.colorNeutralForeground5Hover,
       [`& .${fluentMenuItemClassNames.icon}`]: { color: 'inherit' },
       [`& .${fluentMenuItemClassNames.subText}`]: { color: 'inherit' },
       [`& .${fluentMenuItemClassNames.secondaryContent}`]: {
@@ -100,7 +101,7 @@ const useInteractiveStyles = makeStyles({
       },
     },
     ':hover:active': {
-      color: tokens.colorNeutralForeground5Pressed,
+      color: capTokens.colorNeutralForeground5Pressed,
       [`& .${fluentMenuItemClassNames.subText}`]: { color: 'inherit' },
       [`& .${fluentMenuItemClassNames.secondaryContent}`]: {
         color: tokens.colorNeutralForeground3Pressed,

--- a/packages/react-cap-theme/src/components/react-menu/components/MenuItemCheckbox/useMenuItemCheckboxStyles.styles.ts
+++ b/packages/react-cap-theme/src/components/react-menu/components/MenuItemCheckbox/useMenuItemCheckboxStyles.styles.ts
@@ -1,46 +1,79 @@
-import type {
-  MenuItemCheckboxState,
-  MenuItemSlots,
-} from '@fluentui/react-menu';
+import type { MenuItemCheckboxState } from '@fluentui/react-menu';
 import {
-  getSlotClassNameProp_unstable,
-  type SlotClassNames,
-} from '@fluentui/react-utilities';
+  menuItemCheckboxClassNames,
+  menuItemClassNames,
+} from '@fluentui/react-menu';
 import { makeStyles, mergeClasses } from '@griffel/react';
+import { tokens } from '@fluentui/tokens';
+
 import { useMenuItemStyles } from '../MenuItem/useMenuItemStyles.styles';
+import { useCheckmarkStyles_unstable } from '../../selectable/useCheckmarkStyles.style';
 
-export const menuItemCheckboxClassNames: SlotClassNames<MenuItemSlots> = {
-  root: 'fui-MenuItemCheckbox',
-  content: 'fui-MenuItemCheckbox__content',
-  icon: 'fui-MenuItemCheckbox__icon',
-  checkmark: 'fui-MenuItemCheckbox__checkmark',
-  submenuIndicator: 'fui-MenuItemCheckbox__submenuIndicator',
-  secondaryContent: 'fui-MenuItemCheckbox__secondaryContent',
-  subText: 'fui-MenuItemCheckbox__subText',
-};
-
-const useStyles = makeStyles({
-  checkmark: {
-    fontSize: '20px',
-    height: '20px',
-    width: '20px',
+const useInteractiveStyles = makeStyles({
+  root: {
+    [`:hover .${menuItemClassNames.checkmark}`]: { visibility: 'visible' },
   },
+});
+
+const useCheckmarkStyles = makeStyles({
+  base: {
+    fontSize: tokens.fontSizeBase400,
+    padding: `${tokens.spacingVerticalXXS} ${tokens.spacingHorizontalXXS}`,
+  },
+  unchecked: { visibility: 'hidden' },
 });
 
 export const useMenuItemCheckboxStyles = (
   state: MenuItemCheckboxState
 ): MenuItemCheckboxState => {
-  const styles = useStyles();
+  const { checked, disabled } = state;
+  const interactiveStyles = useInteractiveStyles();
+  const checkmarkStyles = useCheckmarkStyles();
+
+  state.root.className = mergeClasses(
+    state.root.className,
+    menuItemCheckboxClassNames.root,
+    !disabled && interactiveStyles.root,
+  );
+
+  if (state.content) {
+    state.content.className = mergeClasses(
+      state.content.className,
+      menuItemCheckboxClassNames.content,
+    );
+  }
+
+  if (state.secondaryContent) {
+    state.secondaryContent.className = mergeClasses(
+      state.secondaryContent.className,
+      menuItemCheckboxClassNames.secondaryContent,
+    );
+  }
+
+  if (state.icon) {
+    state.icon.className = mergeClasses(
+      state.icon.className,
+      menuItemCheckboxClassNames.icon,
+    );
+  }
 
   if (state.checkmark) {
     state.checkmark.className = mergeClasses(
       state.checkmark.className,
       menuItemCheckboxClassNames.checkmark,
-      styles.checkmark,
-      getSlotClassNameProp_unstable(state.checkmark)
+      checkmarkStyles.base,
+      !checked && checkmarkStyles.unchecked,
     );
   }
 
+  if (state.subText) {
+    state.subText.className = mergeClasses(
+      state.subText.className,
+      menuItemCheckboxClassNames.subText,
+    );
+  }
+
+  useCheckmarkStyles_unstable(state);
   useMenuItemStyles(state);
 
   return state;

--- a/packages/react-cap-theme/src/components/react-menu/components/MenuItemCheckbox/useMenuItemCheckboxStyles.styles.ts
+++ b/packages/react-cap-theme/src/components/react-menu/components/MenuItemCheckbox/useMenuItemCheckboxStyles.styles.ts
@@ -34,27 +34,27 @@ export const useMenuItemCheckboxStyles = (
   state.root.className = mergeClasses(
     state.root.className,
     menuItemCheckboxClassNames.root,
-    !disabled && interactiveStyles.root,
+    !disabled && interactiveStyles.root
   );
 
   if (state.content) {
     state.content.className = mergeClasses(
       state.content.className,
-      menuItemCheckboxClassNames.content,
+      menuItemCheckboxClassNames.content
     );
   }
 
   if (state.secondaryContent) {
     state.secondaryContent.className = mergeClasses(
       state.secondaryContent.className,
-      menuItemCheckboxClassNames.secondaryContent,
+      menuItemCheckboxClassNames.secondaryContent
     );
   }
 
   if (state.icon) {
     state.icon.className = mergeClasses(
       state.icon.className,
-      menuItemCheckboxClassNames.icon,
+      menuItemCheckboxClassNames.icon
     );
   }
 
@@ -63,14 +63,14 @@ export const useMenuItemCheckboxStyles = (
       state.checkmark.className,
       menuItemCheckboxClassNames.checkmark,
       checkmarkStyles.base,
-      !checked && checkmarkStyles.unchecked,
+      !checked && checkmarkStyles.unchecked
     );
   }
 
   if (state.subText) {
     state.subText.className = mergeClasses(
       state.subText.className,
-      menuItemCheckboxClassNames.subText,
+      menuItemCheckboxClassNames.subText
     );
   }
 

--- a/packages/react-cap-theme/src/components/react-menu/components/MenuItemCheckbox/useMenuItemCheckboxStyles.styles.ts
+++ b/packages/react-cap-theme/src/components/react-menu/components/MenuItemCheckbox/useMenuItemCheckboxStyles.styles.ts
@@ -3,6 +3,7 @@ import {
   menuItemCheckboxClassNames,
   menuItemClassNames,
 } from '@fluentui/react-menu';
+export { menuItemCheckboxClassNames } from '@fluentui/react-menu';
 import { makeStyles, mergeClasses } from '@griffel/react';
 import { tokens } from '@fluentui/tokens';
 

--- a/packages/react-cap-theme/src/components/react-menu/components/MenuItemLink/useMenuItemLinkStyles.styles.ts
+++ b/packages/react-cap-theme/src/components/react-menu/components/MenuItemLink/useMenuItemLinkStyles.styles.ts
@@ -1,0 +1,60 @@
+import {
+  type MenuItemLinkState,
+  type MenuItemState,
+  menuItemLinkClassNames,
+} from '@fluentui/react-menu';
+import { makeStyles, mergeClasses } from '@griffel/react';
+import { useMenuItemStyles } from '../MenuItem/useMenuItemStyles.styles';
+
+const useStyles = makeStyles({
+  resetLink: {
+    textDecorationLine: 'none',
+    textDecorationThickness: 'initial',
+    textDecorationStyle: 'initial',
+    textDecorationColor: 'initial',
+  },
+});
+
+export const useMenuItemLinkStyles = (
+  state: MenuItemLinkState
+): MenuItemLinkState => {
+  const styles = useStyles();
+
+  state.root.className = mergeClasses(
+    state.root.className,
+    menuItemLinkClassNames.root,
+    styles.resetLink,
+  );
+
+  if (state.icon) {
+    state.icon.className = mergeClasses(
+      state.icon.className,
+      menuItemLinkClassNames.icon,
+    );
+  }
+
+  if (state.content) {
+    state.content.className = mergeClasses(
+      state.content.className,
+      menuItemLinkClassNames.content,
+    );
+  }
+
+  if (state.secondaryContent) {
+    state.secondaryContent.className = mergeClasses(
+      state.secondaryContent.className,
+      menuItemLinkClassNames.secondaryContent,
+    );
+  }
+
+  if (state.checkmark) {
+    state.checkmark.className = mergeClasses(
+      state.checkmark.className,
+      menuItemLinkClassNames.checkmark,
+    );
+  }
+
+  useMenuItemStyles(state as MenuItemState);
+
+  return state;
+};

--- a/packages/react-cap-theme/src/components/react-menu/components/MenuItemLink/useMenuItemLinkStyles.styles.ts
+++ b/packages/react-cap-theme/src/components/react-menu/components/MenuItemLink/useMenuItemLinkStyles.styles.ts
@@ -23,34 +23,34 @@ export const useMenuItemLinkStyles = (
   state.root.className = mergeClasses(
     state.root.className,
     menuItemLinkClassNames.root,
-    styles.resetLink,
+    styles.resetLink
   );
 
   if (state.icon) {
     state.icon.className = mergeClasses(
       state.icon.className,
-      menuItemLinkClassNames.icon,
+      menuItemLinkClassNames.icon
     );
   }
 
   if (state.content) {
     state.content.className = mergeClasses(
       state.content.className,
-      menuItemLinkClassNames.content,
+      menuItemLinkClassNames.content
     );
   }
 
   if (state.secondaryContent) {
     state.secondaryContent.className = mergeClasses(
       state.secondaryContent.className,
-      menuItemLinkClassNames.secondaryContent,
+      menuItemLinkClassNames.secondaryContent
     );
   }
 
   if (state.checkmark) {
     state.checkmark.className = mergeClasses(
       state.checkmark.className,
-      menuItemLinkClassNames.checkmark,
+      menuItemLinkClassNames.checkmark
     );
   }
 

--- a/packages/react-cap-theme/src/components/react-menu/components/MenuItemRadio/useMenuItemRadioStyles.styles.ts
+++ b/packages/react-cap-theme/src/components/react-menu/components/MenuItemRadio/useMenuItemRadioStyles.styles.ts
@@ -3,6 +3,7 @@ import {
   menuItemClassNames,
   menuItemRadioClassNames,
 } from '@fluentui/react-menu';
+export { menuItemRadioClassNames } from '@fluentui/react-menu';
 import { makeStyles, mergeClasses } from '@griffel/react';
 import { tokens } from '@fluentui/tokens';
 

--- a/packages/react-cap-theme/src/components/react-menu/components/MenuItemRadio/useMenuItemRadioStyles.styles.ts
+++ b/packages/react-cap-theme/src/components/react-menu/components/MenuItemRadio/useMenuItemRadioStyles.styles.ts
@@ -1,51 +1,93 @@
-import type { MenuItemRadioState, MenuItemSlots } from '@fluentui/react-menu';
 import {
-  getSlotClassNameProp_unstable,
-  type SlotClassNames,
-} from '@fluentui/react-utilities';
+  type MenuItemRadioState,
+  menuItemClassNames,
+  menuItemRadioClassNames,
+} from '@fluentui/react-menu';
 import { makeStyles, mergeClasses } from '@griffel/react';
+import { tokens } from '@fluentui/tokens';
+
 import { useMenuItemStyles } from '../MenuItem/useMenuItemStyles.styles';
+import { useCheckmarkStyles_unstable } from '../../selectable/useCheckmarkStyles.style';
 
-export const menuItemRadioClassNames: SlotClassNames<
-  Omit<MenuItemSlots, 'submenuIndicator'>
-> = {
-  root: 'fui-MenuItemRadio',
-  content: 'fui-MenuItemRadio__content',
-  icon: 'fui-MenuItemRadio__icon',
-  checkmark: 'fui-MenuItemRadio__checkmark',
-  secondaryContent: 'fui-MenuItemRadio__secondaryContent',
-  subText: 'fui-MenuItemRadio__subText',
-};
+const useInteractiveStyles = makeStyles({
+  checked: {
+    ':hover': {
+      [`& .${menuItemClassNames.checkmark}`]: {
+        color: tokens.colorBrandForeground2Hover,
+      },
+    },
+    ':hover:active': {
+      [`& .${menuItemClassNames.checkmark}`]: {
+        color: tokens.colorBrandForeground2Pressed,
+      },
+    },
 
-const useStyles = makeStyles({
-  checkmark: {
-    fontSize: '20px',
-    height: '20px',
-    marginTop: 0,
-    visibility: 'visible',
-    width: '20px',
+    '@media (forced-colors: active)': {
+      ':hover': {
+        [`& .${menuItemClassNames.checkmark}`]: { color: 'inherit' },
+      },
+      ':hover:active': {
+        [`& .${menuItemClassNames.checkmark}`]: { color: 'inherit' },
+      },
+    },
   },
+});
+
+const useCheckmarkStyles = makeStyles({
+  checked: { color: tokens.colorBrandForeground2 },
 });
 
 export const useMenuItemRadioStyles = (
   state: MenuItemRadioState
 ): MenuItemRadioState => {
-  const styles = useStyles();
+  const { checked, disabled } = state;
+  const interactiveStyles = useInteractiveStyles();
+  const checkmarkStyles = useCheckmarkStyles();
 
   state.root.className = mergeClasses(
     state.root.className,
     menuItemRadioClassNames.root,
-    getSlotClassNameProp_unstable(state.root)
+    !disabled && checked && interactiveStyles.checked,
   );
-  if (state.checkmark) {
-    state.checkmark.className = mergeClasses(
-      state.checkmark.className,
+
+  if (state.content) {
+    state.content.className = mergeClasses(
+      state.content.className,
       menuItemRadioClassNames.content,
-      styles.checkmark,
-      getSlotClassNameProp_unstable(state.checkmark)
     );
   }
 
+  if (state.secondaryContent) {
+    state.secondaryContent.className = mergeClasses(
+      state.secondaryContent.className,
+      menuItemRadioClassNames.secondaryContent,
+    );
+  }
+
+  if (state.icon) {
+    state.icon.className = mergeClasses(
+      state.icon.className,
+      menuItemRadioClassNames.icon,
+    );
+  }
+
+  if (state.checkmark) {
+    state.checkmark.className = mergeClasses(
+      state.checkmark.className,
+      menuItemRadioClassNames.checkmark,
+      !disabled && checked && checkmarkStyles.checked,
+    );
+  }
+
+  if (state.subText) {
+    state.subText.className = mergeClasses(
+      state.subText.className,
+      menuItemRadioClassNames.subText,
+    );
+  }
+
+  useCheckmarkStyles_unstable(state);
   useMenuItemStyles(state);
+
   return state;
 };

--- a/packages/react-cap-theme/src/components/react-menu/components/MenuItemRadio/useMenuItemRadioStyles.styles.ts
+++ b/packages/react-cap-theme/src/components/react-menu/components/MenuItemRadio/useMenuItemRadioStyles.styles.ts
@@ -48,27 +48,27 @@ export const useMenuItemRadioStyles = (
   state.root.className = mergeClasses(
     state.root.className,
     menuItemRadioClassNames.root,
-    !disabled && checked && interactiveStyles.checked,
+    !disabled && checked && interactiveStyles.checked
   );
 
   if (state.content) {
     state.content.className = mergeClasses(
       state.content.className,
-      menuItemRadioClassNames.content,
+      menuItemRadioClassNames.content
     );
   }
 
   if (state.secondaryContent) {
     state.secondaryContent.className = mergeClasses(
       state.secondaryContent.className,
-      menuItemRadioClassNames.secondaryContent,
+      menuItemRadioClassNames.secondaryContent
     );
   }
 
   if (state.icon) {
     state.icon.className = mergeClasses(
       state.icon.className,
-      menuItemRadioClassNames.icon,
+      menuItemRadioClassNames.icon
     );
   }
 
@@ -76,14 +76,14 @@ export const useMenuItemRadioStyles = (
     state.checkmark.className = mergeClasses(
       state.checkmark.className,
       menuItemRadioClassNames.checkmark,
-      !disabled && checked && checkmarkStyles.checked,
+      !disabled && checked && checkmarkStyles.checked
     );
   }
 
   if (state.subText) {
     state.subText.className = mergeClasses(
       state.subText.className,
-      menuItemRadioClassNames.subText,
+      menuItemRadioClassNames.subText
     );
   }
 

--- a/packages/react-cap-theme/src/components/react-menu/components/MenuItemSwitch/useMenuItemSwitchStyles.styles.ts
+++ b/packages/react-cap-theme/src/components/react-menu/components/MenuItemSwitch/useMenuItemSwitchStyles.styles.ts
@@ -77,17 +77,13 @@ const useInteractiveStyles = makeStyles({
   unchecked: {
     ':hover': {
       [`& .${menuItemSwitchClassNames.switchIndicator}`]: {
-        ...shorthands.borderColor(
-          tokens.colorNeutralStrokeAccessibleHover,
-        ),
+        ...shorthands.borderColor(tokens.colorNeutralStrokeAccessibleHover),
         color: tokens.colorNeutralForeground3Hover,
       },
     },
     ':hover:active': {
       [`& .${menuItemSwitchClassNames.switchIndicator}`]: {
-        ...shorthands.borderColor(
-          tokens.colorNeutralStrokeAccessiblePressed,
-        ),
+        ...shorthands.borderColor(tokens.colorNeutralStrokeAccessiblePressed),
         color: tokens.colorNeutralForeground3Pressed,
       },
     },
@@ -139,7 +135,9 @@ const useSwitchIndicatorStyles = makeStyles({
     color: tokens.colorNeutralForegroundInverted,
     ...shorthands.borderColor(tokens.colorTransparentStroke),
     [`& .${circleFilledClassName}`]: {
-      transform: `translateX(${trackWidth - thumbSize - spaceBetweenThumbAndTrack}px)`,
+      transform: `translateX(${
+        trackWidth - thumbSize - spaceBetweenThumbAndTrack
+      }px)`,
     },
 
     '@media (forced-colors: active)': {
@@ -179,14 +177,14 @@ export const useMenuItemSwitchStyles = (
     menuItemSwitchClassNames.root,
     styles.root,
     !disabled &&
-      (checked ? interactiveStyles.checked : interactiveStyles.unchecked),
+      (checked ? interactiveStyles.checked : interactiveStyles.unchecked)
   );
 
   if (state.content) {
     state.content.className = mergeClasses(
       state.content.className,
       menuItemSwitchClassNames.content,
-      styles.content,
+      styles.content
     );
   }
 
@@ -194,7 +192,7 @@ export const useMenuItemSwitchStyles = (
     state.secondaryContent.className = mergeClasses(
       state.secondaryContent.className,
       menuItemSwitchClassNames.secondaryContent,
-      styles.secondaryContent,
+      styles.secondaryContent
     );
   }
 
@@ -202,14 +200,14 @@ export const useMenuItemSwitchStyles = (
     state.icon.className = mergeClasses(
       state.icon.className,
       menuItemSwitchClassNames.icon,
-      styles.icon,
+      styles.icon
     );
   }
 
   if (state.subText) {
     state.subText.className = mergeClasses(
       state.subText.className,
-      menuItemSwitchClassNames.subText,
+      menuItemSwitchClassNames.subText
     );
   }
 
@@ -219,14 +217,12 @@ export const useMenuItemSwitchStyles = (
       menuItemSwitchClassNames.switchIndicator,
       switchIndicatorBaseStyles,
       styles.switchIndicator,
-      checked
-        ? switchIndicatorStyles.checked
-        : switchIndicatorStyles.unchecked,
+      checked ? switchIndicatorStyles.checked : switchIndicatorStyles.unchecked,
       disabled && switchIndicatorStyles.disabled,
       disabled &&
         (checked
           ? switchIndicatorStyles.disabledChecked
-          : switchIndicatorStyles.disabledUnchecked),
+          : switchIndicatorStyles.disabledUnchecked)
     );
   }
 

--- a/packages/react-cap-theme/src/components/react-menu/components/MenuItemSwitch/useMenuItemSwitchStyles.styles.ts
+++ b/packages/react-cap-theme/src/components/react-menu/components/MenuItemSwitch/useMenuItemSwitchStyles.styles.ts
@@ -1,0 +1,252 @@
+import {
+  menuItemSwitchClassNames,
+  type MenuItemSwitchState,
+} from '@fluentui/react-menu';
+import type { ElementType } from 'react';
+import {
+  makeStyles,
+  makeResetStyles,
+  mergeClasses,
+  shorthands,
+} from '@griffel/react';
+import { tokens } from '@fluentui/tokens';
+import { useMenuItemStyles } from '../MenuItem/useMenuItemStyles.styles';
+import { useCheckmarkStyles_unstable } from '../../selectable/useCheckmarkStyles.style';
+
+const circleFilledClassName =
+  'fui-MenuItemSwitch__switchIndicator__circleFilled';
+
+const spaceBetweenThumbAndTrack = 4;
+const trackHeight = 24;
+const trackWidth = 48;
+const thumbSize = 20;
+
+const useSwitchIndicatorBaseClassName = makeResetStyles({
+  display: 'flex',
+  alignItems: 'center',
+  padding: `${tokens.spacingVerticalXXS} ${tokens.spacingHorizontalXXS}`,
+  fontSize: `${thumbSize}px`,
+  height: `${trackHeight}px`,
+  width: `${trackWidth}px`,
+  borderRadius: tokens.borderRadiusCircular,
+  border: `${tokens.strokeWidthThin} solid ${tokens.colorNeutralStrokeAccessible}`,
+  lineHeight: 0,
+  boxSizing: 'border-box',
+  fill: 'currentColor',
+  flexShrink: 0,
+  transitionDuration: tokens.durationNormal,
+  transitionTimingFunction: tokens.curveEasyEase,
+  transitionProperty: 'background, border, color',
+
+  '@media screen and (prefers-reduced-motion: reduce)': {
+    transitionDuration: '0.01ms',
+  },
+
+  [`& .${circleFilledClassName}`]: {
+    transitionDuration: tokens.durationNormal,
+    transitionTimingFunction: tokens.curveEasyEase,
+    transitionProperty: 'transform',
+
+    '@media screen and (prefers-reduced-motion: reduce)': {
+      transitionDuration: '0.01ms',
+    },
+  },
+});
+
+const useStyles = makeStyles({
+  root: {
+    paddingTop: tokens.spacingVerticalXS,
+    paddingBottom: tokens.spacingVerticalXS,
+  },
+  switchIndicator: { marginLeft: tokens.spacingHorizontalS },
+  content: {
+    marginTop: tokens.spacingVerticalXXS,
+    marginBottom: tokens.spacingVerticalXXS,
+  },
+  icon: {
+    marginTop: tokens.spacingVerticalXXS,
+    marginBottom: tokens.spacingVerticalXXS,
+  },
+  secondaryContent: {
+    marginTop: tokens.spacingVerticalXXS,
+    marginBottom: tokens.spacingVerticalXXS,
+  },
+});
+
+const useInteractiveStyles = makeStyles({
+  unchecked: {
+    ':hover': {
+      [`& .${menuItemSwitchClassNames.switchIndicator}`]: {
+        ...shorthands.borderColor(
+          tokens.colorNeutralStrokeAccessibleHover,
+        ),
+        color: tokens.colorNeutralForeground3Hover,
+      },
+    },
+    ':hover:active': {
+      [`& .${menuItemSwitchClassNames.switchIndicator}`]: {
+        ...shorthands.borderColor(
+          tokens.colorNeutralStrokeAccessiblePressed,
+        ),
+        color: tokens.colorNeutralForeground3Pressed,
+      },
+    },
+    '@media (forced-colors: active)': {
+      ':hover': {
+        [`& .${menuItemSwitchClassNames.switchIndicator}`]: {
+          ...shorthands.borderColor('Highlight'),
+          color: 'inherit',
+        },
+      },
+      ':hover:active': {
+        [`& .${menuItemSwitchClassNames.switchIndicator}`]: {
+          ...shorthands.borderColor('Highlight'),
+          color: 'inherit',
+        },
+      },
+    },
+  },
+  checked: {
+    ':hover': {
+      [`& .${menuItemSwitchClassNames.switchIndicator}`]: {
+        backgroundColor: tokens.colorCompoundBrandBackgroundHover,
+      },
+    },
+    ':hover:active': {
+      [`& .${menuItemSwitchClassNames.switchIndicator}`]: {
+        backgroundColor: tokens.colorCompoundBrandBackgroundPressed,
+      },
+    },
+    '@media (forced-colors: active)': {
+      ':hover': {
+        [`& .${menuItemSwitchClassNames.switchIndicator}`]: {
+          backgroundColor: 'Highlight',
+        },
+      },
+      ':hover:active': {
+        [`& .${menuItemSwitchClassNames.switchIndicator}`]: {
+          backgroundColor: 'Highlight',
+        },
+      },
+    },
+  },
+});
+
+const useSwitchIndicatorStyles = makeStyles({
+  unchecked: { color: tokens.colorNeutralForeground3 },
+  checked: {
+    backgroundColor: tokens.colorCompoundBrandBackground,
+    color: tokens.colorNeutralForegroundInverted,
+    ...shorthands.borderColor(tokens.colorTransparentStroke),
+    [`& .${circleFilledClassName}`]: {
+      transform: `translateX(${trackWidth - thumbSize - spaceBetweenThumbAndTrack}px)`,
+    },
+
+    '@media (forced-colors: active)': {
+      backgroundColor: 'Highlight',
+      ...shorthands.borderColor('Highlight'),
+      color: 'HighlightText',
+    },
+  },
+  disabled: {
+    color: 'inherit',
+    '@media (forced-colors: active)': {
+      backgroundColor: 'Canvas',
+      ...shorthands.borderColor('GrayText'),
+      color: 'inherit',
+    },
+  },
+  disabledChecked: {
+    backgroundColor: tokens.colorNeutralBackgroundDisabled,
+  },
+  disabledUnchecked: {
+    ...shorthands.borderColor(tokens.colorNeutralStrokeDisabled),
+  },
+});
+
+export const useMenuItemSwitchStyles = (
+  state: MenuItemSwitchState
+): MenuItemSwitchState => {
+  const styles = useStyles();
+  const interactiveStyles = useInteractiveStyles();
+  const switchIndicatorBaseStyles = useSwitchIndicatorBaseClassName();
+  const switchIndicatorStyles = useSwitchIndicatorStyles();
+
+  const { checked, disabled } = state;
+
+  state.root.className = mergeClasses(
+    state.root.className,
+    menuItemSwitchClassNames.root,
+    styles.root,
+    !disabled &&
+      (checked ? interactiveStyles.checked : interactiveStyles.unchecked),
+  );
+
+  if (state.content) {
+    state.content.className = mergeClasses(
+      state.content.className,
+      menuItemSwitchClassNames.content,
+      styles.content,
+    );
+  }
+
+  if (state.secondaryContent) {
+    state.secondaryContent.className = mergeClasses(
+      state.secondaryContent.className,
+      menuItemSwitchClassNames.secondaryContent,
+      styles.secondaryContent,
+    );
+  }
+
+  if (state.icon) {
+    state.icon.className = mergeClasses(
+      state.icon.className,
+      menuItemSwitchClassNames.icon,
+      styles.icon,
+    );
+  }
+
+  if (state.subText) {
+    state.subText.className = mergeClasses(
+      state.subText.className,
+      menuItemSwitchClassNames.subText,
+    );
+  }
+
+  if (state.switchIndicator) {
+    state.switchIndicator.className = mergeClasses(
+      state.switchIndicator.className,
+      menuItemSwitchClassNames.switchIndicator,
+      switchIndicatorBaseStyles,
+      styles.switchIndicator,
+      checked
+        ? switchIndicatorStyles.checked
+        : switchIndicatorStyles.unchecked,
+      disabled && switchIndicatorStyles.disabled,
+      disabled &&
+        (checked
+          ? switchIndicatorStyles.disabledChecked
+          : switchIndicatorStyles.disabledUnchecked),
+    );
+  }
+
+  const partialMenuItemState = {
+    components: {
+      ...state.components,
+      checkmark: 'span' as ElementType,
+      submenuIndicator: 'span' as ElementType,
+    },
+    hasSubmenu: false,
+    persistOnClick: true,
+  };
+
+  useCheckmarkStyles_unstable({ ...state, ...partialMenuItemState });
+  useMenuItemStyles({
+    ...state,
+    ...partialMenuItemState,
+    checkmark: undefined,
+    submenuIndicator: undefined,
+  });
+
+  return state;
+};

--- a/packages/react-cap-theme/src/components/react-menu/components/MenuPopover/useMenuPopoverStyles.styles.ts
+++ b/packages/react-cap-theme/src/components/react-menu/components/MenuPopover/useMenuPopoverStyles.styles.ts
@@ -7,6 +7,7 @@ import {
   type SlotClassNames,
 } from '@fluentui/react-utilities';
 import { tokens } from '@fluentui/tokens';
+import { capTokens } from '../../../tokens';
 import { makeStyles, mergeClasses } from '@griffel/react';
 
 export const menuPopoverClassNames: Partial<SlotClassNames<MenuPopoverSlots>> =
@@ -17,10 +18,11 @@ export const menuPopoverClassNames: Partial<SlotClassNames<MenuPopoverSlots>> =
 const useStyles = makeStyles({
   root: {
     border: `${tokens.strokeWidthThin} solid ${tokens.colorNeutralStrokeAlpha}`,
-    borderRadius: tokens.borderRadiusXLarge,
-    boxShadow: tokens.shadow4,
-    padding: `calc(${tokens.spacingVerticalSNudge} - 1px) calc(${tokens.spacingHorizontalSNudge} - 1px)`,
-    width: '248px',
+    borderRadius: capTokens.borderRadius2XLarge,
+    boxShadow: '0 3px 12px 0 rgba(0, 0, 0, 0.18)', // FIXME: update to use shadow token once it's available
+    padding: `${tokens.spacingVerticalSNudge} ${tokens.spacingHorizontalSNudge}`,
+    width: 'auto',
+    minWidth: '160px',
   },
 });
 

--- a/packages/react-cap-theme/src/components/react-menu/components/MenuSplitGroup/useMenuSplitGroupStyles.styles.ts
+++ b/packages/react-cap-theme/src/components/react-menu/components/MenuSplitGroup/useMenuSplitGroupStyles.styles.ts
@@ -8,6 +8,7 @@ import {
   type SlotClassNames,
 } from '@fluentui/react-utilities';
 import { tokens } from '@fluentui/tokens';
+import { capTokens } from '../../../tokens';
 import { makeStyles, mergeClasses } from '@griffel/react';
 
 export const menuSplitGroupClassNames: SlotClassNames<MenuSplitGroupSlots> = {
@@ -17,22 +18,27 @@ export const menuSplitGroupClassNames: SlotClassNames<MenuSplitGroupSlots> = {
 const useStyles = makeStyles({
   root: {
     [`& > .${menuItemClassNames.root}:nth-of-type(1)`]: {
-      borderBottomRightRadius: 0,
-      borderTopRightRadius: 0,
+      alignSelf: 'center',
+      borderBottomRightRadius: tokens.borderRadiusLarge,
+      borderTopRightRadius: tokens.borderRadiusLarge,
     },
     [`& > .${menuItemClassNames.root}:nth-of-type(2)`]: {
       paddingBottom: tokens.spacingVerticalSNudge,
       paddingRight: tokens.spacingHorizontalSNudge,
       paddingTop: tokens.spacingVerticalSNudge,
+      borderTopLeftRadius: tokens.borderRadiusLarge,
+      borderBottomLeftRadius: tokens.borderRadiusLarge,
+    },
+    [`& > .${menuItemClassNames.root}:nth-of-type(2):hover::before`]: {
+      backgroundColor: capTokens.colorNeutralStroke4Hover,
+    },
+    [`& > .${menuItemClassNames.root}:nth-of-type(2):hover:active::before`]: {
+      backgroundColor: capTokens.colorNeutralStroke4Pressed,
     },
     [`& > .${menuItemClassNames.root}:nth-of-type(2)::before`]: {
       alignSelf: 'center',
-      height: '100%',
-      marginTop: tokens.spacingVerticalS,
-      marginBottom: tokens.spacingVerticalS,
-    },
-    [`& .${menuItemClassNames.submenuIndicator}`]: {
-      marginLeft: tokens.spacingHorizontalSNudge,
+      height: '16px',
+      backgroundColor: capTokens.colorNeutralStroke4,
     },
   },
 });

--- a/packages/react-cap-theme/src/components/react-menu/index.ts
+++ b/packages/react-cap-theme/src/components/react-menu/index.ts
@@ -2,7 +2,9 @@ export { useMenuDividerStyles } from './components/MenuDivider/useMenuDividerSty
 export { useMenuGroupHeaderStyles } from './components/MenuGroupHeader/useMenuGroupHeaderStyles.styles';
 export { useMenuItemStyles } from './components/MenuItem/useMenuItemStyles.styles';
 export { useMenuItemCheckboxStyles } from './components/MenuItemCheckbox/useMenuItemCheckboxStyles.styles';
+export { useMenuItemLinkStyles } from './components/MenuItemLink/useMenuItemLinkStyles.styles';
 export { useMenuItemRadioStyles } from './components/MenuItemRadio/useMenuItemRadioStyles.styles';
+export { useMenuItemSwitchStyles } from './components/MenuItemSwitch/useMenuItemSwitchStyles.styles';
 export { useMenuItemSwatchPickerStyles } from './components/MenuItemSwatchPicker/useMenuItemSwatchPickerStyles.styles';
 export { useMenuPopoverStyles } from './components/MenuPopover/useMenuPopoverStyles.styles';
 export { useMenuSplitGroupStyles } from './components/MenuSplitGroup/useMenuSplitGroupStyles.styles';

--- a/packages/react-cap-theme/src/components/react-menu/selectable/useCheckmarkStyles.style.ts
+++ b/packages/react-cap-theme/src/components/react-menu/selectable/useCheckmarkStyles.style.ts
@@ -1,0 +1,85 @@
+import {
+  mergeClasses,
+  makeStyles,
+} from '@griffel/react';
+import {
+  menuItemClassNames,
+  type MenuItemSelectableState,
+  type MenuItemState,
+} from '@fluentui/react-menu';
+import {
+  iconFilledClassName,
+  iconRegularClassName,
+} from '@fluentui/react-icons';
+import { tokens } from '@fluentui/tokens';
+
+const useStyles = makeStyles({
+  checked: {
+    [`& .${iconFilledClassName}`]: { display: 'inline' },
+    [`& .${iconRegularClassName}`]: { display: 'none' },
+
+    [`:hover .${iconFilledClassName}`]: { display: 'inline' },
+    [`:hover .${iconRegularClassName}`]: { display: 'none' },
+  },
+  checkmark: {
+    boxSizing: 'border-box',
+    height: '20px',
+    width: '20px',
+    marginRight: tokens.spacingHorizontalSNudge,
+    marginTop: tokens.spacingVerticalNone,
+    flexShrink: 0,
+    visibility: 'visible',
+  },
+});
+
+const useInteractiveStyles = makeStyles({
+  checked: {
+    ':hover': {
+      [`& .${menuItemClassNames.icon}`]: {
+        color: tokens.colorBrandForeground2Hover,
+      },
+    },
+    ':hover:active': {
+      [`& .${menuItemClassNames.icon}`]: {
+        color: tokens.colorBrandForeground2Pressed,
+      },
+    },
+    '@media (forced-colors: active)': {
+      ':hover': {
+        [`& .${menuItemClassNames.icon}`]: { color: 'inherit' },
+      },
+      ':hover:active': {
+        [`& .${menuItemClassNames.icon}`]: { color: 'inherit' },
+      },
+    },
+  },
+  iconChecked: { color: tokens.colorBrandForeground2 },
+});
+
+export const useCheckmarkStyles_unstable = (
+  state: MenuItemSelectableState & MenuItemState
+): void => {
+  const { checked, disabled } = state;
+  const styles = useStyles();
+  const interactiveStyles = useInteractiveStyles();
+
+  state.root.className = mergeClasses(
+    state.checked && styles.checked,
+    !disabled && checked && interactiveStyles.checked,
+    state.root.className,
+  );
+
+  if (state.icon) {
+    state.icon.className = mergeClasses(
+      !disabled && checked && interactiveStyles.iconChecked,
+      state.icon.className,
+    );
+  }
+
+  if (state.checkmark) {
+    state.checkmark.className = mergeClasses(
+      styles.checkmark,
+      state.checkmark.className,
+    );
+  }
+};

--- a/packages/react-cap-theme/src/components/react-menu/selectable/useCheckmarkStyles.style.ts
+++ b/packages/react-cap-theme/src/components/react-menu/selectable/useCheckmarkStyles.style.ts
@@ -1,7 +1,4 @@
-import {
-  mergeClasses,
-  makeStyles,
-} from '@griffel/react';
+import { mergeClasses, makeStyles } from '@griffel/react';
 import {
   menuItemClassNames,
   type MenuItemSelectableState,
@@ -66,20 +63,20 @@ export const useCheckmarkStyles_unstable = (
   state.root.className = mergeClasses(
     state.checked && styles.checked,
     !disabled && checked && interactiveStyles.checked,
-    state.root.className,
+    state.root.className
   );
 
   if (state.icon) {
     state.icon.className = mergeClasses(
       !disabled && checked && interactiveStyles.iconChecked,
-      state.icon.className,
+      state.icon.className
     );
   }
 
   if (state.checkmark) {
     state.checkmark.className = mergeClasses(
       styles.checkmark,
-      state.checkmark.className,
+      state.checkmark.className
     );
   }
 };

--- a/packages/react-cap-theme/src/components/tokens/tokens.ts
+++ b/packages/react-cap-theme/src/components/tokens/tokens.ts
@@ -8,4 +8,7 @@ export const capTokens: Record<keyof CAPTokens, string> = {
   colorNeutralStroke4Hover: 'var(--colorNeutralStroke4Hover)',
   colorNeutralStroke4Pressed: 'var(--colorNeutralStroke4Pressed)',
   colorNeutralStroke4Selected: 'var(--colorNeutralStroke4Selected)',
+  colorNeutralForeground5: 'var(--colorNeutralForeground5)',
+  colorNeutralForeground5Hover: 'var(--colorNeutralForeground5Hover)',
+  colorNeutralForeground5Pressed: 'var(--colorNeutralForeground5Pressed)',
 };

--- a/packages/react-cap-theme/src/components/tokens/types.ts
+++ b/packages/react-cap-theme/src/components/tokens/types.ts
@@ -7,4 +7,7 @@ export type CAPTokens = {
   colorNeutralStroke4Hover: string;
   colorNeutralStroke4Pressed: string;
   colorNeutralStroke4Selected: string;
+  colorNeutralForeground5: string;
+  colorNeutralForeground5Hover: string;
+  colorNeutralForeground5Pressed: string;
 };

--- a/packages/react-cap-theme/src/index.ts
+++ b/packages/react-cap-theme/src/index.ts
@@ -90,7 +90,9 @@ import {
   useMenuGroupHeaderStyles,
   useMenuItemStyles,
   useMenuItemCheckboxStyles,
+  useMenuItemLinkStyles,
   useMenuItemRadioStyles,
+  useMenuItemSwitchStyles,
   useMenuPopoverStyles,
   useMenuSplitGroupStyles,
 } from './components/react-menu';
@@ -99,7 +101,9 @@ import type {
   MenuGroupHeaderState,
   MenuItemState,
   MenuItemCheckboxState,
+  MenuItemLinkState,
   MenuItemRadioState,
+  MenuItemSwitchState,
   MenuPopoverState,
   MenuSplitGroupState,
 } from '@fluentui/react-menu';
@@ -231,8 +235,14 @@ export const CAP_STYLE_HOOKS: NonNullable<
   useMenuItemCheckboxStyles_unstable: (state) => {
     return useMenuItemCheckboxStyles(state as MenuItemCheckboxState);
   },
+  useMenuItemLinkStyles_unstable: (state) => {
+    return useMenuItemLinkStyles(state as MenuItemLinkState);
+  },
   useMenuItemRadioStyles_unstable: (state) => {
     return useMenuItemRadioStyles(state as MenuItemRadioState);
+  },
+  useMenuItemSwitchStyles_unstable: (state) => {
+    return useMenuItemSwitchStyles(state as MenuItemSwitchState);
   },
   useMenuPopoverStyles_unstable: (state) => {
     return useMenuPopoverStyles(state as MenuPopoverState);

--- a/packages/react-cap-theme/src/index.ts
+++ b/packages/react-cap-theme/src/index.ts
@@ -81,6 +81,8 @@ import type {
 import type { InlineDrawerState } from './components/react-drawer/components/InlineDrawer/InlineDrawer.types';
 import { useImageStyles } from './components/react-image';
 import type { ImageState } from '@fluentui/react-image';
+import { useInputStyles } from './components/react-input';
+import type { InputState } from './components/react-input/components/Input/Input.types';
 import { useLinkStyles } from './components/react-link';
 import type { LinkState } from './components/react-link/components/Link/Link.types';
 import {
@@ -189,6 +191,9 @@ export const CAP_STYLE_HOOKS: NonNullable<
   },
   useImageStyles_unstable: (state) => {
     return useImageStyles(state as ImageState);
+  },
+  useInputStyles_unstable: (state) => {
+    return useInputStyles(state as InputState);
   },
   useInlineDrawerStyles_unstable: (state) => {
     return useInlineDrawerStyles(state as InlineDrawerState);


### PR DESCRIPTION
Updates existing menu component styles and adds new components:
- MenuDivider: update border color to colorNeutralStroke4
- MenuGroupHeader: add foreground color
- MenuItem: add focus outline, interactive states, appearance refresh
- MenuItemCheckbox: add checkmark visibility, interactive styles
- MenuItemRadio: add checkmark color, interactive styles
- MenuPopover: update border radius, shadow, padding, width
- MenuSplitGroup: add split button border radius, separator styles
- MenuItemLink: new component with link reset styles
- MenuItemSwitch: new component with switch indicator styles
- Add shared selectable/useCheckmarkStyles utility