### PR TITLE
feat(react-cap-theme): fix version mismatch between npm+repo

### DIFF
--- a/change/@fluentui-contrib-react-cap-theme-16e79b2f-f7ae-423b-b90f-9df6fe5fef47.json
+++ b/change/@fluentui-contrib-react-cap-theme-16e79b2f-f7ae-423b-b90f-9df6fe5fef47.json
@@ -1,7 +1,0 @@
-{
-  "type": "minor",
-  "comment": "feat(react-cap-theme): add TEAMS_STYLE_HOOKS with button size overrides",
-  "packageName": "@fluentui-contrib/react-cap-theme",
-  "email": "yizhang9@microsoft.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@fluentui-contrib-react-cap-theme-2399e3ea-fd96-423b-bcbd-2639478a4fb7.json
+++ b/change/@fluentui-contrib-react-cap-theme-2399e3ea-fd96-423b-bcbd-2639478a4fb7.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "Fix ToggleButton checked state styling and Checkbox indicator visibility; refactor internal component structure",
-  "packageName": "@fluentui-contrib/react-cap-theme",
-  "email": "egianoglio@microsoft.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@fluentui-contrib-react-cap-theme-25524a71-d5e0-4f78-bfbb-8eaa18f0a4df.json
+++ b/change/@fluentui-contrib-react-cap-theme-25524a71-d5e0-4f78-bfbb-8eaa18f0a4df.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "Remove unused tokens",
-  "packageName": "@fluentui-contrib/react-cap-theme",
-  "email": "dzukowski@microsoft.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@fluentui-contrib-react-cap-theme-4f79978e-d9e7-4863-b21e-f3ac3cf60762.json
+++ b/change/@fluentui-contrib-react-cap-theme-4f79978e-d9e7-4863-b21e-f3ac3cf60762.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "repo recovery for mismatched version",
+  "packageName": "@fluentui-contrib/react-cap-theme",
+  "email": "yizhang9@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-contrib-react-cap-theme-7dd00e9f-c39e-441d-b131-31527d9ae46b.json
+++ b/change/@fluentui-contrib-react-cap-theme-7dd00e9f-c39e-441d-b131-31527d9ae46b.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "try to fix the version bump problem by adding some changes",
-  "packageName": "@fluentui-contrib/react-cap-theme",
-  "email": "yizhang9@microsoft.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@fluentui-contrib-react-cap-theme-9e11b663-b46c-4a40-9cf0-6428013113d9.json
+++ b/change/@fluentui-contrib-react-cap-theme-9e11b663-b46c-4a40-9cf0-6428013113d9.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "feat(react-cap-theme): add react-label component",
-  "packageName": "@fluentui-contrib/react-cap-theme",
-  "email": "dzukowski@microsoft.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@fluentui-contrib-react-cap-theme-f9ae9915-b1ef-4dcb-a645-b3504d4aa6f5.json
+++ b/change/@fluentui-contrib-react-cap-theme-f9ae9915-b1ef-4dcb-a645-b3504d4aa6f5.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "fix(react-cap-theme): use relative import path for button types in teams/index",
-  "packageName": "@fluentui-contrib/react-cap-theme",
-  "email": "yizhang9@microsoft.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@fluentui-contrib-react-cap-theme-input-component.json
+++ b/change/@fluentui-contrib-react-cap-theme-input-component.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "add react-input component",
-  "packageName": "@fluentui-contrib/react-cap-theme",
-  "email": "dzukowski@microsoft.com",
-  "dependentChangeType": "patch"
-}

