### PR TITLE
feat(react-cap-theme): add `react-search` component

### DIFF
--- a/change/@fluentui-contrib-react-cap-theme-ba60e908-6aef-4db4-8e65-7a7dc533b643.json
+++ b/change/@fluentui-contrib-react-cap-theme-ba60e908-6aef-4db4-8e65-7a7dc533b643.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "add react-search component",
+  "packageName": "@fluentui-contrib/react-cap-theme",
+  "email": "egianoglio@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-cap-theme/src/capStyleHooks.ts
+++ b/packages/react-cap-theme/src/capStyleHooks.ts
@@ -134,6 +134,8 @@ import type {
 } from '@fluentui/react-menu';
 import { usePopoverSurfaceStyles } from './components/react-popover';
 import type { PopoverSurfaceState } from '@fluentui/react-popover';
+import { useSearchBoxStyles } from './components/react-search';
+import type { SearchBoxState } from './components/react-search';
 import {
   useTagStyles,
   useInteractionTagStyles,
@@ -313,6 +315,9 @@ export const CAP_STYLE_HOOKS: NonNullable<
   },
   usePopoverSurfaceStyles_unstable: (state) => {
     return usePopoverSurfaceStyles(state as PopoverSurfaceState);
+  },
+  useSearchBoxStyles_unstable: (state) => {
+    return useSearchBoxStyles(state as SearchBoxState);
   },
   useSplitButtonStyles_unstable: (state) => {
     return useSplitButtonStyles(state as SplitButtonState);

--- a/packages/react-cap-theme/src/components/react-input/components/Input/useInputStyles.styles.ts
+++ b/packages/react-cap-theme/src/components/react-input/components/Input/useInputStyles.styles.ts
@@ -1,7 +1,7 @@
 import { inputClassNames } from '@fluentui/react-input';
 import { makeStyles, mergeClasses, shorthands } from '@griffel/react';
 import { getSlotClassNameProp_unstable } from '@fluentui/react-utilities';
-import { tokens, typographyStyles } from '@fluentui/tokens';
+import { tokens } from '@fluentui/tokens';
 import { capTokens } from '../../../tokens';
 import type { InputState } from './Input.types';
 
@@ -9,25 +9,19 @@ const iconFilledClassName = 'fui-Icon-filled';
 const iconRegularClassName = 'fui-Icon-regular';
 
 const useStyles = makeStyles({
+  // Fluent already sets display/align/flex/box/vertical-align/typography/bg/border on the root.
+  // CAP only overrides height, padding, border (all-sides accessible color),
+  // radius, foreground color, and removes Fluent's focus underline (::after).
   root: {
-    boxSizing: 'border-box',
-    display: 'inline-flex',
-    flexWrap: 'nowrap',
-    alignItems: 'center',
-    verticalAlign: 'middle',
     minHeight: '36px',
     padding: `${tokens.spacingVerticalNone} ${tokens.spacingHorizontalMNudge}`,
     color: tokens.colorNeutralForeground1,
-    backgroundColor: tokens.colorNeutralBackground1,
-    border: `${tokens.strokeWidthThin} solid ${tokens.colorNeutralStrokeAccessible}`,
     borderRadius: capTokens.borderRadius2XLarge,
-    ...typographyStyles.body1,
     '::after': { content: 'unset' },
   },
   small: {
     minHeight: '28px',
     padding: `${tokens.spacingVerticalNone} ${tokens.spacingHorizontalS}`,
-    ...typographyStyles.caption1,
     borderRadius: tokens.borderRadiusXLarge,
   },
   medium: {
@@ -35,18 +29,12 @@ const useStyles = makeStyles({
   },
   large: {
     minHeight: '44px',
-    ...typographyStyles.body2,
     padding: `${tokens.spacingVerticalNone} ${tokens.spacingHorizontalM}`,
   },
+  // Fluent already handles disabled root visuals; CAP only needs to keep the
+  // foreground color override so the input inherits it (see inputStyles.base).
   disabled: {
-    ...shorthands.borderColor(tokens.colorNeutralStrokeDisabled),
-    backgroundColor: tokens.colorTransparentBackground,
     color: tokens.colorNeutralForegroundDisabled,
-    cursor: 'not-allowed',
-
-    '@media (forced-colors: active)': {
-      ...shorthands.borderColor('GrayText'),
-    },
   },
   disabledUnderline: {
     borderRadius: '0',
@@ -138,6 +126,7 @@ const useIsEditableStyles = makeStyles({
 
 const useAppearanceStyles = makeStyles({
   outline: {
+    border: `${tokens.strokeWidthThin} solid ${tokens.colorNeutralStrokeAccessible}`,
     ':hover': {
       ...shorthands.borderColor(tokens.colorNeutralStrokeAccessibleHover),
     },
@@ -158,16 +147,12 @@ const useAppearanceStyles = makeStyles({
 });
 
 const useContentStyles = makeStyles({
+  // Fluent already sets display:flex, color, > svg font size, box-sizing on content slots.
+  // CAP only needs to override the color to inherit from the root (so hasValue/noValue
+  // color transitions propagate to icons) and add per-size content paddings.
   base: {
-    display: 'flex',
     color: 'inherit',
-    '> svg': { fontSize: tokens.fontSizeBase500 },
   },
-  small: { '> svg': { fontSize: tokens.fontSizeBase400 } },
-  medium: {
-    /* same as base */
-  },
-  large: { '> svg': { fontSize: tokens.fontSizeBase600 } },
 
   smallContentBefore: { paddingRight: tokens.spacingHorizontalXS },
   smallContentAfter: { paddingLeft: tokens.spacingHorizontalS },
@@ -182,20 +167,11 @@ const useContentStyles = makeStyles({
 });
 
 const useInputElementStyles = makeStyles({
+  // Fluent already sets layout/reset (alignSelf, flexGrow, minWidth, box-sizing,
+  // border:none, outline:none, font-family/size/weight/line-height, bg:transparent).
+  // CAP only needs the foreground inheritance so root color drives the input + placeholder.
   base: {
-    alignSelf: 'stretch',
-    boxSizing: 'border-box',
-    flexGrow: 1,
-    minWidth: 0,
-    backgroundColor: tokens.colorTransparentBackground,
-    border: 'none',
-    outline: 'none',
     color: 'inherit',
-    fontFamily: 'inherit',
-    fontSize: 'inherit',
-    fontWeight: 'inherit',
-    lineHeight: 'inherit',
-
     '::placeholder': {
       opacity: 1,
       color: 'inherit',
@@ -235,8 +211,8 @@ export const useInputStyles = (state: InputState): InputState => {
     isEditable && isEditableStyles.base,
     isEditable &&
       (hasValue ? isEditableStyles.hasValue : isEditableStyles.noValue),
-    isEditable &&
-      (appearance === 'outline' || appearance === 'underline') &&
+    (appearance === 'outline' || appearance === 'underline') &&
+      isEditable &&
       appearanceStyles[appearance],
     isEditable && isEditableStyles[color],
     invalid && styles.invalid,
@@ -258,7 +234,6 @@ export const useInputStyles = (state: InputState): InputState => {
       state.contentBefore.className,
       inputClassNames.contentBefore,
       contentStyles.base,
-      contentStyles[size],
       contentStyles[`${size}ContentBefore`],
       disabled && contentStyles.disabled,
       getSlotClassNameProp_unstable(state.contentBefore)
@@ -270,7 +245,6 @@ export const useInputStyles = (state: InputState): InputState => {
       state.contentAfter.className,
       inputClassNames.contentAfter,
       contentStyles.base,
-      contentStyles[size],
       contentStyles[`${size}ContentAfter`],
       disabled && contentStyles.disabled,
       getSlotClassNameProp_unstable(state.contentAfter)

--- a/packages/react-cap-theme/src/components/react-search/components/SearchBox/SearchBox.types.ts
+++ b/packages/react-cap-theme/src/components/react-search/components/SearchBox/SearchBox.types.ts
@@ -1,0 +1,55 @@
+import type { ComponentState, Slot } from '@fluentui/react-utilities';
+import type {
+  SearchBoxProps as BaseSearchBoxProps,
+  SearchBoxSlots as BaseSearchBoxSlots,
+  SearchBoxState as BaseSearchBoxState,
+} from '@fluentui/react-search';
+
+/**
+ * Internal slots for SearchBox.
+ * @internal
+ */
+export type SearchBoxInternalSlots = {
+  /**
+   * Separator element which is rendered between the input and dismiss.
+   */
+  separator?: Slot<'span'>; // TODO Remove and use "::after"
+};
+
+// FIXME Unresolved designs on buttons inside contentAfter
+/**
+ * Properties for configuring the SearchBox component.
+ * @alpha
+ */
+export type SearchBoxProps = Omit<BaseSearchBoxProps, 'appearance'> & {
+  /**
+   * The appearance of the search box.
+   *
+   * Extends the base Fluent appearances with the CAP-specific 'filled-inset'
+   * variant, which applies an inset shadow effect with circular corners.
+   *
+   * @default outline
+   */
+  appearance?: NonNullable<BaseSearchBoxProps['appearance']> | 'filled-inset';
+
+  /**
+   * The color variant.
+   *
+   * - 'brand' (default): Primary emphasis using brand colors.
+   * - 'neutral': Secondary emphasis using neutral colors.
+   *
+   * @default 'brand'
+   */
+  color?: 'brand' | 'neutral';
+};
+
+/**
+ * State used in rendering the SearchBox component.
+ * @alpha
+ */
+export type SearchBoxState = Omit<
+  BaseSearchBoxState,
+  'components' | 'appearance'
+> &
+  ComponentState<SearchBoxInternalSlots & BaseSearchBoxSlots> &
+  Required<Pick<SearchBoxProps, 'appearance' | 'color'>>;

--- a/packages/react-cap-theme/src/components/react-search/components/SearchBox/useSearchBoxStyles.styles.ts
+++ b/packages/react-cap-theme/src/components/react-search/components/SearchBox/useSearchBoxStyles.styles.ts
@@ -1,0 +1,188 @@
+import type { SlotClassNames } from '@fluentui/react-utilities';
+import { searchBoxClassNames } from '@fluentui/react-search';
+import { makeStyles, mergeClasses, shorthands } from '@griffel/react';
+import { getSlotClassNameProp_unstable } from '@fluentui/react-utilities';
+import {
+  iconFilledClassName,
+  iconRegularClassName,
+} from '@fluentui/react-icons';
+import { tokens } from '@fluentui/tokens';
+import { capTokens } from '../../../tokens';
+import { useInputStyles } from '../../../react-input';
+
+import type { SearchBoxInternalSlots, SearchBoxState } from './SearchBox.types';
+
+const searchBoxInternalClassNames: SlotClassNames<SearchBoxInternalSlots> = {
+  separator: 'spui-SearchBox__separator',
+};
+
+const useStyles = makeStyles({
+  outline: {
+    ...shorthands.borderColor(capTokens.colorNeutralStroke4),
+    ':hover': { ...shorthands.borderColor(capTokens.colorNeutralStroke4Hover) },
+  },
+  underline: {
+    borderBottomColor: capTokens.colorNeutralStroke4,
+    ':hover': { borderBottomColor: capTokens.colorNeutralStroke4Hover },
+  },
+  // CAP-only: reveal dismiss/separator on active/focus when there's a value.
+  isEditableHasInputValue: {
+    ':active,:focus-within': {
+      [`& .${searchBoxClassNames.dismiss}`]: { display: 'flex' },
+    },
+  },
+  isEditableHasInputValueHasContentAfter: {
+    ':active,:focus-within': {
+      [`& .${searchBoxInternalClassNames.separator}`]: { display: 'flex' },
+    },
+  },
+});
+
+const useSeparatorStyles = makeStyles({
+  root: {
+    display: 'none',
+    alignSelf: 'stretch',
+    borderLeft: `${tokens.strokeWidthThin} solid ${capTokens.colorNeutralStroke4Pressed}`,
+    borderRadius: tokens.borderRadiusCircular,
+    margin: `${tokens.spacingVerticalMNudge} ${tokens.spacingHorizontalNone} ${tokens.spacingVerticalMNudge} ${tokens.spacingHorizontalMNudge}`,
+  },
+  small: {
+    margin: `${tokens.spacingVerticalS} ${tokens.spacingHorizontalXXS} ${tokens.spacingVerticalS} ${tokens.spacingHorizontalS}`,
+  },
+  medium: {},
+  large: {
+    margin: `${tokens.spacingVerticalM} ${tokens.spacingHorizontalXS} ${tokens.spacingVerticalM} ${tokens.spacingHorizontalM}`,
+  },
+});
+
+const useDismissStyles = makeStyles({
+  // Fluent base sets boxSizing/display/cursor/> svg fontSize (20px @ medium)
+  // and disabled color. CAP only hides by default (revealed on focus+hasValue),
+  // centers vertically, and uses CAP's foreground token.
+  root: {
+    display: 'none',
+    alignSelf: 'center',
+    color: capTokens.colorNeutralForeground5Pressed,
+  },
+  isEditable: {
+    ':hover': {
+      [`& .${iconRegularClassName}`]: { display: 'none' },
+      [`& .${iconFilledClassName}`]: { display: 'inline' },
+    },
+  },
+});
+
+const useContentAfterStyles = makeStyles({
+  small: { gap: tokens.spacingHorizontalXXS },
+  medium: { gap: tokens.spacingHorizontalXS },
+  large: { gap: tokens.spacingHorizontalS },
+});
+
+const useFilledInsetStyles = makeStyles({
+  root: {
+    ...shorthands.borderColor(tokens.colorTransparentStroke), // High contrast support
+    borderRadius: tokens.borderRadiusCircular,
+    boxShadow: `0 1px 3px 0 ${tokens.colorNeutralShadowAmbient} inset`,
+  },
+  isEditable: {
+    ':active,:focus-within': {
+      boxShadow: 'none',
+      backgroundColor: tokens.colorNeutralBackground1,
+    },
+  },
+  disabled: {
+    ...shorthands.borderColor(tokens.colorTransparentStroke),
+    backgroundColor: tokens.colorTransparentBackground,
+    boxShadow: `0 1px 3px 0 ${tokens.colorNeutralShadowAmbient} inset`,
+  },
+});
+
+export const useSearchBoxStyles = (state: SearchBoxState): SearchBoxState => {
+  const styles = useStyles();
+  const filledInsetStyles = useFilledInsetStyles();
+  const separatorStyles = useSeparatorStyles();
+  const dismissStyles = useDismissStyles();
+  const contentAfterStyles = useContentAfterStyles();
+
+  const { appearance, size } = state;
+  const { disabled } = state.input;
+  const isEditable = !disabled;
+  const hasInputValue = !!state.input.value;
+  const contentAfter = !!state.contentAfter?.children;
+
+  // Forward state as-is, but treat 'filled-inset' as 'outline' so CAP's
+  // Input outline deltas (border/radius/etc.) are applied as the base.
+  useInputStyles({
+    ...state,
+    appearance: appearance === 'filled-inset' ? 'outline' : appearance,
+  });
+
+  state.root.className = mergeClasses(
+    state.root.className,
+    searchBoxClassNames.root,
+    isEditable &&
+      (appearance === 'outline' ||
+        appearance === 'underline' ||
+        appearance === 'filled-inset') &&
+      styles[appearance === 'filled-inset' ? 'outline' : appearance],
+    appearance === 'filled-inset' &&
+      mergeClasses(
+        filledInsetStyles.root,
+        isEditable && filledInsetStyles.isEditable
+      ),
+    isEditable && hasInputValue && styles.isEditableHasInputValue,
+    isEditable &&
+      hasInputValue &&
+      contentAfter &&
+      styles.isEditableHasInputValueHasContentAfter,
+    disabled && appearance === 'filled-inset' && filledInsetStyles.disabled,
+    getSlotClassNameProp_unstable(state.root)
+  );
+
+  if (state.separator) {
+    state.separator.className = mergeClasses(
+      state.separator.className,
+      searchBoxInternalClassNames.separator,
+      separatorStyles.root,
+      separatorStyles[size],
+      getSlotClassNameProp_unstable(state.separator)
+    );
+  }
+
+  if (state.dismiss) {
+    state.dismiss.className = mergeClasses(
+      state.dismiss.className,
+      searchBoxClassNames.dismiss,
+      dismissStyles.root,
+      isEditable && dismissStyles.isEditable,
+      getSlotClassNameProp_unstable(state.dismiss)
+    );
+  }
+
+  if (state.contentBefore) {
+    state.contentBefore.className = mergeClasses(
+      state.contentBefore.className,
+      searchBoxClassNames.contentBefore,
+      getSlotClassNameProp_unstable(state.contentBefore)
+    );
+  }
+
+  if (state.contentAfter) {
+    state.contentAfter.className = mergeClasses(
+      state.contentAfter.className,
+      searchBoxClassNames.contentAfter,
+      contentAfterStyles[size],
+      getSlotClassNameProp_unstable(state.contentAfter)
+    );
+  }
+
+  if (state.input) {
+    state.input.className = mergeClasses(
+      state.input.className,
+      searchBoxClassNames.input,
+      getSlotClassNameProp_unstable(state.input)
+    );
+  }
+
+  return state;
+};

--- a/packages/react-cap-theme/src/components/react-search/components/SearchBox/useSearchBoxStyles.styles.ts
+++ b/packages/react-cap-theme/src/components/react-search/components/SearchBox/useSearchBoxStyles.styles.ts
@@ -36,6 +36,13 @@ const useStyles = makeStyles({
       [`& .${searchBoxInternalClassNames.separator}`]: { display: 'flex' },
     },
   },
+  // CAP delta: with `display: flex` on root, give the input `flex-basis: 0`
+  // so it distributes remaining space proportionally instead of starting from
+  // its intrinsic content width (which `flex-basis: auto` would do).
+  // Fluent base already handles the `::-webkit-search-*` resets.
+  input: {
+    flex: '1 1 0%',
+  },
 });
 
 const useSeparatorStyles = makeStyles({
@@ -63,6 +70,8 @@ const useDismissStyles = makeStyles({
     display: 'none',
     alignSelf: 'center',
     color: capTokens.colorNeutralForeground5Pressed,
+
+    '> svg': { fontSize: tokens.fontSizeBase500 },
   },
   isEditable: {
     ':hover': {
@@ -70,6 +79,9 @@ const useDismissStyles = makeStyles({
       [`& .${iconFilledClassName}`]: { display: 'inline' },
     },
   },
+  small: { '> svg': { fontSize: tokens.fontSizeBase400 } },
+  medium: {},
+  large: {},
 });
 
 const useContentAfterStyles = makeStyles({
@@ -153,14 +165,8 @@ export const useSearchBoxStyles = (state: SearchBoxState): SearchBoxState => {
       state.dismiss.className,
       dismissStyles.root,
       isEditable && dismissStyles.isEditable,
+      dismissStyles[size],
       getSlotClassNameProp_unstable(state.dismiss)
-    );
-  }
-
-  if (state.contentBefore) {
-    state.contentBefore.className = mergeClasses(
-      state.contentBefore.className,
-      getSlotClassNameProp_unstable(state.contentBefore)
     );
   }
 
@@ -175,6 +181,7 @@ export const useSearchBoxStyles = (state: SearchBoxState): SearchBoxState => {
   if (state.input) {
     state.input.className = mergeClasses(
       state.input.className,
+      styles.input,
       getSlotClassNameProp_unstable(state.input)
     );
   }

--- a/packages/react-cap-theme/src/components/react-search/components/SearchBox/useSearchBoxStyles.styles.ts
+++ b/packages/react-cap-theme/src/components/react-search/components/SearchBox/useSearchBoxStyles.styles.ts
@@ -13,7 +13,7 @@ import { useInputStyles } from '../../../react-input';
 import type { SearchBoxInternalSlots, SearchBoxState } from './SearchBox.types';
 
 const searchBoxInternalClassNames: SlotClassNames<SearchBoxInternalSlots> = {
-  separator: 'spui-SearchBox__separator',
+  separator: 'fui-SearchBox__separator',
 };
 
 const useStyles = makeStyles({
@@ -119,7 +119,6 @@ export const useSearchBoxStyles = (state: SearchBoxState): SearchBoxState => {
 
   state.root.className = mergeClasses(
     state.root.className,
-    searchBoxClassNames.root,
     isEditable &&
       (appearance === 'outline' ||
         appearance === 'underline' ||
@@ -152,7 +151,6 @@ export const useSearchBoxStyles = (state: SearchBoxState): SearchBoxState => {
   if (state.dismiss) {
     state.dismiss.className = mergeClasses(
       state.dismiss.className,
-      searchBoxClassNames.dismiss,
       dismissStyles.root,
       isEditable && dismissStyles.isEditable,
       getSlotClassNameProp_unstable(state.dismiss)
@@ -162,7 +160,6 @@ export const useSearchBoxStyles = (state: SearchBoxState): SearchBoxState => {
   if (state.contentBefore) {
     state.contentBefore.className = mergeClasses(
       state.contentBefore.className,
-      searchBoxClassNames.contentBefore,
       getSlotClassNameProp_unstable(state.contentBefore)
     );
   }
@@ -170,7 +167,6 @@ export const useSearchBoxStyles = (state: SearchBoxState): SearchBoxState => {
   if (state.contentAfter) {
     state.contentAfter.className = mergeClasses(
       state.contentAfter.className,
-      searchBoxClassNames.contentAfter,
       contentAfterStyles[size],
       getSlotClassNameProp_unstable(state.contentAfter)
     );
@@ -179,7 +175,6 @@ export const useSearchBoxStyles = (state: SearchBoxState): SearchBoxState => {
   if (state.input) {
     state.input.className = mergeClasses(
       state.input.className,
-      searchBoxClassNames.input,
       getSlotClassNameProp_unstable(state.input)
     );
   }

--- a/packages/react-cap-theme/src/components/react-search/index.ts
+++ b/packages/react-cap-theme/src/components/react-search/index.ts
@@ -1,0 +1,2 @@
+export { useSearchBoxStyles } from './components/SearchBox/useSearchBoxStyles.styles';
+export type { SearchBoxState } from './components/SearchBox/SearchBox.types';


### PR DESCRIPTION
This PR adds a CAP-themed `SearchBox` override on top of `@fluentui/react-search` and
slims down the existing CAP `Input` override so it carries only deltas from Fluent base.