### PR TITLE
React-cap-theme: Removed props being omitted from base Fluent

### DIFF
--- a/change/@fluentui-contrib-react-cap-theme-a4dbf33b-6c0a-4317-98bc-ba507e05dfe8.json
+++ b/change/@fluentui-contrib-react-cap-theme-a4dbf33b-6c0a-4317-98bc-ba507e05dfe8.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "removed omit & picks for components removing types",
+  "packageName": "@fluentui-contrib/react-cap-theme",
+  "email": "miceclavea@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-cap-theme/src/components/react-button/components/Button/Button.types.ts
+++ b/packages/react-cap-theme/src/components/react-button/components/Button/Button.types.ts
@@ -16,10 +16,7 @@ export type ButtonAppearance =
   | 'transparent';
 
 export type ButtonProps = ComponentProps<ButtonSlots> &
-  Pick<
-    BaseButtonProps,
-    'disabledFocusable' | 'disabled' | 'iconPosition' | 'size'
-  > & {
+  Omit<BaseButtonProps, 'appearance'> & {
     appearance?: ButtonAppearance;
   };
 

--- a/packages/react-cap-theme/src/components/react-button/components/MenuButton/MenuButton.types.ts
+++ b/packages/react-cap-theme/src/components/react-button/components/MenuButton/MenuButton.types.ts
@@ -4,7 +4,11 @@ import type { ButtonProps, ButtonState, ButtonSlots } from '../../Button';
 
 export type { MenuButtonSlots } from '@fluentui/react-button';
 
-export type MenuButtonProps = ComponentProps<MenuButtonSlots> & ButtonProps;
+export type MenuButtonProps = ComponentProps<MenuButtonSlots> &
+  Pick<
+    ButtonProps,
+    'appearance' | 'disabled' | 'disabledFocusable' | 'shape' | 'size'
+  >;
 
 export type MenuButtonState = ComponentState<MenuButtonSlots> &
   Omit<ButtonState, keyof ButtonSlots | 'components' | 'iconPosition'>;

--- a/packages/react-cap-theme/src/components/react-button/components/MenuButton/MenuButton.types.ts
+++ b/packages/react-cap-theme/src/components/react-button/components/MenuButton/MenuButton.types.ts
@@ -4,8 +4,7 @@ import type { ButtonProps, ButtonState, ButtonSlots } from '../../Button';
 
 export type { MenuButtonSlots } from '@fluentui/react-button';
 
-export type MenuButtonProps = ComponentProps<MenuButtonSlots> &
-  Pick<ButtonProps, 'appearance' | 'disabled' | 'disabledFocusable' | 'size'>;
+export type MenuButtonProps = ComponentProps<MenuButtonSlots> & ButtonProps;
 
 export type MenuButtonState = ComponentState<MenuButtonSlots> &
   Omit<ButtonState, keyof ButtonSlots | 'components' | 'iconPosition'>;

--- a/packages/react-cap-theme/src/components/react-button/components/ToggleButton/ToggleButton.types.ts
+++ b/packages/react-cap-theme/src/components/react-button/components/ToggleButton/ToggleButton.types.ts
@@ -2,7 +2,7 @@ import type { ToggleButtonProps as BaseToggleButtonProps } from '@fluentui/react
 import type { ButtonProps, ButtonState } from '../../Button';
 
 export type ToggleButtonProps = ButtonProps &
-  Pick<BaseToggleButtonProps, 'defaultChecked' | 'checked'>;
+  Omit<BaseToggleButtonProps, 'appearance'>;
 
 export type ToggleButtonState = ButtonState &
   Required<Pick<ToggleButtonProps, 'checked'>>;

--- a/packages/react-cap-theme/src/components/react-carousel/components/CarouselAutoplayButton/CarouselAutoplayButton.types.ts
+++ b/packages/react-cap-theme/src/components/react-carousel/components/CarouselAutoplayButton/CarouselAutoplayButton.types.ts
@@ -10,11 +10,11 @@ import type {
 } from '../../../react-button/components/ToggleButton/ToggleButton.types';
 
 export type CarouselAutoplayButtonSlots = ButtonSlots &
-  Pick<FluentCarouselAutoplayButtonSlots, 'root'>;
+  FluentCarouselAutoplayButtonSlots;
 
 export type CarouselAutoplayButtonProps = ToggleButtonProps &
   ComponentProps<CarouselAutoplayButtonSlots> &
-  Pick<FluentCarouselAutoplayButtonProps, 'onCheckedChange'>;
+  Omit<FluentCarouselAutoplayButtonProps, 'appearance'>;
 
 export type CarouselAutoplayButtonState = ToggleButtonState &
   ComponentState<CarouselAutoplayButtonSlots>;

--- a/packages/react-cap-theme/src/components/react-carousel/components/CarouselButton/CarouselButton.types.ts
+++ b/packages/react-cap-theme/src/components/react-carousel/components/CarouselButton/CarouselButton.types.ts
@@ -4,10 +4,9 @@ import type {
   CarouselButtonState as FluentCarouselButtonState,
 } from '@fluentui/react-carousel';
 import type { ComponentProps, ComponentState } from '@fluentui/react-utilities';
-import type { ButtonSlots } from '@fluentui/react-button';
 import type { ButtonProps, ButtonState } from '../../../react-button';
 
-export type CarouselButtonSlots = ButtonSlots & FluentCarouselButtonSlots;
+export type CarouselButtonSlots = FluentCarouselButtonSlots;
 
 export type CarouselButtonProps = Partial<ButtonProps> &
   ComponentProps<CarouselButtonSlots> &

--- a/packages/react-cap-theme/src/components/react-carousel/components/CarouselButton/CarouselButton.types.ts
+++ b/packages/react-cap-theme/src/components/react-carousel/components/CarouselButton/CarouselButton.types.ts
@@ -7,16 +7,15 @@ import type { ComponentProps, ComponentState } from '@fluentui/react-utilities';
 import type { ButtonSlots } from '@fluentui/react-button';
 import type { ButtonProps, ButtonState } from '../../../react-button';
 
-export type CarouselButtonSlots = ButtonSlots &
-  Pick<FluentCarouselButtonSlots, 'root'>;
+export type CarouselButtonSlots = ButtonSlots & FluentCarouselButtonSlots;
 
 export type CarouselButtonProps = Partial<ButtonProps> &
   ComponentProps<CarouselButtonSlots> &
-  Pick<FluentCarouselButtonProps, 'navType'>;
+  Omit<FluentCarouselButtonProps, 'appearance'>;
 
 export type CarouselButtonState = ButtonState &
   ComponentState<CarouselButtonSlots> &
-  Pick<FluentCarouselButtonState, 'navType'>;
+  Omit<FluentCarouselButtonState, 'appearance'>;
 
 export type {
   CarouselButtonProps as FluentCarouselButtonProps,

--- a/packages/react-cap-theme/src/components/react-carousel/components/CarouselNavContainer/CarouselNavContainer.types.ts
+++ b/packages/react-cap-theme/src/components/react-carousel/components/CarouselNavContainer/CarouselNavContainer.types.ts
@@ -22,7 +22,10 @@ export type CarouselNavContainerSlots = Omit<
 
 export type CarouselNavContainerProps =
   ComponentProps<CarouselNavContainerSlots> &
-    Omit<FluentCarouselNavContainerProps, keyof ComponentProps<FluentCarouselNavContainerSlots>>;
+    Omit<
+      FluentCarouselNavContainerProps,
+      keyof ComponentProps<FluentCarouselNavContainerSlots>
+    >;
 
 export type CarouselNavContainerState =
   ComponentState<CarouselNavContainerSlots> &

--- a/packages/react-cap-theme/src/components/react-carousel/components/CarouselNavContainer/CarouselNavContainer.types.ts
+++ b/packages/react-cap-theme/src/components/react-carousel/components/CarouselNavContainer/CarouselNavContainer.types.ts
@@ -22,7 +22,7 @@ export type CarouselNavContainerSlots = Omit<
 
 export type CarouselNavContainerProps =
   ComponentProps<CarouselNavContainerSlots> &
-    Pick<FluentCarouselNavContainerProps, 'layout'>;
+    Omit<FluentCarouselNavContainerProps, keyof ComponentProps<FluentCarouselNavContainerSlots>>;
 
 export type CarouselNavContainerState =
   ComponentState<CarouselNavContainerSlots> &

--- a/packages/react-cap-theme/src/components/react-tooltip/components/Tooltip/Tooltip.types.ts
+++ b/packages/react-cap-theme/src/components/react-tooltip/components/Tooltip/Tooltip.types.ts
@@ -10,7 +10,7 @@ import type { ComponentProps, TriggerProps } from '@fluentui/react-utilities';
 export type TooltipProps = ComponentProps<TooltipSlots> &
   TriggerProps<TooltipTriggerProps> &
   Pick<PortalProps, 'mountNode'> &
-  Omit<BaseTooltipProps, 'appearance' | 'withArrow'> & {
+  Omit<BaseTooltipProps, 'appearance'> & {
     appearance?: 'normal' | 'inverted' | 'brand';
   };
 

--- a/packages/react-cap-theme/src/components/react-tooltip/components/Tooltip/Tooltip.types.ts
+++ b/packages/react-cap-theme/src/components/react-tooltip/components/Tooltip/Tooltip.types.ts
@@ -1,18 +1,11 @@
-import type { PortalProps } from '@fluentui/react-portal';
 import type {
   TooltipProps as BaseTooltipProps,
   TooltipState as BaseTooltipState,
-  TooltipSlots,
-  TooltipTriggerProps,
 } from '@fluentui/react-tooltip';
-import type { ComponentProps, TriggerProps } from '@fluentui/react-utilities';
 
-export type TooltipProps = ComponentProps<TooltipSlots> &
-  TriggerProps<TooltipTriggerProps> &
-  Pick<PortalProps, 'mountNode'> &
-  Omit<BaseTooltipProps, 'appearance'> & {
-    appearance?: 'normal' | 'inverted' | 'brand';
-  };
+export type TooltipProps = BaseTooltipProps & {
+  appearance?: 'normal' | 'inverted' | 'brand';
+};
 
 export type TooltipState = BaseTooltipState & {
   extendedAppearance: 'normal' | 'inverted' | 'brand';


### PR DESCRIPTION
- **Button**: `Pick` of 4 base props → `Omit` of only `appearance`, exposing all base props like `shape`, `icon`
- **ToggleButton**: `Pick` of `defaultChecked`/`checked` → `Omit` of `appearance`, exposing `isAccessible` etc.
- **MenuButton**: `Pick` of 4 ButtonProps → full `ButtonProps`
- **Tooltip**: Removed `withArrow` from the `Omit` list so consumers can pass it
- **CarouselButton**: `Pick` on slots/props/state → full Fluent types with `Omit<..., 'appearance'>`
- **CarouselAutoplayButton**: Same — `Pick` → full types with `Omit<..., 'appearance'>`
- **CarouselNavContainer**: `Pick<..., 'layout'>` → `Omit` of slot props (includes all non-slot props)

**No changes**: SplitButton (structural slot Omits), Link (already correct), CarouselNavContainer slot Omit (tooltip type swap), State-level `Required<Pick>` patterns.