--- a/packages/react-cap-theme/CHANGELOG.json
+++ b/packages/react-cap-theme/CHANGELOG.json
@@ -2,6 +2,59 @@
   "name": "@fluentui-contrib/react-cap-theme",
   "entries": [
     {
+      "date": "Thu, 23 Apr 2026 16:23:03 GMT",
+      "tag": "@fluentui-contrib/react-cap-theme_v0.3.0",
+      "version": "0.3.0",
+      "comments": {
+        "patch": [
+          {
+            "author": "yizhang9@microsoft.com",
+            "package": "@fluentui-contrib/react-cap-theme",
+            "commit": "b195d29ec20b0cf1ff88ce84d7cd31fad1ced32c",
+            "comment": "try to fix the version bump problem by adding some changes"
+          },
+          {
+            "author": "egianoglio@microsoft.com",
+            "package": "@fluentui-contrib/react-cap-theme",
+            "commit": "51aef7f68d06e0f53fd7fe46489086107dff9670",
+            "comment": "Fix ToggleButton checked state styling and Checkbox indicator visibility; refactor internal component structure"
+          },
+          {
+            "author": "dzukowski@microsoft.com",
+            "package": "@fluentui-contrib/react-cap-theme",
+            "commit": "de6f1be1a42d4534400eb735e35292387ddbd69a",
+            "comment": "Remove unused tokens"
+          },
+          {
+            "author": "dzukowski@microsoft.com",
+            "package": "@fluentui-contrib/react-cap-theme",
+            "commit": "30d3a2dcad14f5d170582e7302ff5f4b70c9acc7",
+            "comment": "feat(react-cap-theme): add react-label component"
+          },
+          {
+            "author": "dzukowski@microsoft.com",
+            "package": "@fluentui-contrib/react-cap-theme",
+            "commit": "b87187e38274af1e283c7d55a686421415be02fe",
+            "comment": "add react-input component"
+          },
+          {
+            "author": "yizhang9@microsoft.com",
+            "package": "@fluentui-contrib/react-cap-theme",
+            "commit": "515712ffa3e865e17bfa5fb52c3ff7aae4dbc579",
+            "comment": "fix(react-cap-theme): use relative import path for button types in teams/index"
+          }
+        ],
+        "minor": [
+          {
+            "author": "yizhang9@microsoft.com",
+            "package": "@fluentui-contrib/react-cap-theme",
+            "commit": "d8b52d09918d320167ae7005d36a6f18713b40bd",
+            "comment": "feat(react-cap-theme): add TEAMS_STYLE_HOOKS with button size overrides"
+          }
+        ]
+      }
+    },
+    {
       "date": "Fri, 10 Apr 2026 16:04:54 GMT",
       "tag": "@fluentui-contrib/react-cap-theme_v0.2.4",
       "version": "0.2.4",

--- a/packages/react-cap-theme/CHANGELOG.md
+++ b/packages/react-cap-theme/CHANGELOG.md
@@ -1,8 +1,25 @@
 # Change Log - @fluentui-contrib/react-cap-theme
 
-This log was last generated on Fri, 10 Apr 2026 16:04:54 GMT and should not be manually modified.
+This log was last generated on Thu, 23 Apr 2026 16:23:03 GMT and should not be manually modified.
 
 <!-- Start content -->
+
+## 0.3.0
+
+Thu, 23 Apr 2026 16:23:03 GMT
+
+### Minor changes
+
+- feat(react-cap-theme): add TEAMS_STYLE_HOOKS with button size overrides (yizhang9@microsoft.com)
+
+### Patches
+
+- try to fix the version bump problem by adding some changes (yizhang9@microsoft.com)
+- Fix ToggleButton checked state styling and Checkbox indicator visibility; refactor internal component structure (egianoglio@microsoft.com)
+- Remove unused tokens (dzukowski@microsoft.com)
+- feat(react-cap-theme): add react-label component (dzukowski@microsoft.com)
+- add react-input component (dzukowski@microsoft.com)
+- fix(react-cap-theme): use relative import path for button types in teams/index (yizhang9@microsoft.com)
 
 ## 0.2.4
 

--- a/packages/react-cap-theme/package.json
+++ b/packages/react-cap-theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluentui-contrib/react-cap-theme",
-  "version": "0.2.4",
+  "version": "0.3.0",
   "main": "./src/index.js",
   "types": "./src/index.d.ts",
   "peerDependencies": {


### PR DESCRIPTION
Working on the react-cap-theme package in fluentui-contrib, fixing a publish failure where 0.3.0 was already in the npm registry but git state was out of sync.

changes are generated by running `yarn beachball bump -b origin/main --access public --no-fetch --no-publish --no-push --no-git-tags`

More context: https://teams.microsoft.com/l/message/19:5b644df17ad64b89a6b7947969382baa@thread.skype/1776898202004?tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47&groupId=64c2bd5c-33c2-4898-918f-4a02a6ac98e1&parentMessageId=1776898202004&teamName=Fluent%20UI%20Internal&channelName=Engineering%20Systems&createdTime=1776898202004