### PR TITLE
chore: use "^" for @fluentui/keyboard-keys dependency

### DIFF
--- a/change/@fluentui-contrib-react-keytips-c684476c-0d52-4d18-9963-fac314bd1a67.json
+++ b/change/@fluentui-contrib-react-keytips-c684476c-0d52-4d18-9963-fac314bd1a67.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: use \"^\" for @fluentui/keyboard-keys dependency",
+  "packageName": "@fluentui-contrib/react-keytips",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-contrib-react-tree-grid-1f649f50-913d-42b0-a079-2689150b0895.json
+++ b/change/@fluentui-contrib-react-tree-grid-1f649f50-913d-42b0-a079-2689150b0895.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: use \"^\" for @fluentui/keyboard-keys dependency",
+  "packageName": "@fluentui-contrib/react-tree-grid",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-keytips/package.json
+++ b/packages/react-keytips/package.json
@@ -9,7 +9,7 @@
     "react": ">=16.8.0 <20.0.0"
   },
   "dependencies": {
-    "@fluentui/keyboard-keys": "~9.0.6",
+    "@fluentui/keyboard-keys": "^9.0.6",
     "@fluentui/react-jsx-runtime": "^9.0.29",
     "@fluentui/react-positioning": "^9.15.0",
     "@fluentui/react-utilities": "^9.16.0",

--- a/packages/react-tree-grid/package.json
+++ b/packages/react-tree-grid/package.json
@@ -7,7 +7,7 @@
     "react": ">=16.8.0 <20.0.0"
   },
   "dependencies": {
-    "@fluentui/keyboard-keys": "~9.0.6",
+    "@fluentui/keyboard-keys": "^9.0.6",
     "@fluentui/react-aria": "^9.13.5",
     "@fluentui/react-jsx-runtime": "^9.0.29",
     "@fluentui/react-tabster": "^9.17.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2171,7 +2171,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@fluentui-contrib/react-keytips@workspace:packages/react-keytips"
   dependencies:
-    "@fluentui/keyboard-keys": "npm:~9.0.6"
+    "@fluentui/keyboard-keys": "npm:^9.0.6"
     "@fluentui/react-jsx-runtime": "npm:^9.0.29"
     "@fluentui/react-positioning": "npm:^9.15.0"
     "@fluentui/react-utilities": "npm:^9.16.0"
@@ -2230,7 +2230,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@fluentui-contrib/react-tree-grid@workspace:packages/react-tree-grid"
   dependencies:
-    "@fluentui/keyboard-keys": "npm:~9.0.6"
+    "@fluentui/keyboard-keys": "npm:^9.0.6"
     "@fluentui/react-aria": "npm:^9.13.5"
     "@fluentui/react-jsx-runtime": "npm:^9.0.29"
     "@fluentui/react-tabster": "npm:^9.17.2"
@@ -2373,7 +2373,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@fluentui/keyboard-keys@npm:^9.0.8, @fluentui/keyboard-keys@npm:~9.0.6":
+"@fluentui/keyboard-keys@npm:^9.0.6, @fluentui/keyboard-keys@npm:^9.0.8":
   version: 9.0.8
   resolution: "@fluentui/keyboard-keys@npm:9.0.8"
   dependencies:


### PR DESCRIPTION
See title. Needed to remove Yarn resolutions in the product.