### PR TITLE
fix(react-cap-theme): fix border styles for field :focus states

### DIFF
--- a/change/@fluentui-contrib-react-cap-theme-5bafc5c8-0ee9-46a6-b17a-969570d427e3.json
+++ b/change/@fluentui-contrib-react-cap-theme-5bafc5c8-0ee9-46a6-b17a-969570d427e3.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix border styles for field :focus states",
+  "packageName": "@fluentui-contrib/react-cap-theme",
+  "email": "6439050+davezuko@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-cap-theme/src/facets/rounded-corners/index.ts
+++ b/packages/react-cap-theme/src/facets/rounded-corners/index.ts
@@ -178,15 +178,11 @@ const useSplitButtonRadiusStyles = (
   return state;
 };
 
-// Rounds a field's (Input/Combobox/Dropdown/…) root corners while keeping its
-// `:focus-within` bottom border in sync.
-//
-// That bottom border is drawn by an `::after` pseudo-element whose bottom
-// corners Fluent hard-codes to `borderRadiusMedium`, using the radius as the
-// element's height so the corner curve has room to render before `clipPath`
-// trims it to the bottom 2px. Round only the root and that underline keeps the
-// smaller corners and bleeds past the rounded edges on focus. Always set both
-// through this helper so the two can never drift apart.
+// Rounds a field's corners. A field's focus border is a separate `::after`
+// element, so it has to be rounded to match — otherwise it bleeds past the
+// corners on focus. Always go through this helper so the two stay in sync.
+// (The `height` is Fluent's: it sizes the element to the radius so the corner
+// can render before `clipPath` trims the element to the visible 2px line.)
 const fieldRadius = (radius: string): GriffelStyle => ({
   borderRadius: radius,
   '::after': {

--- a/packages/react-cap-theme/src/facets/rounded-corners/index.ts
+++ b/packages/react-cap-theme/src/facets/rounded-corners/index.ts
@@ -178,13 +178,31 @@ const useSplitButtonRadiusStyles = (
   return state;
 };
 
+// Rounds a field's (Input/Combobox/Dropdown/…) root corners while keeping its
+// `:focus-within` bottom border in sync.
+//
+// That bottom border is drawn by an `::after` pseudo-element whose bottom
+// corners Fluent hard-codes to `borderRadiusMedium`, using the radius as the
+// element's height so the corner curve has room to render before `clipPath`
+// trims it to the bottom 2px. Round only the root and that underline keeps the
+// smaller corners and bleeds past the rounded edges on focus. Always set both
+// through this helper so the two can never drift apart.
+const fieldRadius = (radius: string): GriffelStyle => ({
+  borderRadius: radius,
+  '::after': {
+    height: `max(2px, ${radius})`,
+    borderBottomLeftRadius: radius,
+    borderBottomRightRadius: radius,
+  },
+});
+
 // Input/Combobox/Dropdown share the same radius behaviour:
 // base 2XLarge, small XLarge, and a flat (none) radius for the underline
 // appearance (both while editable and while disabled).
 const useFieldRadius = makeStyles({
-  base: { borderRadius: CAP_BORDER_RADII.xxLarge },
-  small: { borderRadius: CAP_BORDER_RADII.xLarge },
-  underline: { borderRadius: CAP_BORDER_RADII.none },
+  base: fieldRadius(CAP_BORDER_RADII.xxLarge),
+  small: fieldRadius(CAP_BORDER_RADII.xLarge),
+  underline: fieldRadius(CAP_BORDER_RADII.none),
 });
 
 // The radius is identical (`none`) whether the underline is editable or


### PR DESCRIPTION
<img width="2560" height="1440" alt="cap-combobox-compare" src="https://github.com/user-attachments/assets/5bff8ff6-b3cc-4ff5-916c-d6a7bb72ad6d" />
<img width="2560" height="1440" alt="cap-dropdown-compare" src="https://github.com/user-attachments/assets/0dab3299-ac8b-4d00-bb71-b846288fbcf4" />
<img width="2560" height="1440" alt="cap-input-compare" src="https://github.com/user-attachments/assets/a84e415d-68d2-46eb-a331-9f969186c4d9" />
